### PR TITLE
refactor: deterministic state machine — pool only via circuit breaker, preserve worktree state

### DIFF
--- a/internal/castellarius/branch_lifecycle_test.go
+++ b/internal/castellarius/branch_lifecycle_test.go
@@ -167,43 +167,6 @@ func TestPrepareBranchInSandbox_ResumeBranch(t *testing.T) {
 	}
 }
 
-// --- cleanupBranchInSandbox tests ---
-
-// TestCleanupBranchInSandbox_DeletesBranch verifies that cleanup detaches HEAD
-// and deletes the feature branch.
-func TestCleanupBranchInSandbox_DeletesBranch(t *testing.T) {
-	dir := makeBareAndClone(t)
-
-	if err := prepareBranchInSandbox(dir, "drop-clean"); err != nil {
-		t.Fatalf("prepareBranchInSandbox: %v", err)
-	}
-	// Make a commit so the branch is not identical to origin/main.
-	if err := os.WriteFile(filepath.Join(dir, "work.go"), []byte("// work\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	branchMustRun(t, branchGitCmd(dir, "add", "."))
-	branchMustRun(t, branchGitCmd(dir, "commit", "-m", "work"))
-
-	cleanupBranchInSandbox(dir, "feat/drop-clean")
-
-	if branchExists(t, dir, "feat/drop-clean") {
-		t.Error("feat/drop-clean should have been deleted by cleanup")
-	}
-
-	// HEAD must be detached after cleanup.
-	if got := currentBranch(t, dir); got != "HEAD" {
-		t.Errorf("HEAD after cleanup = %q, want detached (HEAD)", got)
-	}
-}
-
-// TestCleanupBranchInSandbox_NoopWhenBranchMissing verifies that cleanup is
-// best-effort and does not panic or error when the branch does not exist.
-func TestCleanupBranchInSandbox_NoopWhenBranchMissing(t *testing.T) {
-	dir := makeBareAndClone(t)
-	// cleanupBranchInSandbox ignores errors — must not panic.
-	cleanupBranchInSandbox(dir, "feat/nonexistent")
-}
-
 // --- removeDropletWorktree tests ---
 
 // TestRemoveDropletWorktree_DeletesBranch verifies that removeDropletWorktree

--- a/internal/castellarius/coverage_gaps_test.go
+++ b/internal/castellarius/coverage_gaps_test.go
@@ -223,10 +223,17 @@ func TestPurgeOldItems_DefaultRetentionDays(t *testing.T) {
 // --- recoverInProgress tests ---
 
 func TestRecoverInProgress(t *testing.T) {
+	// Mock tmux as dead so recoverInProgress pools droplets with no outcome
+	// rather than leaving them for a live session.
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return false }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
 	tests := []struct {
-		name     string
-		item     *cistern.Droplet
-		wantStep string
+		name      string
+		item      *cistern.Droplet
+		wantStep  string
+		wantPooled bool
 	}{
 		{
 			name: "item with outcome not reset",
@@ -234,7 +241,8 @@ func TestRecoverInProgress(t *testing.T) {
 				ID: "r1", CurrentCataractae: "implement", Status: "in_progress",
 				Assignee: "alpha", Outcome: "pass",
 			},
-			wantStep: "", // not touched — observe phase handles it
+			wantStep:   "", // not touched — observe phase handles it
+			wantPooled: false,
 		},
 		{
 			name: "item without outcome reset to current step",
@@ -242,7 +250,8 @@ func TestRecoverInProgress(t *testing.T) {
 				ID: "r2", CurrentCataractae: "review", Status: "in_progress",
 				Assignee: "alpha", Outcome: "",
 			},
-			wantStep: "review",
+			wantStep:   "review",
+			wantPooled: false,
 		},
 		{
 			name: "empty step falls back to first workflow step",
@@ -250,7 +259,8 @@ func TestRecoverInProgress(t *testing.T) {
 				ID: "r3", CurrentCataractae: "", Status: "in_progress",
 				Assignee: "alpha", Outcome: "",
 			},
-			wantStep: "implement",
+			wantStep:   "implement",
+			wantPooled: false,
 		},
 	}
 	for _, tc := range tests {
@@ -261,6 +271,15 @@ func TestRecoverInProgress(t *testing.T) {
 			sched.recoverInProgress()
 			client.mu.Lock()
 			defer client.mu.Unlock()
+			if tc.wantPooled {
+				if _, ok := client.pooled[tc.item.ID]; !ok {
+					t.Errorf("expected droplet %s to be pooled, but it was not", tc.item.ID)
+				}
+			} else {
+				if _, ok := client.pooled[tc.item.ID]; ok {
+					t.Errorf("expected droplet %s not to be pooled, but it was", tc.item.ID)
+				}
+			}
 			if client.steps[tc.item.ID] != tc.wantStep {
 				t.Errorf("step = %q, want %q", client.steps[tc.item.ID], tc.wantStep)
 			}
@@ -410,7 +429,7 @@ func TestHeartbeatRepo_UnknownAssignee_WritesStallNote(t *testing.T) {
 // TestHeartbeatRepo_ZombieDetected_AddsNoteAndResetsToOpen verifies that when
 // a tmux session is dead and the item is old enough, heartbeatRepo writes a
 // zombie note (containing session name, worker, and cataractae) and resets the
-// droplet to open via client.Assign.
+// droplet to open for re-dispatch.
 func TestHeartbeatRepo_ZombieDetected_AddsNoteAndResetsToOpen(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return false }
@@ -446,7 +465,7 @@ func TestHeartbeatRepo_ZombieDetected_AddsNoteAndResetsToOpen(t *testing.T) {
 			t.Errorf("zombie note missing %q; got: %s", want, note.notes)
 		}
 	}
-	// Droplet must be reset to open.
+	// Droplet must be reset to open for re-dispatch.
 	if got := client.items[item.ID].Status; got != "open" {
 		t.Errorf("droplet status after zombie reset = %q, want %q", got, "open")
 	}

--- a/internal/castellarius/integration_test.go
+++ b/internal/castellarius/integration_test.go
@@ -280,6 +280,22 @@ func waitDelivered(ctx context.Context, client *cistern.Client, dropletID string
 	}
 }
 
+// waitPooled polls every 200ms until the named droplet reaches 'pooled'
+// status or ctx expires.  Returns true on pool, false on timeout.
+func waitPooled(ctx context.Context, client *cistern.Client, dropletID string) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(200 * time.Millisecond):
+		}
+		d, err := client.Get(dropletID)
+		if err == nil && d != nil && d.Status == "pooled" {
+			return true
+		}
+	}
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Integration tests
 // ─────────────────────────────────────────────────────────────────────────────
@@ -336,11 +352,11 @@ func TestIntegration_HappyPath_FakeAgentDeliversDroplet(t *testing.T) {
 // TestIntegration_StartupRecovery_OrphanedDroplet_RedeliversDroplet verifies
 // that a droplet left in_progress with no outcome before the Castellarius
 // started (simulating an agent that died in a previous process run) is reset
-// at startup and eventually delivered:
+// to open and then re-delivered:
 //
 //	Given: a droplet is in_progress/no-outcome when Castellarius starts
-//	When:  recoverInProgress (startup path) resets it to open; Castellarius dispatches it
-//	Then:  fakeagent signals pass and the droplet reaches 'delivered' within 20s
+//	When:  recoverInProgress (startup path) resets it to open (dead session)
+//	Then:  the droplet is re-dispatched and reaches 'delivered' status
 func TestIntegration_StartupRecovery_OrphanedDroplet_RedeliversDroplet(t *testing.T) {
 	checkIntegrationPrereqs(t)
 	fakeagentPath := buildFakeagent(t)
@@ -388,8 +404,8 @@ func TestIntegration_StartupRecovery_OrphanedDroplet_RedeliversDroplet(t *testin
 			d.Status, d.Outcome)
 	}
 
-	// Start the Castellarius.  recoverInProgress will reset the item to open,
-	// then dispatchRepo picks it up and fakeagent delivers it.
+	// Start the Castellarius.  recoverInProgress will reset the item to open
+	// (dead session, no outcome) and then the main loop will re-dispatch it.
 	sched := newIntScheduler(client, runner, prefix)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
@@ -409,11 +425,12 @@ func TestIntegration_StartupRecovery_OrphanedDroplet_RedeliversDroplet(t *testin
 
 // TestIntegration_HeartbeatRecovery_DeadSession_RedeliversDroplet verifies
 // that a droplet whose agent session dies at runtime (without signaling) is
-// detected by the heartbeat goroutine and reset to open for re-dispatch:
+// detected by the heartbeat goroutine, reset to open, and then re-dispatched
+// to a new session that signals pass:
 //
 //	Given: a droplet is dispatched to a fakeagent that exits without signaling
-//	When:  the heartbeat fires, confirms the tmux session is dead, and resets to open
-//	Then:  a new fakeagent is dispatched, signals pass, and the droplet is delivered
+//	When:  the heartbeat fires, confirms the tmux session is dead, resets to open
+//	Then:  the droplet is re-dispatched and reaches 'delivered' status
 func TestIntegration_HeartbeatRecovery_DeadSession_RedeliversDroplet(t *testing.T) {
 	checkIntegrationPrereqs(t)
 	fakeagentPath := buildFakeagent(t)

--- a/internal/castellarius/production_gaps_test.go
+++ b/internal/castellarius/production_gaps_test.go
@@ -181,7 +181,7 @@ func TestDispatch_SpawnFailure_ResetsDropletAndReleasesWorker(t *testing.T) {
 		t.Errorf("expected 'spawn failed' log; got:\n%s", log)
 	}
 
-	// Droplet must have been reset to open (Assign called with empty worker).
+	// Droplet must have been reset to open (not pooled).
 	client.mu.Lock()
 	status := ""
 	if it, ok := client.items["spawn-fail"]; ok {
@@ -189,7 +189,7 @@ func TestDispatch_SpawnFailure_ResetsDropletAndReleasesWorker(t *testing.T) {
 	}
 	client.mu.Unlock()
 	if status != "open" {
-		t.Errorf("droplet status = %q after spawn failure; want 'open' so it can be retried", status)
+		t.Errorf("droplet status = %q after spawn failure; want 'open'", status)
 	}
 }
 

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -1000,40 +1000,6 @@ func (s *Castellarius) dispatchRepo(ctx context.Context, repo aqueduct.RepoConfi
 					return
 				}
 
-				// Dirty state check: if non-CONTEXT.md files are uncommitted,
-				// recirculate with a diagnostic note rather than spawning into dirty state.
-				// If git status itself fails (transient error, disk full, permissions),
-				// recirculate conservatively rather than letting an unknown dirty state advance.
-				dirtyFiles, dirtyErr := dirtyNonContextFiles(sandboxDir)
-				if dirtyErr != nil {
-					s.logger.Error("dirty check: git status failed — recirculating conservatively",
-						"droplet", req.Item.ID, "error", dirtyErr)
-					s.addNote(client, req.Item.ID, "scheduler",
-						fmt.Sprintf("Dispatch blocked: could not check worktree state: %v", dirtyErr))
-					if err2 := client.Assign(req.Item.ID, "", req.Step.Name); err2 != nil {
-						s.logger.Error("reset after dirty-check error", "droplet", req.Item.ID, "error", err2)
-					}
-					pool.Release(w)
-					return
-				}
-				if len(dirtyFiles) > 0 {
-					note := fmt.Sprintf(
-						"Dispatch blocked: worktree has uncommitted files from a prior session: %s. "+
-							"These must be committed or discarded before proceeding.",
-						strings.Join(dirtyFiles, ", "),
-					)
-					s.logger.Warn("dirty worktree — recirculating",
-						"droplet", req.Item.ID,
-						"files", dirtyFiles,
-					)
-					s.addNote(client, req.Item.ID, "scheduler", note)
-					if err2 := client.Assign(req.Item.ID, "", req.Step.Name); err2 != nil {
-						s.logger.Error("reset after dirty check", "droplet", req.Item.ID, "error", err2)
-					}
-					pool.Release(w)
-					return
-				}
-
 				req.SandboxDir = sandboxDir
 			}
 
@@ -1044,7 +1010,6 @@ func (s *Castellarius) dispatchRepo(ctx context.Context, repo aqueduct.RepoConfi
 					"cataractae", req.Step.Name,
 					"error", err,
 				)
-				// Reset to open so the item can be re-dispatched to same aqueduct.
 				if err2 := client.Assign(req.Item.ID, "", req.Step.Name); err2 != nil {
 					s.logger.Error("reset after spawn failure",
 						"droplet", req.Item.ID, "error", err2)
@@ -1172,11 +1137,13 @@ func (s *Castellarius) handleTerminal(client CisternClient, itemID, terminal, fr
 	}
 }
 
-// recoverInProgress handles items left in_progress after a process restart.
-// Items with a non-null outcome are left as-is — the first observe tick will route them.
-// Items with a null outcome are reset to open so they can be re-dispatched.
-// (Agent sessions that were running will no longer be monitored, but the
-// feature branch preserves their work; the new session picks up incrementally.)
+// recoverInProgress handles items left in_progress after a Castellarius restart.
+//
+// If an outcome is already written, the first observe tick will route it.
+// If the tmux session is still alive, leave the droplet alone — the agent
+// will signal its outcome.
+// Otherwise, reset to open for re-dispatch. The circuit breaker in
+// heartbeatRepo will pool the droplet if it keeps dying.
 func (s *Castellarius) recoverInProgress() {
 	for _, repo := range s.config.Repos {
 		client := s.clients[repo.Name]
@@ -1190,14 +1157,25 @@ func (s *Castellarius) recoverInProgress() {
 
 		for _, item := range items {
 			if item.Outcome != "" {
-				// Outcome already written — leave as in_progress.
-				// The first observe tick will route this item.
 				s.logger.Info("recovery: item has outcome, will be routed on first tick",
 					"repo", repo.Name, "droplet", item.ID, "outcome", item.Outcome)
 				continue
 			}
 
-			// No outcome: reset to open for re-dispatch.
+			if item.Assignee != "" {
+				sessionID := repo.Name + "-" + item.Assignee
+				if isTmuxAlive(sessionID) {
+					s.logger.Info("recovery: session still alive, leaving for agent to signal",
+						"repo", repo.Name, "droplet", item.ID, "session", sessionID)
+					continue
+				}
+				if pool := s.pools[repo.Name]; pool != nil {
+					if w := pool.FindByName(item.Assignee); w != nil {
+						pool.Release(w)
+					}
+				}
+			}
+
 			cataractaeName := item.CurrentCataractae
 			if cataractaeName == "" {
 				step := currentCataracta(item, wf)
@@ -1265,30 +1243,13 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 	threshold := stallThresholdDuration(s.config)
 
 	for _, item := range items {
-		// Items with outcomes are handled by the observe phase — skip them.
 		if item.Outcome != "" {
 			continue
 		}
 
-		// Fast liveness check: if the tmux session is dead, or the session is
-		// alive but the claude process has exited, record a zombie note and reset
-		// the droplet to open for re-dispatch. This runs on every heartbeat
-		// tick (~30s) — no threshold, no waiting.
-		//
-		// State-machine invariant: a droplet is a zombie if and only if
-		//   (1) it is assigned to a worker,
-		//   (2) the worker's tmux session is dead,
-		//   (3) the stage has been running long enough to be real (age guard), AND
-		//   (4) no outcome has been recorded (Outcome == "" — checked above).
-		// Condition (4) is already enforced: the loop skips items whose Outcome
-		// is non-empty. Conditions (1–3) are enforced below.
-		//
-		// Age guard: use StageDispatchedAt (set only when a worker is assigned)
-		// rather than UpdatedAt (bumped by notes, outcome signals, and other
-		// changes). This ensures the guard always reflects actual dispatch time,
-		// not incidental updates. Falls back to UpdatedAt for droplets dispatched
-		// before this field was introduced.
-		// Scale: production (30s heartbeat) → 2min guard; tests (1s heartbeat) → 4s guard.
+		// Dead session detection: tmux dead or agent process dead.
+		// Reset to open for re-dispatch. The circuit breaker below
+		// will pool the droplet if it keeps dying.
 		zombieGuard := 4 * s.heartbeatInterval
 		if item.Assignee != "" {
 			sessionID := repo.Name + "-" + item.Assignee
@@ -1299,127 +1260,75 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 			if time.Since(dispatchedAt) < zombieGuard {
 				continue
 			}
+
+			dead := false
+			tmuxDead := false
 			if !isTmuxAlive(sessionID) {
+				dead = true
+				tmuxDead = true
+				s.logger.Info("heartbeat: tmux dead — resetting to open",
+					"repo", repo.Name, "droplet", item.ID,
+					"assignee", item.Assignee, "session_age", time.Since(dispatchedAt).Round(time.Second).String())
+			} else if !isAgentAlive(sessionID) {
+				dead = true
+				exec.Command("tmux", "kill-session", "-t", sessionID).Run()
+				s.logger.Info("heartbeat: agent dead — killing session, resetting to open",
+					"repo", repo.Name, "droplet", item.ID,
+					"assignee", item.Assignee, "session", sessionID)
+			}
+
+			if dead {
 				step := currentCataracta(item, wf)
 				if step == nil {
 					s.logger.Error("heartbeat: no step for dead session — skipping",
 						"repo", repo.Name, "droplet", item.ID)
 					continue
 				}
-				// Release the pool slot for the dead worker so the next dispatch
-				// cycle can reassign it to another droplet.
 				if pool := s.pools[repo.Name]; pool != nil {
 					if w := pool.FindByName(item.Assignee); w != nil {
 						pool.Release(w)
 					}
 				}
-				// Append a history note so the zombie event is visible in
-				// `ct droplet show` and the TUI timeline.
-				zombieNote := fmt.Sprintf(
-					"Session zombie detected: tmux session %s dead, no outcome recorded. Aqueduct worker: %s, cataractae: %s. Resetting to open for re-dispatch. [%s]",
-					sessionID, item.Assignee, step.Name, time.Now().UTC().Format(time.RFC3339),
-				)
-				if err := client.AddNote(item.ID, "scheduler", zombieNote); err != nil {
-					s.logger.Warn("heartbeat: AddNote failed for zombie reset",
-						"droplet", item.ID, "error", err)
+				var noteMsg string
+				if tmuxDead {
+					noteMsg = fmt.Sprintf("[scheduler:zombie] Session %s died without outcome (worker=%s, cataractae=%s). [%s]",
+						sessionID, item.Assignee, step.Name, time.Now().UTC().Format(time.RFC3339))
+				} else {
+					noteMsg = fmt.Sprintf("Session killed. Re-dispatching (worker=%s, cataractae=%s). [%s]",
+						item.Assignee, step.Name, time.Now().UTC().Format(time.RFC3339))
 				}
-				s.logger.Info("heartbeat: zombie detected — resetting to open",
-					"repo", repo.Name,
-					"droplet", item.ID,
-					"assignee", item.Assignee,
-					"cataractae", step.Name,
-					"session_age", time.Since(dispatchedAt).Round(time.Second).String(),
-				)
+				s.addNote(client, item.ID, "scheduler", noteMsg)
 				if err := client.Assign(item.ID, "", step.Name); err != nil {
-					s.logger.Error("heartbeat: zombie reset failed",
-						"repo", repo.Name, "droplet", item.ID, "error", err)
+					s.logger.Error("heartbeat: reset failed", "droplet", item.ID, "error", err)
 				}
-				continue // handled — skip progress check for this item
-			}
-
-			// The tmux session is alive. Check whether the claude agent process is
-			// still running inside it. If not, the agent exited without signaling an
-			// outcome (e.g. OOM kill, hard token limit) — kill the orphaned session,
-			// record a diagnostic note, and reset the droplet for re-dispatch.
-			if !isAgentAlive(sessionID) {
-				step := currentCataracta(item, wf)
-				if step == nil {
-					s.logger.Error("heartbeat: no step for agent-dead session — skipping",
-						"repo", repo.Name, "droplet", item.ID)
-					continue
-				}
-				if pool := s.pools[repo.Name]; pool != nil {
-					if w := pool.FindByName(item.Assignee); w != nil {
-						pool.Release(w)
-					}
-				}
-				zombieNote := fmt.Sprintf(
-					"Session zombie detected: tmux alive but claude process dead. Session killed. Re-dispatching. [%s]",
-					time.Now().UTC().Format(time.RFC3339),
-				)
-				if err := client.AddNote(item.ID, "scheduler", zombieNote); err != nil {
-					s.logger.Warn("heartbeat: AddNote failed for agent-dead zombie",
-						"droplet", item.ID, "error", err)
-				}
-				s.logger.Info("heartbeat: agent-dead zombie — killed session, resetting to open",
-					"repo", repo.Name,
-					"droplet", item.ID,
-					"assignee", item.Assignee,
-					"cataractae", step.Name,
-					"session", sessionID,
-				)
-				if err := client.Assign(item.ID, "", step.Name); err != nil {
-					s.logger.Error("heartbeat: agent-dead zombie reset failed",
-						"repo", repo.Name, "droplet", item.ID, "error", err)
-				}
-				continue // handled — skip progress check for this item
+				continue
 			}
 		}
 
-		// Stall detection: use the agent heartbeat timestamp as the primary signal.
-		// Agents call `ct droplet heartbeat <id>` every 60 seconds while working.
-		// If the heartbeat is recent (< threshold), the agent is alive — skip.
-		// If no heartbeat has been emitted yet, fall back to UpdatedAt so pre-feature
-		// agents and agents that die before their first heartbeat remain detectable.
+		// Stall detection: agent heartbeat older than threshold.
 		stallSig := item.LastHeartbeatAt
 		if stallSig.IsZero() {
 			stallSig = item.UpdatedAt
 		}
-
-		// Not stalled: heartbeat (or UpdatedAt fallback) is within the threshold.
 		if time.Since(stallSig) <= threshold {
 			continue
 		}
 
-		// Stalled. Write an escalation note. Do NOT auto-respawn: agents that are
-		// emitting heartbeats are alive and working; agents that are not emitting
-		// heartbeats are handled by zombie detection (isTmuxAlive / isAgentAlive).
+		// Stalled — write an escalation note.
 		heartbeatStatus := "none"
 		if !item.LastHeartbeatAt.IsZero() {
 			heartbeatStatus = item.LastHeartbeatAt.UTC().Format(time.RFC3339)
 		}
-		note := fmt.Sprintf(
-			"%s elapsed=%s heartbeat=%s",
-			stallNotePrefix,
-			formatStallDuration(time.Since(stallSig)),
-			heartbeatStatus,
-		)
-		if err := client.AddNote(item.ID, "scheduler", note); err != nil {
-			s.logger.Warn("heartbeat: AddNote failed", "droplet", item.ID, "error", err)
-		} else {
-			s.logger.Warn("heartbeat: stall detected",
-				"repo", repo.Name,
-				"droplet", item.ID,
-				"cataractae", item.CurrentCataractae,
-				"stall_duration", time.Since(stallSig).Round(time.Second).String(),
-				"threshold", threshold.String(),
-			)
-		}
+		note := fmt.Sprintf("%s elapsed=%s heartbeat=%s",
+			stallNotePrefix, formatStallDuration(time.Since(stallSig)), heartbeatStatus)
+		s.addNote(client, item.ID, "scheduler", note)
+		s.logger.Warn("heartbeat: stall detected",
+			"repo", repo.Name, "droplet", item.ID,
+			"cataractae", item.CurrentCataractae,
+			"stall_duration", time.Since(stallSig).Round(time.Second).String(),
+			"threshold", threshold.String())
 
-		// Orphan recovery: no assignee means no named session exists for this
-		// droplet. Force-reset to open so the next dispatch cycle reclaims it.
-		// This handles Castellarius crash/restart and failed dispatch where the
-		// droplet was never assigned a worker.
+		// Orphan: no assignee, no session. Reset to open.
 		if item.Assignee == "" {
 			stepName := item.CurrentCataractae
 			if stepName == "" {
@@ -1427,22 +1336,20 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 					stepName = step.Name
 				}
 			}
-			if err := client.AddNote(item.ID, "scheduler",
-				"[scheduler:recovery] reset orphaned in_progress droplet to open — no assignee, no active session"); err != nil {
-				s.logger.Warn("heartbeat: orphan recovery note failed",
-					"droplet", item.ID, "error", err)
-			}
-			s.logger.Info("heartbeat: orphan recovery — resetting to open",
-				"repo", repo.Name,
-				"droplet", item.ID,
-				"cataractae", stepName,
-			)
+			s.addNote(client, item.ID, "scheduler",
+				fmt.Sprintf("[scheduler:recovery] Orphan reset to open (cataractae=%s).", stepName))
+			s.logger.Info("heartbeat: orphan reset to open",
+				"repo", repo.Name, "droplet", item.ID, "cataractae", stepName)
 			if err := client.Assign(item.ID, "", stepName); err != nil {
-				s.logger.Error("heartbeat: orphan recovery reset failed",
-					"repo", repo.Name, "droplet", item.ID, "error", err)
+				s.logger.Error("heartbeat: orphan reset failed", "droplet", item.ID, "error", err)
 			}
 		}
 	}
+
+	// Circuit breaker: pool droplets that have been dispatched too many
+	// times without producing an outcome. This is the only path that
+	// pools — everything else resets to open for re-dispatch.
+	s.circuitBreaker(repo, items)
 }
 
 // stallThresholdDuration returns the configured stall threshold, defaulting to 45 minutes.
@@ -1469,6 +1376,78 @@ func formatStallDuration(d time.Duration) string {
 		return fmt.Sprintf("%dh", hours)
 	}
 	return fmt.Sprintf("%dh%dm", hours, minutes)
+}
+
+// circuitBreakerMaxDispatches is the maximum number of dispatch attempts within
+// circuitBreakerWindow that a droplet can have without producing an outcome
+// before being pooled. This is the sole mechanism that transitions a droplet
+// to pooled — everything else resets to open.
+const (
+	circuitBreakerMaxDispatches = 5
+	circuitBreakerWindow        = 15 * time.Minute
+)
+
+// circuitBreaker checks in-progress droplets for a tight respawn loop:
+// a droplet that has been dispatched many times within a short window
+// without ever producing an outcome. If detected, the droplet is pooled
+// to stop the token burn. This is the only path that pools.
+func (s *Castellarius) circuitBreaker(repo aqueduct.RepoConfig, items []*cistern.Droplet) {
+	client := s.clients[repo.Name]
+
+	for _, item := range items {
+		if item.Outcome != "" {
+			continue
+		}
+		if item.StageDispatchedAt.IsZero() {
+			continue
+		}
+		// Only check items that have been around long enough to accumulate cycles.
+		if time.Since(item.StageDispatchedAt) < circuitBreakerWindow {
+			continue
+		}
+
+		notes, err := client.GetNotes(item.ID)
+		if err != nil {
+			continue
+		}
+
+		cutoff := time.Now().Add(-circuitBreakerWindow)
+		dispatchCount := 0
+		for _, n := range notes {
+			if n.CataractaeName == "scheduler" &&
+				strings.Contains(n.Content, "Session died without outcome") &&
+				n.CreatedAt.After(cutoff) {
+				dispatchCount++
+			}
+		}
+
+		if dispatchCount >= circuitBreakerMaxDispatches {
+			reason := fmt.Sprintf("[circuit-breaker] %d dead sessions in %s with no outcome — pooling",
+				dispatchCount, circuitBreakerWindow)
+			s.logger.Warn("circuit breaker: pooling droplet",
+				"repo", repo.Name, "droplet", item.ID,
+				"dead_sessions", dispatchCount, "window", circuitBreakerWindow)
+			s.addNote(client, item.ID, "scheduler", reason)
+
+			// Release the pool slot.
+			if item.Assignee != "" {
+				if pool := s.pools[repo.Name]; pool != nil {
+					if w := pool.FindByName(item.Assignee); w != nil {
+						pool.Release(w)
+					}
+				}
+			}
+
+			if s.sandboxRoot != "" {
+				primaryDir := filepath.Join(s.sandboxRoot, repo.Name, "_primary")
+				removeDropletWorktree(primaryDir, s.sandboxRoot, repo.Name, item.ID, true)
+			}
+
+			if err := client.Pool(item.ID, reason); err != nil {
+				s.logger.Error("circuit breaker: pool failed", "droplet", item.ID, "error", err)
+			}
+		}
+	}
 }
 
 // isTmuxAliveFn is a variable so tests can substitute a fake implementation
@@ -1594,13 +1573,12 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 	t0 := time.Now()
 
 	if _, err := os.Stat(worktreePath); err == nil {
-		// Worktree exists — resume by checking out the branch, then hard-reset
-		// to guarantee a clean state. Any uncommitted changes from prior manual
-		// work or prior cataractae are discarded — agents must commit their work.
+		// Worktree exists — resume the branch, preserving any uncommitted work
+		// from the prior session. The agent will be told to commit its changes.
 
 		// Abort any in-progress rebase or merge left by a prior interrupted
-		// dispatch (e.g. Castellarius restart, timeout). Both commands exit
-		// non-zero when nothing is in progress — errors are ignored.
+		// dispatch (e.g. Castellarius restart, timeout). These are corrupted
+		// git state, not meaningful uncommitted work.
 		abortRebase := exec.Command("git", "rebase", "--abort")
 		abortRebase.Dir = worktreePath
 		_ = abortRebase.Run()
@@ -1615,14 +1593,6 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 		if out, err := checkout.CombinedOutput(); err != nil {
 			return "", fmt.Errorf("git checkout %s in %s: %w: %s", branch, worktreePath, err, out)
 		}
-		reset := exec.Command("git", "reset", "--hard", "HEAD")
-		reset.Dir = worktreePath
-		if out, err := reset.CombinedOutput(); err != nil {
-			logger.Warn("git reset --hard HEAD failed", "path", worktreePath, "error", err, "output", string(out))
-		}
-		clean := exec.Command("git", "clean", "-fd")
-		clean.Dir = worktreePath
-		_ = clean.Run()
 
 		logger.Info("worktree resumed",
 			"droplet", dropletID, "path", worktreePath,
@@ -1716,58 +1686,6 @@ func removeDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRoo
 	} else {
 		logger.Info("worktree deleted", "droplet", dropletID, "path", worktreePath)
 	}
-}
-
-// dirtyNonContextFiles returns uncommitted non-CONTEXT.md files in dir.
-// An empty slice means the worktree is clean for dispatch.
-// An error is returned when git status itself fails (non-git dir, disk error,
-// permissions) — callers must treat this as an unknown dirty state and
-// recirculate conservatively rather than proceeding to spawn.
-func dirtyNonContextFiles(dir string) ([]string, error) {
-	cmd := exec.Command("git", "status", "--porcelain")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("git status in %s: %w", dir, err)
-	}
-	var dirty []string
-	for _, line := range strings.Split(string(out), "\n") {
-		if line == "" {
-			continue
-		}
-		// Format: "XY filename" — XY is always exactly 2 chars, then a space.
-		if len(line) < 4 {
-			continue
-		}
-		xy := line[:2]
-		// Skip untracked files ("??" prefix) — gitignored binaries (ct, install)
-		// show as untracked and should never block dispatch.
-		if xy == "??" {
-			continue
-		}
-		name := strings.TrimSpace(line[3:])
-		if name != "CONTEXT.md" && name != ".current-stage" {
-			dirty = append(dirty, name)
-		}
-	}
-	return dirty, nil
-}
-
-// cleanupBranchInSandbox detaches HEAD in the worktree and deletes the feature
-// branch. Called by the Castellarius after a droplet completes or recirculates.
-// Errors are ignored — this is best-effort cleanup.
-//
-// Deprecated: use removeDropletWorktree for per-droplet worktrees.
-// Kept for backwards compatibility with existing tests.
-func cleanupBranchInSandbox(dir, branch string) {
-	// Detach HEAD so we can delete the branch.
-	detach := exec.Command("git", "checkout", "--detach", "HEAD")
-	detach.Dir = dir
-	_ = detach.Run()
-
-	del := exec.Command("git", "branch", "-D", branch)
-	del.Dir = dir
-	_ = del.Run()
 }
 
 // WriteContext writes a CONTEXT.md file with notes from previous steps.

--- a/internal/castellarius/scheduler_test.go
+++ b/internal/castellarius/scheduler_test.go
@@ -175,6 +175,11 @@ func (m *mockClient) Pool(id, reason string) error {
 		return m.poolErr
 	}
 	m.pooled[id] = reason
+	if item, ok := m.items[id]; ok {
+		item.Status = "pooled"
+		item.Assignee = ""
+		item.AssignedAqueduct = ""
+	}
 	return nil
 }
 
@@ -621,12 +626,12 @@ func TestTick_CrashRequeue(t *testing.T) {
 
 	client.mu.Lock()
 	defer client.mu.Unlock()
-	// Item stays at "implement" — not advanced, not pooled.
+	// Spawn failed — droplet is reset to open at step "implement", not left in_progress.
 	if client.steps["b1"] != "implement" {
-		t.Errorf("expected step to remain 'implement' after crash, got %q", client.steps["b1"])
+		t.Errorf("expected droplet reset to step 'implement' after spawn failure, got %q", client.steps["b1"])
 	}
-	if _, ok := client.pooled["b1"]; ok {
-		t.Error("should not pool on crash — just requeue")
+	if item, ok := client.items["b1"]; ok && item.Status != "open" {
+		t.Errorf("expected droplet status 'open' after spawn failure, got %q", item.Status)
 	}
 }
 
@@ -1838,8 +1843,8 @@ func TestObserve_ExternalCancel_NormalFlowUnaffected(t *testing.T) {
 }
 
 // TestDispatch_DirtyWorktree verifies that when a worktree has uncommitted files
-// from a prior session, prepareDropletWorktree hard-resets them away (commit #86
-// behaviour) and the agent spawns normally into a clean state.
+// from a prior session, the agent spawns normally and the dirty state is preserved.
+// The agent is told about uncommitted files via CONTEXT.md and must commit them.
 func TestDispatch_DirtyWorktree(t *testing.T) {
 	sandboxRoot := t.TempDir()
 
@@ -1851,15 +1856,12 @@ func TestDispatch_DirtyWorktree(t *testing.T) {
 		Status:            "open",
 	})
 
-	// Create the worktree directory and initialize a git repo inside it.
-	// Per-droplet worktrees are at sandboxRoot/<repo>/<dropletID>.
 	sandboxDir := filepath.Join(sandboxRoot, "test-repo", itemID)
 	if err := os.MkdirAll(sandboxDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	makeGitSandbox(t, sandboxDir)
 
-	// Create the feature branch so prepareDropletWorktree's checkout succeeds.
 	cmd := exec.Command("git", "checkout", "-b", "feat/"+itemID)
 	cmd.Dir = sandboxDir
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -1881,21 +1883,20 @@ func TestDispatch_DirtyWorktree(t *testing.T) {
 	sched.Tick(context.Background())
 	time.Sleep(50 * time.Millisecond)
 
-	// prepareDropletWorktree hard-resets on resume (commit #86), so the dirty
-	// file is cleaned before the dirty check runs. Spawn proceeds normally.
+	// Spawn proceeds normally — dirty state is preserved for the agent to commit.
 	runner.mu.Lock()
 	defer runner.mu.Unlock()
 	if len(runner.calls) != 1 {
-		t.Errorf("expected spawn to proceed after hard-reset cleaned dirty file, got %d runner calls", len(runner.calls))
+		t.Fatalf("expected spawn to proceed with dirty worktree, got %d runner calls", len(runner.calls))
 	}
 
-	// No dirty-worktree note should be attached — the reset handled it silently.
-	client.mu.Lock()
-	defer client.mu.Unlock()
-	for _, n := range client.attached {
-		if n.id == itemID && strings.Contains(n.notes, "uncommitted files") {
-			t.Errorf("unexpected dirty-worktree note (hard-reset should have cleaned it): %v", n)
-		}
+	// The dirty state should still be present — not hard-reset away.
+	content, err := os.ReadFile(filepath.Join(sandboxDir, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "dirty\n" {
+		t.Errorf("dirty file was reset; expected preserved content, got %q", string(content))
 	}
 }
 
@@ -2007,148 +2008,6 @@ func TestDispatch_RebaseInProgress(t *testing.T) {
 	}
 }
 
-// --- dirtyNonContextFiles unit tests ---
-
-func TestDirtyNonContextFiles_Error(t *testing.T) {
-	// Non-existent directory: git status should fail and return an error.
-	files, err := dirtyNonContextFiles("/does/not/exist/at/all")
-	if err == nil {
-		t.Error("expected error for non-existent directory, got nil")
-	}
-	if len(files) != 0 {
-		t.Errorf("expected no files on error, got %v", files)
-	}
-}
-
-func TestDirtyNonContextFiles_Clean(t *testing.T) {
-	dir := t.TempDir()
-	makeGitSandbox(t, dir)
-
-	files, err := dirtyNonContextFiles(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(files) != 0 {
-		t.Errorf("expected no dirty files for clean repo, got %v", files)
-	}
-}
-
-func TestDirtyNonContextFiles_DirtyTrackedFile(t *testing.T) {
-	dir := t.TempDir()
-	makeGitSandbox(t, dir)
-
-	// Modify a tracked file without committing.
-	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("modified\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	files, err := dirtyNonContextFiles(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(files) == 0 {
-		t.Fatal("expected dirty files, got none")
-	}
-	found := false
-	for _, f := range files {
-		if f == "README.md" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected README.md in dirty files, got %v", files)
-	}
-}
-
-func TestDirtyNonContextFiles_FiltersContextMD(t *testing.T) {
-	dir := t.TempDir()
-	makeGitSandbox(t, dir)
-
-	// Commit CONTEXT.md as a tracked file, then modify it.
-	if err := os.WriteFile(filepath.Join(dir, "CONTEXT.md"), []byte("original\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	for _, args := range [][]string{
-		{"git", "add", "CONTEXT.md"},
-		{"git", "commit", "-m", "add CONTEXT.md"},
-	} {
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("%v: %v\n%s", args, err, out)
-		}
-	}
-	if err := os.WriteFile(filepath.Join(dir, "CONTEXT.md"), []byte("modified\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	files, err := dirtyNonContextFiles(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	for _, f := range files {
-		if f == "CONTEXT.md" {
-			t.Error("CONTEXT.md should be filtered from dirty files")
-		}
-	}
-}
-
-func TestDirtyNonContextFiles_FiltersUntracked(t *testing.T) {
-	dir := t.TempDir()
-	makeGitSandbox(t, dir)
-
-	// Create an untracked file (never added to git).
-	if err := os.WriteFile(filepath.Join(dir, "untracked.go"), []byte("// new\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	files, err := dirtyNonContextFiles(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	for _, f := range files {
-		if f == "untracked.go" {
-			t.Error("untracked file should be filtered from dirty files")
-		}
-	}
-}
-
-// TestDirtyNonContextFiles_FiltersCurrentStage verifies that a tracked, modified
-// .current-stage file is excluded from the dirty list so the stage marker never
-// blocks dispatch.
-func TestDirtyNonContextFiles_FiltersCurrentStage(t *testing.T) {
-	dir := t.TempDir()
-	makeGitSandbox(t, dir)
-
-	// Commit .current-stage as a tracked file, then modify it.
-	if err := os.WriteFile(filepath.Join(dir, ".current-stage"), []byte("implementer\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	for _, args := range [][]string{
-		{"git", "add", ".current-stage"},
-		{"git", "commit", "-m", "add stage marker"},
-	} {
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("%v: %v\n%s", args, err, out)
-		}
-	}
-	if err := os.WriteFile(filepath.Join(dir, ".current-stage"), []byte("reviewer\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	files, err := dirtyNonContextFiles(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	for _, f := range files {
-		if f == ".current-stage" {
-			t.Error(".current-stage should be filtered from dirty files")
-		}
-	}
-}
-
 // TestDispatch_DiffOnlyStepGetsSandboxDir verifies that when a diff_only agent
 // step is dispatched, the Castellarius prepares the per-droplet worktree and
 // passes its path as req.SandboxDir. Without this, generateDiff runs on the
@@ -2248,15 +2107,15 @@ func TestHeartbeatRepo_StallDetected_AppendsNoteAndWarnLog(t *testing.T) {
 
 	sched.heartbeatRepo(context.Background(), config.Repos[0])
 
-	// Stall note and recovery note must both be appended.
+	// Stall note and orphan note must both be appended.
 	if len(client.attached) != 2 {
-		t.Fatalf("expected 2 notes (stall + recovery), got %d", len(client.attached))
+		t.Fatalf("expected 2 notes (stall + orphan), got %d", len(client.attached))
 	}
 	if !strings.HasPrefix(client.attached[0].notes, stallNotePrefix) {
 		t.Errorf("stall note missing structured prefix %q; got: %s", stallNotePrefix, client.attached[0].notes)
 	}
 	if !strings.Contains(client.attached[1].notes, "[scheduler:recovery]") {
-		t.Errorf("recovery note missing '[scheduler:recovery]'; got: %s", client.attached[1].notes)
+		t.Errorf("orphan note missing '[scheduler:recovery]'; got: %s", client.attached[1].notes)
 	}
 
 	// A Warn-level log entry must be present containing the droplet ID.
@@ -2270,7 +2129,7 @@ func TestHeartbeatRepo_StallDetected_AppendsNoteAndWarnLog(t *testing.T) {
 }
 
 // TestHeartbeatRepo_OrphanRecovery_SecondTick_ItemResetToOpenNotReprocessed
-// verifies that after orphan recovery resets a no-assignee in_progress droplet
+// verifies that after orphan handling resets a no-assignee in_progress droplet
 // to open on the first tick, the second heartbeat tick writes no additional
 // notes because the item is no longer in_progress and is not returned by List.
 func TestHeartbeatRepo_OrphanRecovery_SecondTick_ItemResetToOpenNotReprocessed(t *testing.T) {
@@ -2298,7 +2157,7 @@ func TestHeartbeatRepo_OrphanRecovery_SecondTick_ItemResetToOpenNotReprocessed(t
 		t.Fatalf("expected 2 notes (stall + recovery) after first tick, got %d", len(client.attached))
 	}
 	if item.Status != "open" {
-		t.Errorf("expected item reset to open after orphan recovery, got status %q", item.Status)
+		t.Errorf("expected item reset to open after orphan handling, got status %q", item.Status)
 	}
 
 	// Second call: item is now open (no longer in_progress) → no additional notes.
@@ -2433,8 +2292,8 @@ func TestHeartbeatRepo_StallWithAssignee_WritesNoteNoRespawn(t *testing.T) {
 
 // TestHeartbeatRepo_StallWithNoAssignee_RecoverAndNoSpawn verifies that when a
 // stall is detected on an orphaned droplet (no assignee), both the stall note and
-// the recovery note are written, the droplet is reset to open, and runner.Spawn is
-// NOT called (there is no session to resume).
+// the recovery note are written, the droplet is reset to open for re-dispatch,
+// and runner.Spawn is NOT called (there is no session to resume).
 func TestHeartbeatRepo_StallWithNoAssignee_RecoverAndNoSpawn(t *testing.T) {
 	client := newMockClient()
 	runner := newMockRunner(client)
@@ -2456,15 +2315,15 @@ func TestHeartbeatRepo_StallWithNoAssignee_RecoverAndNoSpawn(t *testing.T) {
 
 	sched.heartbeatRepo(context.Background(), config.Repos[0])
 
-	// Stall note and recovery note must both be written.
+	// Stall note and orphan note must both be written.
 	if len(client.attached) != 2 {
-		t.Fatalf("expected 2 notes (stall + recovery) for orphaned droplet, got %d", len(client.attached))
+		t.Fatalf("expected 2 notes (stall + orphan) for orphaned droplet, got %d", len(client.attached))
 	}
 	if !strings.Contains(client.attached[1].notes, "[scheduler:recovery]") {
 		t.Errorf("second note should be recovery note; got: %s", client.attached[1].notes)
 	}
 
-	// Item must be reset to open.
+	// Item must be reset to open for re-dispatch.
 	if item.Status != "open" {
 		t.Errorf("expected item reset to open, got status %q", item.Status)
 	}
@@ -2479,7 +2338,7 @@ func TestHeartbeatRepo_StallWithNoAssignee_RecoverAndNoSpawn(t *testing.T) {
 }
 
 // TestHeartbeatRepo_OrphanRecovery_ClearsAssignedAqueduct verifies that the
-// orphan recovery path clears assigned_aqueduct so the re-opened droplet is not
+// orphan handling path clears assigned_aqueduct so the pooled droplet is not
 // locked to a specific aqueduct operator that may no longer exist.
 func TestHeartbeatRepo_OrphanRecovery_ClearsAssignedAqueduct(t *testing.T) {
 	client := newMockClient()
@@ -2504,7 +2363,7 @@ func TestHeartbeatRepo_OrphanRecovery_ClearsAssignedAqueduct(t *testing.T) {
 	sched.heartbeatRepo(context.Background(), config.Repos[0])
 
 	if item.Status != "open" {
-		t.Errorf("expected item status=open after recovery, got %q", item.Status)
+		t.Errorf("expected item status=open after orphan handling, got %q", item.Status)
 	}
 	if item.AssignedAqueduct != "" {
 		t.Errorf("expected assigned_aqueduct cleared after recovery, got %q", item.AssignedAqueduct)
@@ -2512,8 +2371,8 @@ func TestHeartbeatRepo_OrphanRecovery_ClearsAssignedAqueduct(t *testing.T) {
 }
 
 // TestHeartbeatRepo_OrphanRecovery_AssignFailure_ClearsDebounce verifies that
-// when the Assign reset fails, the debounce entry is cleared so the next
-// heartbeat retries the recovery rather than suppressing it permanently.
+// when the Assign call fails, the debounce entry is cleared so the next
+// heartbeat retries the orphan handling rather than suppressing it permanently.
 func TestHeartbeatRepo_OrphanRecovery_AssignFailure_ClearsDebounce(t *testing.T) {
 	client := newMockClient()
 	client.assignErr = errors.New("db error")
@@ -2536,15 +2395,15 @@ func TestHeartbeatRepo_OrphanRecovery_AssignFailure_ClearsDebounce(t *testing.T)
 
 	sched.heartbeatRepo(context.Background(), config.Repos[0])
 
-	// Recovery note must be written (best-effort) even when Assign fails.
-	recoveryNotes := 0
+	// Orphan note must be written (best-effort) even when Pool fails.
+	orphanNotes := 0
 	for _, n := range client.attached {
 		if strings.Contains(n.notes, "[scheduler:recovery]") {
-			recoveryNotes++
+			orphanNotes++
 		}
 	}
-	if recoveryNotes < 1 {
-		t.Errorf("expected recovery note even on Assign failure, got %d recovery notes", recoveryNotes)
+	if orphanNotes < 1 {
+		t.Errorf("expected recovery note even on Assign failure, got %d recovery notes", orphanNotes)
 	}
 }
 
@@ -2653,8 +2512,8 @@ func TestHeartbeatRepo_AgentNotEmittingHeartbeat_Stalled(t *testing.T) {
 // --- heartbeat zombie detection tests ---
 
 // TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet verifies that when the
-// tmux session is dead the droplet is reset to open and a zombie note is written.
-// This covers the existing "tmux fully dead" path (acceptance criterion 3).
+// tmux session is dead the droplet is reset to open for re-dispatch and a zombie
+// note is written.
 func TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet(t *testing.T) {
 	// Ensure tmux appears dead for our test session.
 	orig := isTmuxAliveFn
@@ -2685,23 +2544,23 @@ func TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet(t *testing.T) {
 		t.Fatalf("expected 1 zombie note, got %d", len(client.attached))
 	}
 	note := client.attached[0].notes
-	if !strings.Contains(note, "tmux session") || !strings.Contains(note, "dead") {
-		t.Errorf("zombie note missing expected text; got: %s", note)
+	if !strings.Contains(note, "[scheduler:zombie]") {
+		t.Errorf("zombie note missing [scheduler:zombie] prefix; got: %s", note)
 	}
 
-	// Droplet must have been reset to open.
+	// Droplet must have been reset to open for re-dispatch.
 	if item.Status != "open" {
 		t.Errorf("item status = %q, want open", item.Status)
 	}
 	if item.Assignee != "" {
-		t.Errorf("item assignee = %q, want empty", item.Assignee)
+		t.Errorf("item assignee = %q, want empty after reset", item.Assignee)
 	}
 }
 
 // TestHeartbeatRepo_TmuxAliveAgentDead_WritesNoteKillsSessionAndResetsDroplet
-// verifies the new path: tmux session alive but claude process has exited.
-// The heartbeat must kill the session, write a diagnostic note, and reset the
-// droplet to open for re-dispatch (acceptance criterion 2).
+// verifies the path: tmux session alive but agent process has exited.
+// The heartbeat must kill the session, write a diagnostic note, and reset
+// the droplet to open for re-dispatch.
 func TestHeartbeatRepo_TmuxAliveAgentDead_WritesNoteKillsSessionAndResetsDroplet(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
@@ -2734,9 +2593,6 @@ func TestHeartbeatRepo_TmuxAliveAgentDead_WritesNoteKillsSessionAndResetsDroplet
 		t.Fatalf("expected 1 note, got %d", len(client.attached))
 	}
 	note := client.attached[0].notes
-	if !strings.Contains(note, "tmux alive but claude process dead") {
-		t.Errorf("note missing expected text; got: %s", note)
-	}
 	if !strings.Contains(note, "Session killed") {
 		t.Errorf("note missing 'Session killed'; got: %s", note)
 	}
@@ -2744,12 +2600,12 @@ func TestHeartbeatRepo_TmuxAliveAgentDead_WritesNoteKillsSessionAndResetsDroplet
 		t.Errorf("note missing 'Re-dispatching'; got: %s", note)
 	}
 
-	// Droplet must have been reset to open.
+	// Droplet must have been reset to open for re-dispatch.
 	if item.Status != "open" {
 		t.Errorf("item status = %q, want open", item.Status)
 	}
 	if item.Assignee != "" {
-		t.Errorf("item assignee = %q, want empty", item.Assignee)
+		t.Errorf("item assignee = %q, want empty after reset", item.Assignee)
 	}
 }
 
@@ -2959,25 +2815,25 @@ func TestHeartbeatRepo_GenuineZombie_StageDispatchedAtOld_Detected(t *testing.T)
 
 	sched.heartbeatRepo(context.Background(), config.Repos[0])
 
-	// StageDispatchedAt is old → zombie guard fires → droplet must be reset.
+	// StageDispatchedAt is old → zombie guard fires → droplet must be reset to open.
 	if item.Status != "open" {
 		t.Errorf("item status = %q, want open — genuine zombie must be reset", item.Status)
 	}
 	if item.Assignee != "" {
-		t.Errorf("item assignee = %q, want empty — genuine zombie must be unassigned", item.Assignee)
+		t.Errorf("item assignee = %q, want empty — genuine zombie must be reset", item.Assignee)
 	}
 	if len(client.attached) != 1 {
 		t.Fatalf("expected 1 zombie note, got %d", len(client.attached))
 	}
 	if !strings.Contains(client.attached[0].notes, "zombie") {
-		t.Errorf("zombie note missing expected text; got: %s", client.attached[0].notes)
+		t.Errorf("zombie note missing 'zombie'; got: %s", client.attached[0].notes)
 	}
 }
 
 // TestHeartbeatRepo_UpdatedAtFallback_StaleUpdatedAt_ZombieFires verifies the
-// migration fallback branch (scheduler.go:1438-1439): when StageDispatchedAt is
+// migration fallback branch: when StageDispatchedAt is
 // zero (pre-migration droplet) and UpdatedAt is older than zombieGuard, the
-// droplet is treated as a zombie and reset to open.
+// droplet is treated as a zombie and pooled.
 func TestHeartbeatRepo_UpdatedAtFallback_StaleUpdatedAt_ZombieFires(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return false }
@@ -3004,25 +2860,25 @@ func TestHeartbeatRepo_UpdatedAtFallback_StaleUpdatedAt_ZombieFires(t *testing.T
 
 	sched.heartbeatRepo(context.Background(), config.Repos[0])
 
-	// UpdatedAt fallback: stale UpdatedAt → zombie fires → droplet must be reset.
+	// UpdatedAt fallback: stale UpdatedAt → zombie fires → droplet must be reset to open.
 	if item.Status != "open" {
-		t.Errorf("item status = %q, want open — stale UpdatedAt fallback must trigger zombie", item.Status)
+		t.Errorf("item status = %q, want open — stale UpdatedAt fallback must trigger zombie reset", item.Status)
 	}
 	if item.Assignee != "" {
-		t.Errorf("item assignee = %q, want empty — zombie reset must clear assignee", item.Assignee)
+		t.Errorf("item assignee = %q, want empty — zombie must clear assignee", item.Assignee)
 	}
 	if len(client.attached) != 1 {
 		t.Fatalf("expected 1 zombie note, got %d", len(client.attached))
 	}
 	if !strings.Contains(client.attached[0].notes, "zombie") {
-		t.Errorf("zombie note missing expected text; got: %s", client.attached[0].notes)
+		t.Errorf("zombie note missing 'zombie'; got: %s", client.attached[0].notes)
 	}
 }
 
 // TestHeartbeatRepo_UpdatedAtFallback_RecentUpdatedAt_ZombieSuppressed verifies the
-// migration fallback branch (scheduler.go:1438-1439): when StageDispatchedAt is
+// migration fallback branch: when StageDispatchedAt is
 // zero (pre-migration droplet) and UpdatedAt is recent (within zombieGuard), the
-// droplet is NOT declared a zombie — the age guard suppresses the reset.
+// droplet is NOT declared a zombie — the age guard suppresses the pool.
 func TestHeartbeatRepo_UpdatedAtFallback_RecentUpdatedAt_ZombieSuppressed(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return false }

--- a/internal/cataractae/context.go
+++ b/internal/cataractae/context.go
@@ -179,6 +179,19 @@ func writeContextFile(path string, p ContextParams) error {
 		b.WriteString("\n\n")
 	}
 
+	if p.Level == aqueduct.ContextFullCodebase || p.Level == "" {
+		if dirty, err := uncommittedFiles(p.SandboxDir); err == nil && len(dirty) > 0 {
+			b.WriteString("### Uncommitted Files from Prior Session\n\n")
+			b.WriteString("The worktree has uncommitted changes from a prior agent session.\n")
+			b.WriteString("You MUST commit these changes before making new ones.\n")
+			b.WriteString("Review the changes, ensure they are correct, then commit with a descriptive message.\n\n")
+			for _, f := range dirty {
+				b.WriteString(fmt.Sprintf("- `%s`\n", f))
+			}
+			b.WriteString("\n")
+		}
+	}
+
 	b.WriteString(fmt.Sprintf("## Current Step: %s\n\n", p.Step.Name))
 	b.WriteString(fmt.Sprintf("- **Type:** %s\n", p.Step.Type))
 	if p.Step.Identity != "" {
@@ -420,6 +433,32 @@ func readSkillDescription(path string) string {
 // non-heading, non-empty line as a brief description. Falls back to name.
 func skillDescription(name string) string {
 	return readSkillDescription(skills.LocalPath(name))
+}
+
+// uncommittedFiles returns a list of modified/staged files (excluding CONTEXT.md,
+// .current-stage, and untracked files) in the given directory. Returns nil on error.
+func uncommittedFiles(dir string) ([]string, error) {
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		xy := line[:2]
+		if xy == "??" {
+			continue
+		}
+		name := strings.TrimSpace(line[3:])
+		if name != "CONTEXT.md" && name != ".current-stage" {
+			files = append(files, name)
+		}
+	}
+	return files, nil
 }
 
 // generateDiff captures all committed changes on the item's feature branch vs

--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -430,8 +430,8 @@ Do not wrap the agent command in a shell (bash -c, sh -c, pipes, tee) unless you
 **3. CONTEXT.md is pipeline state — never commit it.**
 CONTEXT.md is injected at dispatch time and listed in .gitignore. If you see it in a git add or git commit, stop. Committing it causes merge conflicts across concurrent deliveries and corrupts origin/main.
 
-**4. The zombie circuit breaker will pool after 5 spawns with no outcome.**
-If a droplet is being repeatedly respawned with no progress, the system will pool it automatically. If you see this happening in notes, do not attempt to work around it — pool the droplet and explain why in the notes so a human can investigate.
+**4. The circuit breaker pools after 5 dead sessions in 15 minutes.**
+If your droplet keeps dying without signaling an outcome, the scheduler will pool it automatically. This stops token burn — a human needs to investigate before the droplet is re-opened.
 
 **5. Do not call git add -f or git add --force on any ignored file.**
 The .gitignore exists for a reason. Overriding it for pipeline state files (CONTEXT.md, .current-stage, session logs) corrupts the state machine.


### PR DESCRIPTION
## Summary

Simplifies the Castellarius to a clean, deterministic state machine:

- **Dead sessions reset to `open`** for re-dispatch (not pooled). The only path to `pooled` is the circuit breaker.
- **Circuit breaker**: a droplet that dies 5 times in 15 minutes with no outcome gets pooled. This is the sole escape hatch for broken environments.
- **Worktrees preserve state**: removed `git reset --hard HEAD` and `git clean -fd` from the worktree resume path. Dirty state from a prior agent session is shown in CONTEXT.md with instructions to commit.
- **Removed `dirtyNonContextFiles`** dispatch check — the Castellarius owns worktrees, dirty state is the agent's responsibility.
- **Removed deprecated `cleanupBranchInSandbox`** function and tests.
- **Fixed systemd service**: moved `StartLimitIntervalSec` to `[Unit]` section (was in `[Service]`), added `opencode` to PATH.
- **Updated `baseCataractaePrompt`** invariant #4 to describe the circuit breaker.

### State machine transitions (after)

| Event | Transition |
|---|---|
| Agent signals outcome | `in_progress` → next step via observe |
| Dead tmux / dead agent (heartbeat) | `in_progress` → `open` (re-queue) |
| Spawn failure / worktree error | `in_progress` → `open` (re-queue) |
| Orphan (no assignee, stalled) | `in_progress` → `open` (re-queue) |
| Startup recovery, dead session | `in_progress` → `open` (re-queue) |
| Circuit breaker: 5 deaths in 15min | `in_progress` → **`pooled`** (only this) |

Net change: -491 lines deleted, +303 lines added. 188 lines simpler.