### PR TITLE
fix: check outcome before declaring zombie — prevent race condition

### DIFF
--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -34,6 +34,7 @@ const (
 type CisternClient interface {
 	GetReady(repo string) (*cistern.Droplet, error)
 	Assign(id, worker, step string) error
+	Get(id string) (*cistern.Droplet, error)
 
 	AddNote(id, step, content string) error
 	GetNotes(id string) ([]cistern.CataractaeNote, error)
@@ -1278,6 +1279,17 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 			}
 
 			if dead {
+				// Re-read the item from the DB before resetting. The agent may
+				// have called ct droplet pass/recirculate/pool between when we
+				// fetched the list and now. If an outcome exists, the observe
+				// cycle will handle it — do not reset.
+				fresh, err := client.Get(item.ID)
+				if err == nil && fresh.Outcome != "" {
+					s.logger.Info("heartbeat: dead session but outcome already written — skipping reset",
+						"repo", repo.Name, "droplet", item.ID, "outcome", fresh.Outcome)
+					continue
+				}
+
 				step := currentCataracta(item, wf)
 				if step == nil {
 					s.logger.Error("heartbeat: no step for dead session — skipping",

--- a/internal/castellarius/scheduler_test.go
+++ b/internal/castellarius/scheduler_test.go
@@ -134,6 +134,15 @@ func (m *mockClient) Assign(id, worker, step string) error {
 	return nil
 }
 
+func (m *mockClient) Get(id string) (*cistern.Droplet, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if item, ok := m.items[id]; ok {
+		return item, nil
+	}
+	return nil, fmt.Errorf("not found: %s", id)
+}
+
 func (m *mockClient) SetOutcome(id, outcome string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/castellarius/smoke_test.go
+++ b/internal/castellarius/smoke_test.go
@@ -125,6 +125,13 @@ func (c *pipelineClient) Assign(id, worker, step string) error {
 	return nil
 }
 
+func (c *pipelineClient) Get(id string) (*cistern.Droplet, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	item := c.item
+	return &item, nil
+}
+
 // SetOutcome is called by the mock runner to signal step completion.
 // The observe phase reads this on the next Tick to route the item.
 func (c *pipelineClient) SetOutcome(id, outcome string) error {


### PR DESCRIPTION
## Summary

Prevents the heartbeat from resetting a droplet to `open` when the agent already signaled its outcome but the tmux session died before the observe cycle processed it.

When `opencode run` completes: the agent calls `ct droplet pass`, then the process exits, then tmux closes. The heartbeat detects the dead tmux and resets the droplet to `open` for re-dispatch — but the outcome is already in the DB. The observe cycle then processes it, and the re-dispatched agent finds the droplet already advanced.

This caused:
- Noisy zombie notes on every stage transition
- Unnecessary re-dispatches
- Duplicate reviews (reviewer ran twice with same findings)

Fix: before resetting a dead session, re-read the droplet from the DB. If an outcome was written, skip the reset — the observe cycle will handle routing.

Adds `Get(id)` to the `CisternClient` interface and both mock clients.