### PR TITLE
feat: event-driven outcome notification — agents signal castellarius via SIGUSR1

### DIFF
--- a/cmd/ct/castellarius.go
+++ b/cmd/ct/castellarius.go
@@ -110,6 +110,18 @@ keep dispatching droplets into aqueducts automatically.`,
 		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 		defer cancel()
 
+		// SIGUSR1 triggers an immediate tick when an agent signals an outcome.
+		// The Castellarius processes the outcome on the next tick, which normally
+		// takes 10s, but SIGUSR1 causes it to run immediately.
+		sigusr1Ch := make(chan os.Signal, 1)
+		signal.Notify(sigusr1Ch, syscall.SIGUSR1)
+		defer signal.Stop(sigusr1Ch)
+		go func() {
+			for range sigusr1Ch {
+				sched.NotifyOutcome()
+			}
+		}()
+
 		// Tmux keepalive: ensure the tmux server stays running for the lifetime of
 		// the Castellarius. If the server dies (socket cleaned up, idle timeout, etc.)
 		// all subsequent session spawns fail silently. We maintain a dedicated

--- a/cmd/ct/cistern.go
+++ b/cmd/ct/cistern.go
@@ -727,6 +727,7 @@ var dropletPoolCmd = &cobra.Command{
 		if err := c.SetOutcome(args[0], "pool"); err != nil {
 			return err
 		}
+		notifyCastellarius()
 		// When not in_progress, Castellarius will never observe this droplet.
 		// Directly pool so the reason is recorded in events with a non-empty payload.
 		if item.Status != "in_progress" {
@@ -1028,6 +1029,7 @@ var dropletPassCmd = &cobra.Command{
 		if err := c.SetOutcome(args[0], "pass"); err != nil {
 			return err
 		}
+		notifyCastellarius()
 		fmt.Printf("droplet %s: outcome=pass\n", args[0])
 		return nil
 	},
@@ -1087,6 +1089,7 @@ var dropletRecirculateCmd = &cobra.Command{
 		if err := c.SetOutcome(args[0], outcome); err != nil {
 			return err
 		}
+		notifyCastellarius()
 		fmt.Printf("droplet %s: outcome=%s\n", args[0], outcome)
 		return nil
 	},

--- a/cmd/ct/notify.go
+++ b/cmd/ct/notify.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// notifyCastellarius reads the castellarius PID from its health file and sends
+// SIGUSR1 to trigger an immediate observe+dispatch tick. This is called after
+// ct droplet pass/recirculate/pool writes an outcome so the castellarius
+// processes it immediately instead of waiting for the next poll cycle.
+func notifyCastellarius() {
+	dbPath := resolveDBPath()
+	dbDir := filepath.Dir(dbPath)
+	hPath := filepath.Join(dbDir, "castellarius.health")
+
+	data, err := os.ReadFile(hPath)
+	if err != nil {
+		return
+	}
+
+	var hf struct {
+		PID int `json:"pid"`
+	}
+	if err := json.Unmarshal(data, &hf); err != nil || hf.PID == 0 {
+		return
+	}
+
+	proc, err := os.FindProcess(hf.PID)
+	if err != nil {
+		return
+	}
+
+	if err := proc.Signal(syscall.SIGUSR1); err != nil {
+		fmt.Fprintf(os.Stderr, "ct: notify castellarius (pid %d): %v\n", hf.PID, err)
+	}
+}

--- a/internal/castellarius/health.go
+++ b/internal/castellarius/health.go
@@ -13,6 +13,7 @@ type HealthFile struct {
 	PollIntervalSec  int        `json:"pollIntervalSec"`
 	DroughtRunning   bool       `json:"droughtRunning"`
 	DroughtStartedAt *time.Time `json:"droughtStartedAt"`
+	PID              int        `json:"pid"`
 }
 
 // writeHealthFile atomically writes the health file to
@@ -33,6 +34,7 @@ func (s *Castellarius) writeHealthFile() {
 		PollIntervalSec:  int(s.pollInterval.Seconds()),
 		DroughtRunning:   s.droughtRunning.Load(),
 		DroughtStartedAt: s.droughtStartedAt.Load(),
+		PID:              os.Getpid(),
 	}
 
 	b, err := json.Marshal(data)

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -109,6 +109,7 @@ type Castellarius struct {
 	startupCfgMtime    time.Time     // mtime of cistern.yaml at startup; used to detect updates
 	supervised         bool          // true if managed by systemd/supervisord/etc.
 	reloadCh           chan struct{} // signals Tick() to hot-reload workflows from disk
+	outcomeCh          chan struct{} // signals immediate tick when an agent writes an outcome
 
 	// drainTimeout is the maximum duration to wait for in-flight sessions to
 	// signal an outcome after SIGTERM. Defaults to 5 minutes.
@@ -207,6 +208,7 @@ func New(config aqueduct.AqueductConfig, dbPath string, runner CataractaeRunner,
 		startupBinaryMtime:     startupBinaryMtime,
 		supervised:             isSupervisedProcess(),
 		reloadCh:               make(chan struct{}, 1),
+		outcomeCh:              make(chan struct{}, 1),
 	}
 	for _, o := range opts {
 		o(s)
@@ -342,6 +344,18 @@ func defaultAqueductNames(n int) []string {
 	return names
 }
 
+// NotifyOutcome signals the Castellarius that an agent has written an outcome
+// to the DB. This triggers an immediate tick (observe + dispatch) so outcomes
+// are processed without waiting for the next poll cycle. Called by ct droplet
+// pass/recirculate/pool after writing the outcome, and by SIGUSR1 handler.
+func (s *Castellarius) NotifyOutcome() {
+	select {
+	case s.outcomeCh <- struct{}{}:
+	default:
+		// Channel full — a tick is already scheduled, no need to queue another.
+	}
+}
+
 // Run starts the scheduler loop. It blocks until ctx is cancelled.
 func (s *Castellarius) Run(ctx context.Context) error {
 	supervisorStatus := "unsupervised (manual restart required for binary updates)"
@@ -420,6 +434,9 @@ func (s *Castellarius) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return s.drainInFlight()
 		case <-ticker.C:
+			s.tick(ctx)
+		case <-s.outcomeCh:
+			s.logger.Info("outcome signal — immediate tick")
 			s.tick(ctx)
 		}
 	}


### PR DESCRIPTION
## Summary

Agents now signal the castellarius immediately after writing an outcome,
instead of relying on the 10-second poll cycle to notice. This eliminates
the race condition where the heartbeat detected a dead tmux session and
reset the droplet before the observe cycle could process the outcome.

## Changes

- **outcomeCh**: Buffered channel on Castellarius that triggers immediate tick
- **NotifyOutcome()**: Non-blocking send on outcomeCh (drops if already pending)
- **SIGUSR1 handler**: Castellarius catches SIGUSR1 and calls NotifyOutcome()
- **notify.go**: Reads castellarius PID from health file, sends SIGUSR1
- **ct droplet pass/recirculate/pool**: Call notifyCastellarius() after SetOutcome
- **Health file**: Now includes PID field for inter-process signaling

## Flow

1. Agent calls `ct droplet pass <id>` → writes outcome to DB → sends SIGUSR1
2. Castellarius receives SIGUSR1 → immediate observe+dispatch tick
3. Outcome processed within milliseconds, not 10 seconds
4. By the time the heartbeat scans (every 30s), the droplet is already advanced
5. Heartbeat is now a safety net, not the primary mechanism

## Previous fix still in place

The heartbeat DB re-read fix (check outcome + cataractae advancement) is
still there as a safety net. SIGUSR1 makes it virtually unnecessary, but
the defense-in-depth approach ensures correctness even if the signal is
missed.