### PR TITLE
doctor: add opencode and copilot LLM provider inference

### DIFF
--- a/cmd/ct/doctor.go
+++ b/cmd/ct/doctor.go
@@ -436,6 +436,10 @@ func inferLLMProviderFromPreset(presetName string) string {
 		return "openai"
 	case "gemini":
 		return "gemini"
+	case "opencode":
+		return "ollama"
+	case "copilot":
+		return "openai"
 	}
 	return ""
 }

--- a/cmd/ct/doctor_test.go
+++ b/cmd/ct/doctor_test.go
@@ -1300,8 +1300,8 @@ func TestInferLLMProviderFromPreset_KnownPresets(t *testing.T) {
 		{"claude", "anthropic"},
 		{"codex", "openai"},
 		{"gemini", "gemini"},
-		{"copilot", ""},
-		{"opencode", ""},
+		{"copilot", "openai"},
+		{"opencode", "ollama"},
 		{"unknown", ""},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- Map `opencode` → `ollama` and `copilot` → `openai` in `inferLLMProviderFromPreset`
- Produces more accurate provider+LLM mismatch advisories when using these providers