### PR TITLE
Fix zombie loops: remove agent-alive check, add rate-limit pooling

### DIFF
--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -1482,12 +1482,28 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 				}
 				// Clear the .current-stage marker so the next spawn starts
 				// fresh instead of attempting --continue on a dead session.
-				// Without this, a zombie loop occurs: spawn → resume
-				// (--continue) → "No conversation found to continue" → exit
-				// → zombie detected → respawn → resume again → loop.
 				if s.sandboxRoot != "" {
 					worktreePath := filepath.Join(s.sandboxRoot, repo.Name, item.ID)
 					os.Remove(filepath.Join(worktreePath, ".current-stage"))
+				}
+
+				// Check session log for rate-limit errors (429). If the agent
+				// died because of rate limiting, pool the droplet instead of
+				// respawning — respawning would just hit the same limit and
+				// burn credits in a loop until the circuit breaker kicks in.
+				if isRateLimitError(sessionID) {
+					note := fmt.Sprintf("Session died with API rate-limit errors (429). Pooling to prevent credit burn loop. [%s]",
+						time.Now().UTC().Format(time.RFC3339))
+					s.addNote(client, item.ID, "scheduler", note)
+					s.logger.Warn("heartbeat: zombie with rate-limit errors — pooling instead of respawn",
+						"repo", repo.Name, "droplet", item.ID, "session", sessionID)
+					if err := client.Pool(item.ID, note); err != nil {
+						s.logger.Error("heartbeat: rate-limit pool failed",
+							"repo", repo.Name, "droplet", item.ID, "error", err)
+					} else {
+						s.dispatchLoop.reset(item.ID)
+					}
+					continue
 				}
 
 				// Append a history note so the zombie event is visible in
@@ -1514,53 +1530,18 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 				continue // handled — skip progress check for this item
 			}
 
-			// The tmux session is alive. Check whether the claude agent process is
-			// still running inside it. If not, the agent exited without signaling an
-			// outcome (e.g. OOM kill, hard token limit) — kill the orphaned session,
-			// record a diagnostic note, and reset the droplet for re-dispatch.
-			if !isAgentAlive(sessionID) {
-				step := currentCataracta(item, wf)
-				if step == nil {
-					s.logger.Error("heartbeat: no step for agent-dead session — skipping",
-						"repo", repo.Name, "droplet", item.ID)
-					continue
-				}
-				if err := s.killSessionFn(sessionID); err != nil {
-					s.logger.Warn("heartbeat: kill-session failed for agent-dead zombie",
-						"droplet", item.ID, "session", sessionID, "error", err)
-				}
-				if pool := s.pools[repo.Name]; pool != nil {
-					if w := pool.FindByName(item.Assignee); w != nil {
-						pool.Release(w)
-					}
-				}
-				// Clear the .current-stage marker so the next spawn starts
-				// fresh instead of attempting --continue on a dead session.
-				if s.sandboxRoot != "" {
-					worktreePath := filepath.Join(s.sandboxRoot, repo.Name, item.ID)
-					os.Remove(filepath.Join(worktreePath, ".current-stage"))
-				}
-				zombieNote := fmt.Sprintf(
-					"Session zombie detected: tmux alive but claude process dead. Session killed. Re-dispatching. [%s]",
-					time.Now().UTC().Format(time.RFC3339),
-				)
-				if err := client.AddNote(item.ID, "scheduler", zombieNote); err != nil {
-					s.logger.Warn("heartbeat: AddNote failed for agent-dead zombie",
-						"droplet", item.ID, "error", err)
-				}
-				s.logger.Info("heartbeat: agent-dead zombie — killed session, resetting to open",
-					"repo", repo.Name,
-					"droplet", item.ID,
-					"assignee", item.Assignee,
-					"cataractae", step.Name,
-					"session", sessionID,
-				)
-				if err := client.Assign(item.ID, "", step.Name); err != nil {
-					s.logger.Error("heartbeat: agent-dead zombie reset failed",
-						"repo", repo.Name, "droplet", item.ID, "error", err)
-				}
-				continue // handled — skip progress check for this item
-			}
+			// NOTE: agent-process liveness checking is intentionally removed.
+			// The isAgentAlive check was causing more harm than good:
+			//   - It couldn't reliably detect processes inside wrappers (false
+			//     negatives killed healthy sessions)
+			//   - When it did detect a dead agent, the immediate kill + respawn
+			//     created zombie loops that burned LLM credits until the circuit
+			//     breaker kicked in
+			//   - The spawn-cycle circuit breaker in dispatch is a sufficient
+			//     safety net without the aggressive heartbeat-based killing
+			// If the tmux session is alive, we trust the agent is working.
+			// If it's truly stuck, the stall detector or circuit breaker will
+			// handle it — no need for a per-tick process check.
 		}
 
 		// Stall detection: use the agent heartbeat timestamp as the primary signal.
@@ -2066,4 +2047,28 @@ func (s *Castellarius) ensureCataractaeIntegrity() {
 			s.logger.Info("Cataractae CLAUDE.md files regenerated successfully")
 		}
 	}
+}
+
+// isRateLimitError checks the session log for evidence of API rate-limit
+// errors (429 status codes). Returns true if rate-limit errors are found,
+// indicating the session died because the LLM provider throttled requests.
+// In this case the droplet should be pooled rather than respawned to prevent
+// credit-burning zombie loops.
+func isRateLimitError(sessionID string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	logPath := filepath.Join(home, ".cistern", "session-logs", sessionID+".log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return false // no log file — can't determine cause
+	}
+	tail := string(data)
+	// Only check the last 4KB to avoid reading huge logs
+	if len(tail) > 4096 {
+		tail = tail[len(tail)-4096:]
+	}
+	return strings.Contains(tail, "429") &&
+		(strings.Contains(tail, "rate_limit") || strings.Contains(tail, "rate limit"))
 }

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -1480,6 +1480,16 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 						pool.Release(w)
 					}
 				}
+				// Clear the .current-stage marker so the next spawn starts
+				// fresh instead of attempting --continue on a dead session.
+				// Without this, a zombie loop occurs: spawn → resume
+				// (--continue) → "No conversation found to continue" → exit
+				// → zombie detected → respawn → resume again → loop.
+				if s.sandboxRoot != "" {
+					worktreePath := filepath.Join(s.sandboxRoot, repo.Name, item.ID)
+					os.Remove(filepath.Join(worktreePath, ".current-stage"))
+				}
+
 				// Append a history note so the zombie event is visible in
 				// `ct droplet show` and the TUI timeline.
 				zombieNote := fmt.Sprintf(
@@ -1523,6 +1533,12 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 					if w := pool.FindByName(item.Assignee); w != nil {
 						pool.Release(w)
 					}
+				}
+				// Clear the .current-stage marker so the next spawn starts
+				// fresh instead of attempting --continue on a dead session.
+				if s.sandboxRoot != "" {
+					worktreePath := filepath.Join(s.sandboxRoot, repo.Name, item.ID)
+					os.Remove(filepath.Join(worktreePath, ".current-stage"))
 				}
 				zombieNote := fmt.Sprintf(
 					"Session zombie detected: tmux alive but claude process dead. Session killed. Re-dispatching. [%s]",

--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -220,6 +220,14 @@ func writeStageMarker(workDir, identity string) {
 	_ = os.WriteFile(filepath.Join(workDir, ".current-stage"), []byte(identity), 0o644)
 }
 
+// ClearStageMarker removes the .current-stage file from workDir so the next
+// spawn will start a fresh session rather than attempting to --continue a
+// prior session. This is called when a zombie is detected — the prior session
+// is gone and --continue will fail with "No conversation found to continue".
+func ClearStageMarker(workDir string) {
+	_ = os.Remove(filepath.Join(workDir, ".current-stage"))
+}
+
 // isSessionAlive returns true if a tmux session with the given ID is running.
 // Extracted as a package-level function so the quick-exit goroutine can call
 // it without holding a *Session reference.

--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -268,6 +268,9 @@ func (s *Session) collectEnvArgs() []string {
 	if s.Identity != "" {
 		args = append(args, "-e", "CT_CATARACTA_NAME="+s.Identity)
 	}
+	if s.ID != "" {
+		args = append(args, "-e", "CT_TMUX_SESSION="+s.ID)
+	}
 	if db := os.Getenv("CT_DB"); db != "" {
 		args = append(args, "-e", "CT_DB="+db)
 	}

--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -150,8 +150,15 @@ func (s *Session) spawn() error {
 	// Session output log: prepare the log directory so pipe-pane can write to it
 	// after the session is created. The log path is also read by the heartbeat
 	// for quick-exit diagnostics.
+	//
+	// Truncate any existing log file so stale errors from prior sessions
+	// (e.g. 429 rate-limit errors from a previous zombie loop) don't pollute
+	// the isRateLimitError check for the current session.
 	sessionLogPath := filepath.Join(home, ".cistern", "session-logs", s.ID+".log")
 	logDirReady := os.MkdirAll(filepath.Dir(sessionLogPath), 0o750) == nil
+	if logDirReady {
+		_ = os.Truncate(sessionLogPath, 0)
+	}
 
 	args = append(args, s.collectEnvArgs()...)
 	args = append(args, agentCmd)

--- a/internal/provider/preset.go
+++ b/internal/provider/preset.go
@@ -115,7 +115,7 @@ var builtins = []ProviderPreset{
 		Command:          "ollama-claude-wrapper",
 		Args:             []string{},
 		ModelFlag:        "--model",
-		DefaultModel:     "kimi-k2.5:cloud",
+		DefaultModel:     "glm-5.1:cloud",
 		AddDirFlag:       "--add-dir",
 		PromptFlag:       "-p",
 		ContinueFlag:     "--continue",


### PR DESCRIPTION
## Problem

The heartbeat zombie detection was causing more harm than good:

1. **Agent-alive check killed healthy sessions** — The `isAgentAlive` check walks the process tree looking for a `claude` binary. With wrappers (like `ollama-claude-wrapper`), it couldn't reliably detect the agent process, leading to false negatives that killed working sessions and triggered respawn loops.

2. **Credit-burning zombie loops** — When a session died due to API rate limiting (429), the heartbeat would detect a zombie, respawn it, it would immediately hit the rate limit again, die, get respawned... cycling every ~3.5 minutes for hours and burning LLM credits.

3. **Stale `.current-stage` marker** — After a zombie kill, the respawn would try `--continue` on a dead session, which fails with "No conversation found to continue" and creates another zombie.

## Changes

### 1. Remove `isAgentAlive` zombie check (scheduler.go)
The agent-process liveness check is removed entirely. If the tmux session is alive, we trust the agent is working. The spawn-cycle circuit breaker in dispatch is a sufficient safety net without the aggressive heartbeat-based killing.

### 2. Add rate-limit detection (scheduler.go)
When a tmux session dies, the heartbeat now checks the session log for 429 rate-limit errors. If found, the droplet is **pooled immediately** instead of respawned — preventing the credit burn loop.

### 3. Clear `.current-stage` on zombie detection (scheduler.go)
When a tmux session dies (zombie), the `.current-stage` marker is cleared so the next spawn starts fresh instead of attempting `--continue` on a dead session.

### 4. Export `ClearStageMarker()` (session.go)
Added for reuse; used inline in scheduler to avoid import cycle.

### 5. Default model → `glm-5.1:cloud` (preset.go)
Updated from `kimi-k2.5:cloud`.

## Testing
Droplet `ci-oahfh` was flowing with `glm-5.1:cloud` via the Ollama wrapper. Sessions survived for 7+ minutes (previously died within 2 minutes). Rate-limit detection verified against actual 429 errors in session logs.