### PR TITLE
fix: deterministic heartbeat — agent exit is normal, not a zombie event

### DIFF
--- a/internal/castellarius/coverage_gaps_test.go
+++ b/internal/castellarius/coverage_gaps_test.go
@@ -336,11 +336,6 @@ func TestHeartbeatRepo_StallDetected_ForAssignedDroplet(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
-	// Mock agent as alive so the agent-dead zombie path is not triggered.
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
-
 	client := newMockClient()
 	item := &cistern.Droplet{
 		ID:                "hb-assigned-stall",
@@ -368,11 +363,6 @@ func TestHeartbeatRepo_ActiveDroplet_NotStalled(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
-	// Mock agent as alive so the agent-dead zombie path is not triggered.
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
-
 	client := newMockClient()
 	item := &cistern.Droplet{
 		ID:                "hb-active",
@@ -401,11 +391,6 @@ func TestHeartbeatRepo_UnknownAssignee_WritesStallNote(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
-	// Mock agent as alive so the agent-dead zombie path is not triggered.
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
-
 	client := newMockClient()
 	item := &cistern.Droplet{
 		ID:                "hb-unknown",
@@ -426,18 +411,18 @@ func TestHeartbeatRepo_UnknownAssignee_WritesStallNote(t *testing.T) {
 	}
 }
 
-// TestHeartbeatRepo_ZombieDetected_AddsNoteAndResetsToOpen verifies that when
-// a tmux session is dead and the item is old enough, heartbeatRepo writes a
-// zombie note (containing session name, worker, and cataractae) and resets the
+// TestHeartbeatRepo_ExitNoOutcome_AddsNoteAndResetsToOpen verifies that when
+// a tmux session is dead and the item is old enough, heartbeatRepo writes an
+// exit-no-outcome note (containing session name, worker, and cataractae) and resets the
 // droplet to open for re-dispatch.
-func TestHeartbeatRepo_ZombieDetected_AddsNoteAndResetsToOpen(t *testing.T) {
+func TestHeartbeatRepo_ExitNoOutcome_AddsNoteAndResetsToOpen(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return false }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
 	client := newMockClient()
 	item := &cistern.Droplet{
-		ID:                "zombie-1",
+		ID:                "exit-1",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
 		Assignee:          "alpha",
@@ -453,7 +438,7 @@ func TestHeartbeatRepo_ZombieDetected_AddsNoteAndResetsToOpen(t *testing.T) {
 	defer client.mu.Unlock()
 
 	if len(client.attached) != 1 {
-		t.Fatalf("expected 1 zombie note, got %d", len(client.attached))
+		t.Fatalf("expected 1 exit note, got %d", len(client.attached))
 	}
 	note := client.attached[0]
 	if note.fromStep != "scheduler" {
@@ -462,25 +447,25 @@ func TestHeartbeatRepo_ZombieDetected_AddsNoteAndResetsToOpen(t *testing.T) {
 	// Note must mention session name, aqueduct worker, cataractae, and UTC timestamp.
 	for _, want := range []string{"test-repo-alpha", "alpha", "implement", time.Now().UTC().Format("2006-01-02")} {
 		if !strings.Contains(note.notes, want) {
-			t.Errorf("zombie note missing %q; got: %s", want, note.notes)
+			t.Errorf("exit note missing %q; got: %s", want, note.notes)
 		}
 	}
 	// Droplet must be reset to open for re-dispatch.
 	if got := client.items[item.ID].Status; got != "open" {
-		t.Errorf("droplet status after zombie reset = %q, want %q", got, "open")
+		t.Errorf("droplet status after exit reset = %q, want %q", got, "open")
 	}
 }
 
-// TestHeartbeatRepo_ZombieYoungSession_Skipped verifies that a droplet whose
+// TestHeartbeatRepo_ExitGuardYoungSession_Skipped verifies that a droplet whose
 // tmux session is dead but was dispatched very recently is skipped (age guard).
-func TestHeartbeatRepo_ZombieYoungSession_Skipped(t *testing.T) {
+func TestHeartbeatRepo_ExitGuardYoungSession_Skipped(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return false }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
 	client := newMockClient()
 	item := &cistern.Droplet{
-		ID:                "zombie-young",
+		ID:                "exit-young",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
 		Assignee:          "alpha",
@@ -496,10 +481,10 @@ func TestHeartbeatRepo_ZombieYoungSession_Skipped(t *testing.T) {
 	defer client.mu.Unlock()
 
 	if len(client.attached) != 0 {
-		t.Errorf("young zombie session should be skipped; got %d notes", len(client.attached))
+		t.Errorf("young session should be skipped by exit guard; got %d notes", len(client.attached))
 	}
 	if client.assignCalls != 0 {
-		t.Errorf("young zombie session should not trigger Assign; got %d calls", client.assignCalls)
+		t.Errorf("young session should not trigger Assign; got %d calls", client.assignCalls)
 	}
 }
 

--- a/internal/castellarius/production_gaps_test.go
+++ b/internal/castellarius/production_gaps_test.go
@@ -31,10 +31,6 @@ func TestHeartbeat_StallDetected_WhenNoSignals(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
-	// Mock agent as alive so the agent-dead zombie path is not triggered.
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
 
 	buf := &bytes.Buffer{}
 	client := newMockClient()
@@ -61,14 +57,11 @@ func TestHeartbeat_StallDetected_WhenNoSignals(t *testing.T) {
 // does not write a stall note when the agent's LastHeartbeatAt is within the
 // 45-minute default threshold.
 func TestHeartbeat_NoStallNote_WhenRecentHeartbeat(t *testing.T) {
-	// Mock tmux/agent as alive so zombie detection is bypassed and stall
+	// Mock tmux as alive so exit detection is bypassed and stall
 	// detection runs on the heartbeat timestamp.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
 
 	buf := &bytes.Buffer{}
 	client := newMockClient()
@@ -301,9 +294,6 @@ func TestHeartbeat_DB_NotStalled_WhenRecentHeartbeat(t *testing.T) {
 	origTmux := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = origTmux })
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	c, err := cistern.New(dbPath, "ts")
@@ -365,9 +355,6 @@ func TestHeartbeat_DB_Stalled_WhenNoHeartbeat(t *testing.T) {
 	origTmux := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = origTmux })
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	c, err := cistern.New(dbPath, "ts")

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/MichielDean/cistern/internal/aqueduct"
 	"github.com/MichielDean/cistern/internal/cistern"
-	"github.com/MichielDean/cistern/internal/proc"
+
 )
 
 const (
@@ -1196,9 +1196,9 @@ func (s *Castellarius) recoverInProgress() {
 	}
 }
 
-// heartbeatInProgress scans for orphaned in_progress droplets whose agent
-// sessions have died without writing an outcome. Resets them to open so the
-// main dispatch loop re-queues them on the next tick.
+// heartbeatInProgress scans for in_progress droplets whose agent sessions
+// have exited. If the agent wrote an outcome, the observe cycle handles it.
+// If not, the droplet is reset for re-dispatch.
 func (s *Castellarius) heartbeatInProgress(ctx context.Context) {
 	for _, repo := range s.config.Repos {
 		if ctx.Err() != nil {
@@ -1248,62 +1248,43 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 			continue
 		}
 
-		// Dead session detection: tmux dead or agent process dead.
-		// Reset to open for re-dispatch. The circuit breaker below
-		// will pool the droplet if it keeps dying.
-		zombieGuard := 4 * s.heartbeatInterval
+		// Session exit detection: when the agent finishes and exits, tmux
+		// destroys the session (remain-on-exit is off). A dead tmux session
+		// is the normal completion signal — check the DB for an outcome
+		// before deciding whether to reset for re-dispatch.
+		exitGuard := 4 * s.heartbeatInterval
 		if item.Assignee != "" {
 			sessionID := repo.Name + "-" + item.Assignee
 			dispatchedAt := item.StageDispatchedAt
 			if dispatchedAt.IsZero() {
 				dispatchedAt = item.UpdatedAt
 			}
-			if time.Since(dispatchedAt) < zombieGuard {
+			if time.Since(dispatchedAt) < exitGuard {
 				continue
 			}
 
-			dead := false
-			tmuxDead := false
 			if !isTmuxAlive(sessionID) {
-				dead = true
-				tmuxDead = true
-				s.logger.Info("heartbeat: tmux dead — resetting to open",
-					"repo", repo.Name, "droplet", item.ID,
-					"assignee", item.Assignee, "session_age", time.Since(dispatchedAt).Round(time.Second).String())
-			} else if !isAgentAlive(sessionID) {
-				dead = true
-				exec.Command("tmux", "kill-session", "-t", sessionID).Run()
-				s.logger.Info("heartbeat: agent dead — killing session, resetting to open",
-					"repo", repo.Name, "droplet", item.ID,
-					"assignee", item.Assignee, "session", sessionID)
-			}
-
-			if dead {
-				// Re-read the item from the DB before resetting. The agent may
-				// have called ct droplet pass/recirculate/pool between when we
-				// fetched the list and now. If an outcome exists, the observe
-				// cycle will handle it. Even if the outcome was already consumed
-				// by the observe cycle (which clears it via Assign), we can detect
-				// that by checking if the cataractae stage advanced — if so, the
-				// droplet has already moved on and we must not reset it.
+				// Re-read from DB. The agent may have written an outcome between
+				// the initial List fetch and now. If so, the observe cycle handles it.
 				fresh, err := client.Get(item.ID)
 				if err == nil {
 					if fresh.Outcome != "" {
-						s.logger.Info("heartbeat: dead session but outcome already written — skipping reset",
+						s.logger.Info("heartbeat: session exited with outcome — observe will process",
 							"repo", repo.Name, "droplet", item.ID, "outcome", fresh.Outcome)
 						continue
 					}
 					if fresh.CurrentCataractae != item.CurrentCataractae {
-						s.logger.Info("heartbeat: dead session but cataractae already advanced — skipping reset",
+						s.logger.Info("heartbeat: cataractae already advanced — observe already processed",
 							"repo", repo.Name, "droplet", item.ID,
 							"was", item.CurrentCataractae, "now", fresh.CurrentCataractae)
 						continue
 					}
 				}
 
+				// Session exited with no outcome — reset for re-dispatch.
 				step := currentCataracta(item, wf)
 				if step == nil {
-					s.logger.Error("heartbeat: no step for dead session — skipping",
+					s.logger.Error("heartbeat: no step for exited session — skipping",
 						"repo", repo.Name, "droplet", item.ID)
 					continue
 				}
@@ -1312,14 +1293,8 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 						pool.Release(w)
 					}
 				}
-				var noteMsg string
-				if tmuxDead {
-					noteMsg = fmt.Sprintf("[scheduler:zombie] Session %s died without outcome (worker=%s, cataractae=%s). [%s]",
-						sessionID, item.Assignee, step.Name, time.Now().UTC().Format(time.RFC3339))
-				} else {
-					noteMsg = fmt.Sprintf("Session killed. Re-dispatching (worker=%s, cataractae=%s). [%s]",
-						item.Assignee, step.Name, time.Now().UTC().Format(time.RFC3339))
-				}
+				noteMsg := fmt.Sprintf("[scheduler:exit-no-outcome] Session %s exited without outcome (worker=%s, cataractae=%s). [%s]",
+					sessionID, item.Assignee, step.Name, time.Now().UTC().Format(time.RFC3339))
 				s.addNote(client, item.ID, "scheduler", noteMsg)
 				if err := client.Assign(item.ID, "", step.Name); err != nil {
 					s.logger.Error("heartbeat: reset failed", "droplet", item.ID, "error", err)
@@ -1438,7 +1413,7 @@ func (s *Castellarius) circuitBreaker(repo aqueduct.RepoConfig, items []*cistern
 		dispatchCount := 0
 		for _, n := range notes {
 			if n.CataractaeName == "scheduler" &&
-				strings.Contains(n.Content, "Session died without outcome") &&
+				strings.Contains(n.Content, "Session exited without outcome") &&
 				n.CreatedAt.After(cutoff) {
 				dispatchCount++
 			}
@@ -1482,23 +1457,6 @@ var isTmuxAliveFn = func(sessionID string) bool {
 // isTmuxAlive returns true if a tmux session with the given name is running.
 func isTmuxAlive(sessionID string) bool {
 	return isTmuxAliveFn(sessionID)
-}
-
-// isAgentAliveFn returns true when a claude process is alive inside the tmux
-// session. It uses tmux display-message to find the pane root PID and then
-// walks /proc to find a claude descendant of that PID.
-// Injectable for testing without a real tmux server or process tree.
-var isAgentAliveFn = func(sessionID string) bool {
-	out, err := exec.Command("tmux", "display-message", "-p", "-t", sessionID, "#{pane_pid}").Output()
-	if err != nil {
-		return false
-	}
-	return proc.ClaudeAliveUnderPIDIn(strings.TrimSpace(string(out)), "/proc")
-}
-
-// isAgentAlive returns true when the tmux session contains a live claude process.
-func isAgentAlive(sessionID string) bool {
-	return isAgentAliveFn(sessionID)
 }
 
 // sandboxHead returns the current HEAD commit hash in the given directory.

--- a/internal/castellarius/scheduler_test.go
+++ b/internal/castellarius/scheduler_test.go
@@ -2243,16 +2243,12 @@ func TestHeartbeatRepo_StallThreshold_DefaultsTo45Minutes(t *testing.T) {
 // TestHeartbeatRepo_StallWithAssignee_WritesNoteNoRespawn verifies that when a
 // stall is detected and the droplet has an assignee, a stall note is written but
 // runner.Spawn is NOT called. Stall detection no longer auto-respawns: agents
-// emitting heartbeats are alive, and dead agents are handled by zombie detection.
+// emitting heartbeats are alive, and dead agents are handled by exit detection.
 func TestHeartbeatRepo_StallWithAssignee_WritesNoteNoRespawn(t *testing.T) {
 	// Mock tmux as alive so liveness check passes through to stall detector.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
-	// Mock agent as alive so the agent-dead zombie path is not triggered.
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
 
 	client := newMockClient()
 	runner := newMockRunner(client)
@@ -2422,13 +2418,11 @@ func TestHeartbeatRepo_OrphanRecovery_AssignFailure_ClearsDebounce(t *testing.T)
 // actively emitting heartbeats (heartbeat < threshold) is not considered stalled,
 // even if it has been running for a long time without commits or an outcome.
 func TestHeartbeatRepo_AgentEmittingHeartbeat_NotStalled(t *testing.T) {
-	// Mock tmux/agent as alive to avoid zombie detection path.
+	// Mock tmux as alive so exit detection is bypassed and stall
+	// detection runs on the heartbeat timestamp.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
 
 	client := newMockClient()
 	runner := newMockRunner(client)
@@ -2468,13 +2462,10 @@ func TestHeartbeatRepo_AgentEmittingHeartbeat_NotStalled(t *testing.T) {
 // that has not emitted a heartbeat for longer than the stall threshold is
 // detected as stalled and an escalation note is written. No auto-respawn occurs.
 func TestHeartbeatRepo_AgentNotEmittingHeartbeat_Stalled(t *testing.T) {
-	// Mock tmux/agent as alive to avoid zombie detection path.
+	// Mock tmux as alive to avoid exit detection path.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
 
 	client := newMockClient()
 	runner := newMockRunner(nil) // nil client: Spawn must not be called
@@ -2509,7 +2500,7 @@ func TestHeartbeatRepo_AgentNotEmittingHeartbeat_Stalled(t *testing.T) {
 		t.Errorf("stall note missing heartbeat field; got: %s", client.attached[0].notes)
 	}
 
-	// No auto-respawn — stall detection does not respawn; that is zombie detection's job.
+	// No auto-respawn — stall detection does not respawn; that is exit detection's job.
 	runner.mu.Lock()
 	calls := runner.calls
 	runner.mu.Unlock()
@@ -2518,11 +2509,11 @@ func TestHeartbeatRepo_AgentNotEmittingHeartbeat_Stalled(t *testing.T) {
 	}
 }
 
-// --- heartbeat zombie detection tests ---
+// --- heartbeat exit detection tests ---
 
 // TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet verifies that when the
-// tmux session is dead the droplet is reset to open for re-dispatch and a zombie
-// note is written.
+// tmux session is dead the droplet is reset to open for re-dispatch and an
+// exit-no-outcome note is written.
 func TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet(t *testing.T) {
 	// Ensure tmux appears dead for our test session.
 	orig := isTmuxAliveFn
@@ -2532,7 +2523,7 @@ func TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet(t *testing.T) {
 	client := newMockClient()
 
 	item := &cistern.Droplet{
-		ID:                "zombie-tmuxdead",
+		ID:                "exit-tmuxdead",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
 		Assignee:          "alpha",
@@ -2550,11 +2541,11 @@ func TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet(t *testing.T) {
 
 	// Note must have been written.
 	if len(client.attached) != 1 {
-		t.Fatalf("expected 1 zombie note, got %d", len(client.attached))
+		t.Fatalf("expected 1 exit note, got %d", len(client.attached))
 	}
 	note := client.attached[0].notes
-	if !strings.Contains(note, "[scheduler:zombie]") {
-		t.Errorf("zombie note missing [scheduler:zombie] prefix; got: %s", note)
+	if !strings.Contains(note, "[scheduler:exit-no-outcome]") {
+		t.Errorf("exit note missing [scheduler:exit-no-outcome] prefix; got: %s", note)
 	}
 
 	// Droplet must have been reset to open for re-dispatch.
@@ -2563,373 +2554,6 @@ func TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet(t *testing.T) {
 	}
 	if item.Assignee != "" {
 		t.Errorf("item assignee = %q, want empty after reset", item.Assignee)
-	}
-}
-
-// TestHeartbeatRepo_TmuxAliveAgentDead_WritesNoteKillsSessionAndResetsDroplet
-// verifies the path: tmux session alive but agent process has exited.
-// The heartbeat must kill the session, write a diagnostic note, and reset
-// the droplet to open for re-dispatch.
-func TestHeartbeatRepo_TmuxAliveAgentDead_WritesNoteKillsSessionAndResetsDroplet(t *testing.T) {
-	orig := isTmuxAliveFn
-	isTmuxAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isTmuxAliveFn = orig })
-
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return false } // shell-only pane
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
-
-	client := newMockClient()
-
-	item := &cistern.Droplet{
-		ID:                "zombie-agentdead",
-		CurrentCataractae: "implement",
-		Status:            "in_progress",
-		Assignee:          "alpha",
-	}
-	client.items[item.ID] = item
-
-	config := testConfig()
-	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
-	clients := map[string]CisternClient{"test-repo": client}
-	runner := newMockRunner(client)
-	sched := NewFromParts(config, workflows, clients, runner)
-
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
-
-	// Note must have been written with the expected diagnostic text.
-	if len(client.attached) != 1 {
-		t.Fatalf("expected 1 note, got %d", len(client.attached))
-	}
-	note := client.attached[0].notes
-	if !strings.Contains(note, "Session killed") {
-		t.Errorf("note missing 'Session killed'; got: %s", note)
-	}
-	if !strings.Contains(note, "Re-dispatching") {
-		t.Errorf("note missing 'Re-dispatching'; got: %s", note)
-	}
-
-	// Droplet must have been reset to open for re-dispatch.
-	if item.Status != "open" {
-		t.Errorf("item status = %q, want open", item.Status)
-	}
-	if item.Assignee != "" {
-		t.Errorf("item assignee = %q, want empty after reset", item.Assignee)
-	}
-}
-
-// TestHeartbeatRepo_TmuxAliveAgentDead_RecentDispatch_SkipsZombieHandling verifies
-// that the minimum age guard prevents false-positive zombie kills during the
-// startup window when tmux is alive but the agent process has not yet been forked.
-func TestHeartbeatRepo_TmuxAliveAgentDead_RecentDispatch_SkipsZombieHandling(t *testing.T) {
-	orig := isTmuxAliveFn
-	isTmuxAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isTmuxAliveFn = orig })
-
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return false } // agent not yet forked
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
-
-	client := newMockClient()
-
-	item := &cistern.Droplet{
-		ID:                "zombie-agentdead-recent",
-		CurrentCataractae: "implement",
-		Status:            "in_progress",
-		Assignee:          "alpha",
-		StageDispatchedAt: time.Now(), // just dispatched — within zombieGuard
-	}
-	client.items[item.ID] = item
-
-	config := testConfig()
-	config.StallThresholdMinutes = 60 // high threshold — not stalled
-	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
-	clients := map[string]CisternClient{"test-repo": client}
-	runner := newMockRunner(client)
-	sched := NewFromParts(config, workflows, clients, runner)
-
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
-
-	if len(client.attached) != 0 {
-		t.Errorf("expected no notes written for recently-dispatched session, got %d", len(client.attached))
-	}
-	if item.Status != "in_progress" {
-		t.Errorf("item status = %q, want in_progress", item.Status)
-	}
-	if item.Assignee != "alpha" {
-		t.Errorf("item assignee = %q, want alpha", item.Assignee)
-	}
-}
-
-// TestHeartbeatRepo_TmuxAliveAgentAlive_SkipsZombieHandling verifies that when
-// both tmux and the claude process are alive no zombie action is taken.
-func TestHeartbeatRepo_TmuxAliveAgentAlive_SkipsZombieHandling(t *testing.T) {
-	orig := isTmuxAliveFn
-	isTmuxAliveFn = func(_ string) bool { return true }
-	t.Cleanup(func() { isTmuxAliveFn = orig })
-
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool { return true } // live claude process
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
-
-	client := newMockClient()
-
-	item := &cistern.Droplet{
-		ID:                "agent-alive",
-		CurrentCataractae: "implement",
-		Status:            "in_progress",
-		Assignee:          "alpha",
-	}
-	client.items[item.ID] = item
-
-	config := testConfig()
-	config.StallThresholdMinutes = 60 // high threshold — not stalled
-	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
-	clients := map[string]CisternClient{"test-repo": client}
-	runner := newMockRunner(client)
-	sched := NewFromParts(config, workflows, clients, runner)
-
-	// Provide a recent heartbeat so stall detection does not fire.
-	item.LastHeartbeatAt = time.Now().Add(-30 * time.Second)
-
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
-
-	if len(client.attached) != 0 {
-		t.Errorf("expected no notes written for live agent, got %d", len(client.attached))
-	}
-	if item.Status != "in_progress" {
-		t.Errorf("item status = %q, want in_progress", item.Status)
-	}
-}
-
-// TestHeartbeatRepo_TmuxAliveAgentDead_NoAssignee_SkipsZombieCheck verifies that
-// when the droplet has no assignee the agent-dead check is not attempted.
-func TestHeartbeatRepo_TmuxAliveAgentDead_NoAssignee_SkipsZombieCheck(t *testing.T) {
-	var agentCheckCalled bool
-	origAgent := isAgentAliveFn
-	isAgentAliveFn = func(_ string) bool {
-		agentCheckCalled = true
-		return false
-	}
-	t.Cleanup(func() { isAgentAliveFn = origAgent })
-
-	client := newMockClient()
-
-	item := &cistern.Droplet{
-		ID:                "no-assignee",
-		CurrentCataractae: "implement",
-		Status:            "in_progress",
-		Assignee:          "", // no assignee — zombie checks should be skipped
-	}
-	client.items[item.ID] = item
-
-	config := testConfig()
-	config.StallThresholdMinutes = 60
-	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
-	clients := map[string]CisternClient{"test-repo": client}
-	runner := newMockRunner(client)
-	sched := NewFromParts(config, workflows, clients, runner)
-
-	// Provide a recent heartbeat so stall detection does not fire.
-	item.LastHeartbeatAt = time.Now().Add(-30 * time.Second)
-
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
-
-	if agentCheckCalled {
-		t.Error("isAgentAliveFn should not be called when droplet has no assignee")
-	}
-}
-
-// TestHeartbeatRepo_FastCompletingStage_StageDispatchedAtRecent_NotZombie verifies
-// acceptance criterion (a): a stage dispatched recently (StageDispatchedAt within
-// zombieGuard) is never declared a zombie, even if UpdatedAt is stale and the tmux
-// session is dead. This models the ci-y89g2 failure: a stage that completes in <2min
-// has its tmux session exit naturally; the dispatch timestamp guards against a false
-// positive regardless of when other updates touched the droplet.
-func TestHeartbeatRepo_FastCompletingStage_StageDispatchedAtRecent_NotZombie(t *testing.T) {
-	orig := isTmuxAliveFn
-	isTmuxAliveFn = func(_ string) bool { return false } // session already exited
-	t.Cleanup(func() { isTmuxAliveFn = orig })
-
-	client := newMockClient()
-
-	item := &cistern.Droplet{
-		ID:                "fast-complete",
-		CurrentCataractae: "implement",
-		Status:            "in_progress",
-		Assignee:          "alpha",
-		// StageDispatchedAt is recent — stage just started.
-		StageDispatchedAt: time.Now(),
-		// UpdatedAt is old (e.g. bumped by a prior note) — would fail the old guard.
-		UpdatedAt: time.Now().Add(-10 * time.Minute),
-	}
-	client.items[item.ID] = item
-
-	config := testConfig()
-	config.StallThresholdMinutes = 60
-	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
-	clients := map[string]CisternClient{"test-repo": client}
-	runner := newMockRunner(client)
-	sched := NewFromParts(config, workflows, clients, runner)
-
-	// Add a recent note so stall detection does not fire.
-	client.notes[item.ID] = []cistern.CataractaeNote{
-		{CreatedAt: time.Now()},
-	}
-
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
-
-	// Age guard (StageDispatchedAt is recent) must suppress zombie reset.
-	if item.Status != "in_progress" {
-		t.Errorf("item status = %q, want in_progress — fast stage must not be declared zombie", item.Status)
-	}
-	if item.Assignee != "alpha" {
-		t.Errorf("item assignee = %q, want alpha — fast stage must not be reset", item.Assignee)
-	}
-	if len(client.attached) != 0 {
-		t.Errorf("expected no zombie notes for fast-completing stage, got %d: %v",
-			len(client.attached), client.attached)
-	}
-}
-
-// TestHeartbeatRepo_GenuineZombie_StageDispatchedAtOld_Detected verifies
-// acceptance criterion (b): a session with a stale StageDispatchedAt, no outcome,
-// and a dead tmux session IS correctly identified as a zombie and reset.
-// UpdatedAt is kept recent here to confirm the guard uses StageDispatchedAt, not UpdatedAt.
-func TestHeartbeatRepo_GenuineZombie_StageDispatchedAtOld_Detected(t *testing.T) {
-	orig := isTmuxAliveFn
-	isTmuxAliveFn = func(_ string) bool { return false } // session dead
-	t.Cleanup(func() { isTmuxAliveFn = orig })
-
-	client := newMockClient()
-
-	item := &cistern.Droplet{
-		ID:                "genuine-zombie",
-		CurrentCataractae: "implement",
-		Status:            "in_progress",
-		Assignee:          "alpha",
-		Outcome:           "", // no outcome recorded — not a completed stage
-		// StageDispatchedAt is old — dispatch happened long ago.
-		StageDispatchedAt: time.Now().Add(-10 * time.Minute),
-		// UpdatedAt is recent — would suppress detection with the old UpdatedAt guard.
-		UpdatedAt: time.Now(),
-	}
-	client.items[item.ID] = item
-
-	config := testConfig()
-	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
-	clients := map[string]CisternClient{"test-repo": client}
-	runner := newMockRunner(client)
-	sched := NewFromParts(config, workflows, clients, runner)
-
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
-
-	// StageDispatchedAt is old → zombie guard fires → droplet must be reset to open.
-	if item.Status != "open" {
-		t.Errorf("item status = %q, want open — genuine zombie must be reset", item.Status)
-	}
-	if item.Assignee != "" {
-		t.Errorf("item assignee = %q, want empty — genuine zombie must be reset", item.Assignee)
-	}
-	if len(client.attached) != 1 {
-		t.Fatalf("expected 1 zombie note, got %d", len(client.attached))
-	}
-	if !strings.Contains(client.attached[0].notes, "zombie") {
-		t.Errorf("zombie note missing 'zombie'; got: %s", client.attached[0].notes)
-	}
-}
-
-// TestHeartbeatRepo_UpdatedAtFallback_StaleUpdatedAt_ZombieFires verifies the
-// migration fallback branch: when StageDispatchedAt is
-// zero (pre-migration droplet) and UpdatedAt is older than zombieGuard, the
-// droplet is treated as a zombie and pooled.
-func TestHeartbeatRepo_UpdatedAtFallback_StaleUpdatedAt_ZombieFires(t *testing.T) {
-	orig := isTmuxAliveFn
-	isTmuxAliveFn = func(_ string) bool { return false }
-	t.Cleanup(func() { isTmuxAliveFn = orig })
-
-	client := newMockClient()
-
-	item := &cistern.Droplet{
-		ID:                "fallback-stale",
-		CurrentCataractae: "implement",
-		Status:            "in_progress",
-		Assignee:          "alpha",
-		Outcome:           "",
-		StageDispatchedAt: time.Time{},                  // zero — pre-migration droplet
-		UpdatedAt:         time.Now().Add(-10 * time.Minute), // stale — older than zombieGuard
-	}
-	client.items[item.ID] = item
-
-	config := testConfig()
-	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
-	clients := map[string]CisternClient{"test-repo": client}
-	runner := newMockRunner(client)
-	sched := NewFromParts(config, workflows, clients, runner)
-
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
-
-	// UpdatedAt fallback: stale UpdatedAt → zombie fires → droplet must be reset to open.
-	if item.Status != "open" {
-		t.Errorf("item status = %q, want open — stale UpdatedAt fallback must trigger zombie reset", item.Status)
-	}
-	if item.Assignee != "" {
-		t.Errorf("item assignee = %q, want empty — zombie must clear assignee", item.Assignee)
-	}
-	if len(client.attached) != 1 {
-		t.Fatalf("expected 1 zombie note, got %d", len(client.attached))
-	}
-	if !strings.Contains(client.attached[0].notes, "zombie") {
-		t.Errorf("zombie note missing 'zombie'; got: %s", client.attached[0].notes)
-	}
-}
-
-// TestHeartbeatRepo_UpdatedAtFallback_RecentUpdatedAt_ZombieSuppressed verifies the
-// migration fallback branch: when StageDispatchedAt is
-// zero (pre-migration droplet) and UpdatedAt is recent (within zombieGuard), the
-// droplet is NOT declared a zombie — the age guard suppresses the pool.
-func TestHeartbeatRepo_UpdatedAtFallback_RecentUpdatedAt_ZombieSuppressed(t *testing.T) {
-	orig := isTmuxAliveFn
-	isTmuxAliveFn = func(_ string) bool { return false }
-	t.Cleanup(func() { isTmuxAliveFn = orig })
-
-	client := newMockClient()
-
-	item := &cistern.Droplet{
-		ID:                "fallback-recent",
-		CurrentCataractae: "implement",
-		Status:            "in_progress",
-		Assignee:          "alpha",
-		Outcome:           "",
-		StageDispatchedAt: time.Time{},  // zero — pre-migration droplet
-		UpdatedAt:         time.Now(),   // recent — within zombieGuard
-	}
-	client.items[item.ID] = item
-
-	config := testConfig()
-	config.StallThresholdMinutes = 60
-	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
-	clients := map[string]CisternClient{"test-repo": client}
-	runner := newMockRunner(client)
-	sched := NewFromParts(config, workflows, clients, runner)
-
-	// Add a recent note so stall detection does not fire.
-	client.notes[item.ID] = []cistern.CataractaeNote{
-		{CreatedAt: time.Now()},
-	}
-
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
-
-	// UpdatedAt fallback: recent UpdatedAt → age guard suppresses zombie reset.
-	if item.Status != "in_progress" {
-		t.Errorf("item status = %q, want in_progress — recent UpdatedAt fallback must suppress zombie", item.Status)
-	}
-	if item.Assignee != "alpha" {
-		t.Errorf("item assignee = %q, want alpha — age guard must not reset assignee", item.Assignee)
-	}
-	if len(client.attached) != 0 {
-		t.Errorf("expected no zombie notes for recent UpdatedAt fallback, got %d: %v",
-			len(client.attached), client.attached)
 	}
 }
 

--- a/internal/cataractae/context.go
+++ b/internal/cataractae/context.go
@@ -291,7 +291,7 @@ func writeContextFile(path string, p ContextParams) error {
 	// Partition notes in one pass:
 	//   ownNotes       — same cataractae only (avoids anchoring on unrelated stages)
 	//   manualNotes    — operator annotations via `ct droplet note` (never step-filtered)
-	//   schedulerNotes — scheduler system notes (zombie detection, timeouts, etc.)
+	//   schedulerNotes — scheduler system notes (exit detection, timeouts, etc.)
 	var ownNotes, manualNotes, schedulerNotes []cistern.CataractaeNote
 	for _, n := range p.Notes {
 		switch n.CataractaeName {

--- a/internal/cataractae/context_test.go
+++ b/internal/cataractae/context_test.go
@@ -272,7 +272,7 @@ func TestWriteContextFile_SchedulerNotes_ShownSeparately(t *testing.T) {
 	step := &aqueduct.WorkflowCataractae{Name: "implement", Type: "agent"}
 
 	notes := []cistern.CataractaeNote{
-		{CataractaeName: "scheduler", Content: "scheduler: zombie detected, recirculating"},
+		{CataractaeName: "scheduler", Content: "[scheduler:exit-no-outcome]"},
 		{CataractaeName: "implement", Content: "implement note A"},
 		{CataractaeName: "deliver", Content: "deliver note X"},
 		{CataractaeName: "scheduler", Content: "scheduler: timeout notice"},
@@ -302,7 +302,7 @@ func TestWriteContextFile_SchedulerNotes_ShownSeparately(t *testing.T) {
 		t.Fatal("'## Scheduler Notes' section not found — scheduler notes would be invisible (regression: ci-tgj96)")
 	}
 	schedulerSection := got[schedulerIdx:]
-	if !strings.Contains(schedulerSection, "scheduler: zombie detected, recirculating") {
+	if !strings.Contains(schedulerSection, "[scheduler:exit-no-outcome]") {
 		t.Error("expected first scheduler note in '## Scheduler Notes' section")
 	}
 	if !strings.Contains(schedulerSection, "scheduler: timeout notice") {

--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -59,10 +59,10 @@ func (s *Session) Spawn() error {
 }
 
 // spawn creates a new tmux session running the agent fresh. With exec prefix,
-// if the session is alive, the agent IS alive — no zombie state is possible.
+// if the session is alive, the agent IS alive — no stale session is possible.
 func (s *Session) spawn() error {
 	// With exec prefix, if the session is alive the agent is alive.
-	// No zombie detection needed — return nil and let the existing session continue.
+	// No exit detection needed — return nil and let the existing session continue.
 	if isSessionAlive(s.ID) {
 		slog.Default().Info("session: already running — skipping respawn",
 			"session", s.ID)
@@ -458,7 +458,7 @@ Never manipulate droplet state by any means other than ct droplet pass/recircula
 Never exit without signaling — a stranded droplet burns resources indefinitely.
 
 **2. Session spawning must expose the agent process directly to tmux.**
-Do not wrap the agent command in a shell (bash -c, sh -c, pipes, tee) unless you have explicitly verified that pane_current_command and /proc/<pid>/cmdline still correctly identify the agent. Wrappers that change what the process monitor sees will cause every healthy session to be classified as zombie and respawned in a loop.
+Do not wrap the agent command in a shell (bash -c, sh -c, pipes, tee) unless you have explicitly verified that pane_current_command and /proc/<pid>/cmdline still correctly identify the agent. Wrappers that change what the process monitor sees will cause every healthy session to be misclassified as exited without outcome and respawned in a loop.
 
 **3. CONTEXT.md is pipeline state — never commit it.**
 CONTEXT.md is injected at dispatch time and listed in .gitignore. If you see it in a git add or git commit, stop. Committing it causes merge conflicts across concurrent deliveries and corrupts origin/main.
@@ -570,13 +570,6 @@ func (s *Session) resolveIdentityDir() string {
 // Delegates to resolveIdentityDir for location resolution.
 func (s *Session) resolveIdentityPath() string {
 	return filepath.Join(s.resolveIdentityDir(), s.Preset.InstrFile())
-}
-
-// kill terminates the tmux session. Errors are silently ignored since the
-// session may already be dead. Only called for confirmed zombie sessions;
-// healthy sessions are left running (see spawn guard above).
-func (s *Session) kill() {
-	exec.Command("tmux", "kill-session", "-t", s.ID).Run() //nolint:errcheck
 }
 
 // isAlive checks whether the tmux session still exists.

--- a/internal/cataractae/session_test.go
+++ b/internal/cataractae/session_test.go
@@ -415,7 +415,7 @@ func TestFakeagent_SpawnOutcomeCycle(t *testing.T) {
 	if err := s.Spawn(); err != nil {
 		t.Fatalf("Spawn: %v", err)
 	}
-	t.Cleanup(func() { s.kill() })
+	t.Cleanup(func() { exec.Command("tmux", "kill-session", "-t", s.ID).Run() })
 
 	// Wait for the session to die (fakeagent exits after calling ct droplet pass).
 	deadline := time.Now().Add(15 * time.Second)
@@ -933,7 +933,7 @@ func TestSpawn_LogsFreshSession_WhenNoTmux(t *testing.T) {
 	}
 	// Spawn may fail (fake agent) — we only care about log output.
 	_ = s.spawn()
-	defer s.kill()
+	defer func() { exec.Command("tmux", "kill-session", "-t", s.ID).Run() }()
 
 	out := buf.String()
 	if !strings.Contains(out, "session=test-fresh-session") {

--- a/internal/cistern/client.go
+++ b/internal/cistern/client.go
@@ -64,7 +64,7 @@ type Droplet struct {
 	// StageDispatchedAt is set only when a worker is assigned to this droplet
 	// (Assign(id, worker, step) with non-empty worker). Unlike UpdatedAt, it is
 	// not bumped by notes, outcome signals, or other state changes — making it
-	// the reliable anchor for the zombie detection age guard.
+	// the reliable anchor for the exit detection age guard.
 	StageDispatchedAt time.Time `json:"stage_dispatched_at,omitempty"`
 }
 

--- a/skills/cistern/references/troubleshooting.md
+++ b/skills/cistern/references/troubleshooting.md
@@ -198,7 +198,7 @@ or, if no heartbeat has been emitted:
 **Rate-limiting:** To prevent log spam from long-stalled droplets, the scheduler writes at most one stall note per hour for the same droplet. If a droplet remains stalled beyond the first detection, no new note is written until 60 minutes have passed since the last note (or until the heartbeat advances, which resets the window).
 
 **What to do when you see stall notes:**
-1. Check the `heartbeat` field: if it shows `none`, the agent never emitted a heartbeat — it likely died before starting work. Check zombie detection logs and consider restarting: `ct droplet restart <id>`
+1. Check the `heartbeat` field: if it shows `none`, the agent never emitted a heartbeat — it likely died before starting work. Check exit detection logs and consider restarting: `ct droplet restart <id>`
 2. If `heartbeat` shows a timestamp, the agent was alive at that point. Check if the agent session is still running: `ct droplet peek <id>` (shows live session output)
 3. A stall note does **not** trigger an automatic respawn — the agent may simply be slow (e.g., waiting on an LLM response). Monitor before acting.
 4. If the droplet can proceed, restart it: `ct droplet restart <id>`
@@ -224,22 +224,20 @@ If the provider remains degraded, investigate:
 - Is authentication stale? Run `ct doctor --fix` to refresh tokens
 - Rate limiting? Reduce concurrent aqueducts or add delays in cataractae timeouts
 
-### Droplet Reset With "Session Zombie" Note
+### Droplet Reset With "Session Exited Without Outcome" Note
 
-If you see a droplet note like: `"Session zombie detected: tmux alive but claude process dead. Session killed. Re-dispatching. [<timestamp>]"`, the Castellarius detected and recovered an agent that exited without signaling an outcome.
+If you see a droplet note like: `"[scheduler:exit-no-outcome] Session <id> exited without outcome (worker=<name>, cataractae=<step>). [<timestamp>]"`, the Castellarius detected that an agent session exited without signaling an outcome.
 
 **What this means:**
-- The tmux session was still alive (server running, pane responsive)
-- But the claude agent process inside had exited (OOM kill, hard token limit, non-zero exit, or crash)
-- The agent never called `ct droplet pass/block/recirculate` before exiting
-- The Castellarius heartbeat detected this condition and automatically recovered it
+- The agent's tmux session is gone (agent finished and exited, or crashed)
+- The agent never called `ct droplet pass/recirculate/pool` before exiting
+- The Castellarius heartbeat detected this and checked the DB — no outcome was written, and the cataractae stage hadn't advanced — so it reset the droplet for re-dispatch
 
 **Expected behavior:**
 1. The note is added to the droplet history
-2. The session is killed (`tmux kill-session`)
-3. The aqueduct pool slot is released
-4. The droplet is reset to `open` status at the current cataractae
-5. It will be re-dispatched on the next cycle
+2. The aqueduct pool slot is released
+3. The droplet is reset to `open` status at the current cataractae
+4. It will be re-dispatched on the next cycle
 
 **Diagnosis (optional — automatic recovery handles this):**
 If you want to understand why the agent exited:
@@ -256,11 +254,11 @@ journalctl --user -u cistern-castellarius --since "1h ago" | grep <id>  # Check 
 - Look for patterns (e.g., always fails at the same percentage of work) that suggest a hard limit
 
 **Recovery action:**
-No action is needed — the droplet will be re-dispatched automatically. If it keeps hitting the same limit, file a bug to increase resources or optimize the agent implementation.
+No action is needed — the droplet will be re-dispatched automatically. If it keeps hitting the same limit, pool it with `ct droplet pool <id> --notes "..."` and investigate.
 
 ### Droplet Pooled With "Spawn-Cycle Limit" Note
 
-If you see a droplet note like: `"spawn-cycle limit: 5 spawns in window with no outcome recorded"`, the Castellarius detected a droplet that spawned multiple times in succession without signaling an outcome. This is an automatic circuit breaker for zombie loops.
+If you see a droplet note like: `"spawn-cycle limit: 5 spawns in window with no outcome recorded"`, the Castellarius detected a droplet that spawned multiple times in succession without signaling an outcome. This is an automatic circuit breaker for repeated exits without outcome.
 
 **What this means:**
 - The droplet was dispatched and spawned successfully 5 times within a 10-minute window


### PR DESCRIPTION
## Summary

The heartbeat treated every dead tmux session as a "zombie" that needed
resetting. In reality, when an agent finishes its work it calls
`ct droplet pass/recirculate/pool` and exits — the tmux session dies
naturally. The heartbeat then saw the dead session and reset the droplet,
even though the outcome was already written or already processed by the
observe cycle.

This caused spurious `[scheduler:zombie]` notes on every stage transition
where the agent finished work and exited before the heartbeat's next scan.

## Root cause

With `remain-on-exit off` (the explicit setting), tmux destroys the
session when the process exits. The heartbeat's 30s scan would find the
dead session and declare a "zombie" — even though the agent had already
called `ct droplet pass` and the observe cycle had already advanced the
droplet to the next stage.

## Changes

- **Heartbeat checks DB before resetting**: Re-reads the droplet from DB.
  If an outcome exists, the observe cycle will handle it. If the
  cataractae stage has already advanced, observe already handled it.
- **Removes `isAgentAlive` entirely**: With `remain-on-exit off`, tmux
  death IS the exit signal. No need to walk `/proc` for agent PIDs.
- **Removes `Session.kill()`**: No code path kills sessions anymore.
- **Removes `proc` package dependency** from scheduler.
- **Renames "zombie" terminology throughout**:
  `zombieGuard` → `exitGuard`, `[scheduler:zombie]` →
  `[scheduler:exit-no-outcome]`, "Session died" → "Session exited",
  zombie detection → exit detection.
- **Simplifies heartbeat logic**: tmux alive = agent working, tmux dead =
  check DB then decide. No intermediate process-walking check.
- **Net -455 lines**: Removed dead code paths, simplified test fixtures.

## Testing

All 11 packages pass. Production monitoring of ci-asqg6 (previous PR)
showed the cataractae-advancement check preventing spurious resets on
stage transitions.