### PR TITLE
fix: update installer integration test for provider-aware doctor check

### DIFF
--- a/tests/installer/README.md
+++ b/tests/installer/README.md
@@ -113,7 +113,7 @@ as a GitHub Actions step:
 | `claude_on_path` | `claude` resolves via `exec.LookPath` (on `PATH`) |
 | `no_pass_installed` | `pass` password manager is absent |
 | `ct_init_creates_config` | `ct init` creates `~/.cistern/cistern.yaml` |
-| `ct_doctor_claude_found` | `ct doctor` reports the `claude` CLI as found |
+| `ct_doctor_agent_cli_found` | `ct doctor` reports the configured agent CLI as found |
 | `start_castellarius_script_executable` | `/usr/local/bin/start-castellarius.sh` is present and executable |
 
 ### Integration scenarios

--- a/tests/installer/run-tests.sh
+++ b/tests/installer/run-tests.sh
@@ -120,17 +120,17 @@ else
     fail "ct_init_creates_config" "${init_out}"
 fi
 
-# ── Test 7: ct doctor recognises claude CLI ───────────────────────────────────
+# ── Test 7: ct doctor recognises agent CLI ────────────────────────────────────
 # Given: fakeagent is on PATH as "claude" and ct init has run
 # When:  running `ct doctor`
-# Then:  doctor output contains "✓ claude CLI found" (success prefix only)
+# Then:  doctor output contains "✓ agent CLI: claude" (success prefix only)
 # Note:  doctor exits non-zero when other checks fail (e.g. gh not authenticated);
-#        that is expected. We only care that the claude check itself passes.
+#        that is expected. We only care that the agent CLI check itself passes.
 doctor_out=$(ct doctor 2>&1 || true)
-if echo "${doctor_out}" | grep -q '✓.*claude CLI found'; then
-    pass "ct_doctor_claude_found"
+if echo "${doctor_out}" | grep -q '✓.*agent CLI: claude'; then
+    pass "ct_doctor_agent_cli_found"
 else
-    fail "ct_doctor_claude_found" "doctor did not report claude found: ${doctor_out}"
+    fail "ct_doctor_agent_cli_found" "doctor did not report agent CLI found: ${doctor_out}"
 fi
 
 # ── Test 8: start-castellarius.sh is present and executable ───────────────────


### PR DESCRIPTION
## Summary
- Rename `ct_doctor_claude_found` to `ct_doctor_agent_cli_found` in installer test
- Match new `agent CLI: claude` output format instead of old `claude CLI found`

PR #425 changed the doctor output format but the installer integration test still matched the old pattern, causing it to fail.