### PR TITLE
doctor: make CLI checks provider-aware

### DIFF
--- a/cmd/ct/doctor.go
+++ b/cmd/ct/doctor.go
@@ -37,13 +37,6 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		return err
 	}, nil) && ok
 
-	ok = checkWithFix("claude CLI found", func() error {
-		_, err := exec.LookPath("claude")
-		return err
-	}, nil) && ok
-
-	ok = checkWithFix("claude CLI authenticated", claudeAuthStatusFn, nil) && ok
-
 	ok = checkWithFix("git installed", func() error {
 		_, err := exec.LookPath("git")
 		return err
@@ -77,6 +70,13 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		_, err := aqueduct.ParseAqueductConfig(cfgPath)
 		return err
 	}, cfgFix) && ok
+
+	// Provider-aware CLI binary and auth checks.
+	// Resolved after config is parsed so we check only the binaries that
+	// the configured provider(s) actually need.
+	if cfg, cfgErr := aqueduct.ParseAqueductConfig(cfgPath); cfgErr == nil {
+		ok = runDoctorProviderChecks(cfg) && ok
+	}
 
 	dbFile := filepath.Join(home, ".cistern", "cistern.db")
 
@@ -156,6 +156,51 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// runDoctorProviderChecks checks that each provider binary required by the
+// current configuration is present in PATH, and runs provider-specific auth
+// checks (e.g. "claude auth status" for the claude provider).
+func runDoctorProviderChecks(cfg *aqueduct.AqueductConfig) bool {
+	ok := true
+	seenBinaries := map[string]bool{}
+	for _, repo := range cfg.Repos {
+		preset, presErr := cfg.ResolveProvider(repo.Name)
+		if presErr != nil || seenBinaries[preset.Command] {
+			continue
+		}
+		seenBinaries[preset.Command] = true
+
+		cmd := preset.Command
+		name := preset.Name
+		ok = checkWithFix("agent CLI: "+cmd, func() error {
+			if _, lookErr := exec.LookPath(cmd); lookErr != nil {
+				hint := providerInstallHint(name)
+				if hint != "" {
+					return fmt.Errorf("not found in PATH — run: %s", hint)
+				}
+				return fmt.Errorf("not found in PATH")
+			}
+			return nil
+		}, nil) && ok
+
+		if name == "claude" {
+			ok = checkWithFix("claude CLI authenticated", providerAuthStatusFn, nil) && ok
+		}
+	}
+	return ok
+}
+
+// providerAuthStatusFn runs the configured provider's auth status check.
+// Only the claude provider has a discrete auth check command; other providers
+// authenticate via env vars which are checked separately.
+// Replaced in tests with a stub.
+var providerAuthStatusFn = func() error {
+	out, err := exec.Command("claude", "auth", "status").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s", out)
+	}
+	return nil
+}
+
 // fixCisternConfig creates ~/.cistern/cistern.yaml from the embedded default template.
 func fixCisternConfig(cfgPath string) error {
 	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
@@ -187,6 +232,7 @@ func fixCisternDB(dbFile string) error {
 //  7. Skills installed at ~/.cistern/skills/<name>/SKILL.md
 //  8. Aqueduct YAML validity (one check per repo)
 //  9. Castellarius process (informational, does not fail the check)
+//
 // 10. Castellarius health file (warnings only, does not fail the check)
 // 11. Systemd service health (only on systemd systems)
 // 12. Repo sandbox health
@@ -373,6 +419,8 @@ func providerInstallHint(presetName string) string {
 		return "npm install -g @openai/codex"
 	case "gemini":
 		return "npm install -g @google/gemini-cli"
+	case "opencode":
+		return "go install github.com/opencode-ai/opencode@latest"
 	}
 	return ""
 }
@@ -798,16 +846,6 @@ func checkStalledDroplets(dbPath string) {
 			fmt.Printf("\u26A0 %s in_progress for %dm \u2014 may be stalled\n", d.ID, int(elapsed.Minutes()))
 		}
 	}
-}
-
-// claudeAuthStatusFn runs "claude auth status" and returns an error on non-zero exit.
-// Replaced in tests with a stub.
-var claudeAuthStatusFn = func() error {
-	out, err := exec.Command("claude", "auth", "status").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s", out)
-	}
-	return nil
 }
 
 // execCommandFn wraps exec.Command to allow injection in tests.

--- a/cmd/ct/doctor_test.go
+++ b/cmd/ct/doctor_test.go
@@ -990,7 +990,7 @@ func TestProviderInstallHint_KnownPreset_ReturnsHint(t *testing.T) {
 		{"claude", true},
 		{"codex", true},
 		{"gemini", true},
-		{"opencode", false},
+		{"opencode", true},
 		{"copilot", false},
 		{"unknown", false},
 	}
@@ -1312,27 +1312,166 @@ func TestInferLLMProviderFromPreset_KnownPresets(t *testing.T) {
 	}
 }
 
-// --- claudeAuthStatusFn (claude CLI authenticated) tests ---
+// --- runDoctorProviderChecks tests ---
+
+func TestRunDoctorProviderChecks_ClaudeProvider_ChecksClaudeBinaryAndAuth(t *testing.T) {
+	home := t.TempDir()
+	cisternDir := filepath.Join(home, ".cistern")
+	aqueductDir := filepath.Join(cisternDir, "aqueduct")
+	if err := os.MkdirAll(aqueductDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	setupFakeBinAndAPIKey(t, "claude", "")
+
+	cfgPath := filepath.Join(cisternDir, "cistern.yaml")
+	if err := os.WriteFile(cfgPath, []byte(minimalCisternConfigYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	orig := providerAuthStatusFn
+	t.Cleanup(func() { providerAuthStatusFn = orig })
+	providerAuthStatusFn = func() error { return nil }
+
+	cfg, err := aqueduct.ParseAqueductConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	result := runDoctorProviderChecks(cfg)
+	if !result {
+		t.Error("expected provider checks to pass for claude provider with binary and auth")
+	}
+}
+
+func TestRunDoctorProviderChecks_OpencodeProvider_ChecksOpencodeOnly(t *testing.T) {
+	home := t.TempDir()
+	cisternDir := filepath.Join(home, ".cistern")
+	aqueductDir := filepath.Join(cisternDir, "aqueduct")
+	if err := os.MkdirAll(aqueductDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Set up fake opencode binary, but NOT claude.
+	setupFakeBinAndAPIKey(t, "opencode", "")
+
+	opencodeConfigYAML := `repos:
+  - name: testrepo
+    url: https://github.com/example/testrepo
+    workflow_path: aqueduct/workflow.yaml
+    cataractae: 1
+    prefix: ct
+provider:
+  name: opencode
+max_cataractae: 1
+`
+	cfgPath := filepath.Join(cisternDir, "cistern.yaml")
+	if err := os.WriteFile(cfgPath, []byte(opencodeConfigYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := aqueduct.ParseAqueductConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	result := runDoctorProviderChecks(cfg)
+	if !result {
+		t.Error("expected provider checks to pass for opencode provider without claude")
+	}
+}
+
+func TestRunDoctorProviderChecks_OpencodeProvider_ClaudeMissingNoFailure(t *testing.T) {
+	home := t.TempDir()
+	cisternDir := filepath.Join(home, ".cistern")
+	aqueductDir := filepath.Join(cisternDir, "aqueduct")
+	if err := os.MkdirAll(aqueductDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// PATH with opencode but no claude.
+	binDir := t.TempDir()
+	fakeBin := filepath.Join(binDir, "opencode")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake opencode: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	opencodeConfigYAML := `repos:
+  - name: testrepo
+    url: https://github.com/example/testrepo
+    workflow_path: aqueduct/workflow.yaml
+    cataractae: 1
+    prefix: ct
+provider:
+  name: opencode
+max_cataractae: 1
+`
+	cfgPath := filepath.Join(cisternDir, "cistern.yaml")
+	if err := os.WriteFile(cfgPath, []byte(opencodeConfigYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := aqueduct.ParseAqueductConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	result := runDoctorProviderChecks(cfg)
+	if !result {
+		t.Error("expected provider checks to pass for opencode provider even when claude is missing")
+	}
+}
+
+func TestRunDoctorProviderChecks_MissingBinary_Fails(t *testing.T) {
+	home := t.TempDir()
+	cisternDir := filepath.Join(home, ".cistern")
+	aqueductDir := filepath.Join(cisternDir, "aqueduct")
+	if err := os.MkdirAll(aqueductDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Empty PATH — no binaries found.
+	emptyDir := t.TempDir()
+	t.Setenv("PATH", emptyDir)
+
+	cfgPath := filepath.Join(cisternDir, "cistern.yaml")
+	if err := os.WriteFile(cfgPath, []byte(minimalCisternConfigYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := aqueduct.ParseAqueductConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	result := runDoctorProviderChecks(cfg)
+	if result {
+		t.Error("expected provider checks to fail when provider binary is missing")
+	}
+}
+
+// --- providerAuthStatusFn (claude CLI authenticated) tests ---
 
 func TestClaudeAuthenticated_ExitZero_PassesCheck(t *testing.T) {
-	orig := claudeAuthStatusFn
-	t.Cleanup(func() { claudeAuthStatusFn = orig })
-	claudeAuthStatusFn = func() error { return nil }
+	orig := providerAuthStatusFn
+	t.Cleanup(func() { providerAuthStatusFn = orig })
+	providerAuthStatusFn = func() error { return nil }
 
-	got := checkWithFix("claude CLI authenticated", claudeAuthStatusFn, nil)
+	got := checkWithFix("claude CLI authenticated", providerAuthStatusFn, nil)
 	if !got {
 		t.Error("expected checkWithFix to return true when claude auth status exits 0")
 	}
 }
 
 func TestClaudeAuthenticated_NonZeroExit_FailsCheck(t *testing.T) {
-	orig := claudeAuthStatusFn
-	t.Cleanup(func() { claudeAuthStatusFn = orig })
-	claudeAuthStatusFn = func() error {
+	orig := providerAuthStatusFn
+	t.Cleanup(func() { providerAuthStatusFn = orig })
+	providerAuthStatusFn = func() error {
 		return fmt.Errorf("Not logged in")
 	}
 
-	got := checkWithFix("claude CLI authenticated", claudeAuthStatusFn, nil)
+	got := checkWithFix("claude CLI authenticated", providerAuthStatusFn, nil)
 	if got {
 		t.Error("expected checkWithFix to return false when claude auth status exits non-zero")
 	}


### PR DESCRIPTION
## Summary
- Remove hardcoded `claude CLI found` and `claude CLI authenticated` checks that always ran regardless of configured provider
- Add `runDoctorProviderChecks()` — runs after config is parsed, checks only the binary for the configured provider(s)
- Only run `claude auth status` when claude is the configured provider
- Add `opencode` install hint (`go install github.com/opencode-ai/opencode@latest`)
- 4 new tests covering provider-aware basic checks

This means `ct doctor` with `provider: opencode` will check for `opencode` and skip claude entirely, instead of always failing on missing claude.