### PR TITLE
fix: heartbeat skips reset when cataractae already advanced

### DIFF
--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -34,6 +34,7 @@ const (
 type CisternClient interface {
 	GetReady(repo string) (*cistern.Droplet, error)
 	Assign(id, worker, step string) error
+	Get(id string) (*cistern.Droplet, error)
 
 	AddNote(id, step, content string) error
 	GetNotes(id string) ([]cistern.CataractaeNote, error)
@@ -1278,6 +1279,17 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 			}
 
 			if dead {
+				// Re-read the item from the DB before resetting. The agent may
+				// have called ct droplet pass/recirculate/pool between when we
+				// fetched the list and now. If an outcome exists, the observe
+				// cycle will handle it — do not reset.
+				fresh, err := client.Get(item.ID)
+				if err == nil && fresh.Outcome != "" {
+					s.logger.Info("heartbeat: dead session but outcome already written — skipping reset",
+						"repo", repo.Name, "droplet", item.ID, "outcome", fresh.Outcome)
+					continue
+				}
+
 				step := currentCataracta(item, wf)
 				if step == nil {
 					s.logger.Error("heartbeat: no step for dead session — skipping",

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -1282,12 +1282,23 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 				// Re-read the item from the DB before resetting. The agent may
 				// have called ct droplet pass/recirculate/pool between when we
 				// fetched the list and now. If an outcome exists, the observe
-				// cycle will handle it — do not reset.
+				// cycle will handle it. Even if the outcome was already consumed
+				// by the observe cycle (which clears it via Assign), we can detect
+				// that by checking if the cataractae stage advanced — if so, the
+				// droplet has already moved on and we must not reset it.
 				fresh, err := client.Get(item.ID)
-				if err == nil && fresh.Outcome != "" {
-					s.logger.Info("heartbeat: dead session but outcome already written — skipping reset",
-						"repo", repo.Name, "droplet", item.ID, "outcome", fresh.Outcome)
-					continue
+				if err == nil {
+					if fresh.Outcome != "" {
+						s.logger.Info("heartbeat: dead session but outcome already written — skipping reset",
+							"repo", repo.Name, "droplet", item.ID, "outcome", fresh.Outcome)
+						continue
+					}
+					if fresh.CurrentCataractae != item.CurrentCataractae {
+						s.logger.Info("heartbeat: dead session but cataractae already advanced — skipping reset",
+							"repo", repo.Name, "droplet", item.ID,
+							"was", item.CurrentCataractae, "now", fresh.CurrentCataractae)
+						continue
+					}
 				}
 
 				step := currentCataracta(item, wf)

--- a/internal/castellarius/scheduler_test.go
+++ b/internal/castellarius/scheduler_test.go
@@ -134,6 +134,15 @@ func (m *mockClient) Assign(id, worker, step string) error {
 	return nil
 }
 
+func (m *mockClient) Get(id string) (*cistern.Droplet, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if item, ok := m.items[id]; ok {
+		return item, nil
+	}
+	return nil, fmt.Errorf("not found: %s", id)
+}
+
 func (m *mockClient) SetOutcome(id, outcome string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/castellarius/smoke_test.go
+++ b/internal/castellarius/smoke_test.go
@@ -125,6 +125,13 @@ func (c *pipelineClient) Assign(id, worker, step string) error {
 	return nil
 }
 
+func (c *pipelineClient) Get(id string) (*cistern.Droplet, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	item := c.item
+	return &item, nil
+}
+
 // SetOutcome is called by the mock runner to signal step completion.
 // The observe phase reads this on the next Tick to route the item.
 func (c *pipelineClient) SetOutcome(id, outcome string) error {


### PR DESCRIPTION
## Summary

The heartbeat zombie detection had a remaining race condition: even after the
first fix (checking `fresh.Outcome != ""`), agents that signaled their outcome
and exited were still getting spurious zombie resets.

**Root cause:** The observe cycle processes the outcome and calls `Assign(id, "", next)`,
which clears the `outcome` field. By the time the heartbeat re-reads the DB, the
outcome is gone even though the droplet has already moved forward. The heartbeat
sees a dead session with no outcome and resets it.

**Fix:** Added a second check — if `fresh.CurrentCataractae != item.CurrentCataractae`,
the observe cycle has already advanced the droplet to the next stage, so the
heartbeat must not interfere.

This was visible in production as repeated `[scheduler:zombie]` notes on droplets
that had already been processed by the observe cycle, causing redundant
re-dispatches of the same cataractae stage.