### PR TITLE
fix: kill stale worker session before respawning for new cataractae

### DIFF
--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -61,12 +61,15 @@ func (s *Session) Spawn() error {
 // spawn creates a new tmux session running the agent fresh. With exec prefix,
 // if the session is alive, the agent IS alive — no stale session is possible.
 func (s *Session) spawn() error {
-	// With exec prefix, if the session is alive the agent is alive.
-	// No exit detection needed — return nil and let the existing session continue.
+	// Kill any existing session for this worker. A session from a previous
+	// cataractae may still be running if the agent hasn't exited yet after
+	// signaling its outcome. The observe cycle advances the droplet to the
+	// next step, and the dispatch cycle re-assigns the same worker — but
+	// the running session is for the OLD step, not the new one.
 	if isSessionAlive(s.ID) {
-		slog.Default().Info("session: already running — skipping respawn",
+		slog.Default().Info("session: killing existing session before respawn",
 			"session", s.ID)
-		return nil
+		exec.Command("tmux", "kill-session", "-t", s.ID).Run() //nolint:errcheck
 	}
 
 	home, err := os.UserHomeDir()


### PR DESCRIPTION
## Summary

The `session: already running — skipping respawn` guard in `spawn()` was
checking if the tmux session for a worker was alive and returning nil
(success) if so. This was designed for persistent per-worker sessions, but
the current architecture uses per-droplet worktrees where each dispatch
starts a new session for the current cataractae.

When the observe cycle advances a droplet (e.g., docs → delivery) and
re-assigns the same worker, `spawn()` found the old session still alive
(from the docs agent that called `ct droplet pass` but hadn't exited yet)
and skipped the respawn. The delivery agent never started, and the
heartbeat eventually detected the dead session and wrote an exit-no-outcome
note.

The SIGUSR1 outcome notification (PR #440) makes this worse by processing
outcomes immediately — the observe and dispatch cycles run before the
old agent has even exited, so the session is always "still alive" when
the new step tries to spawn.

## Fix

Replace the `isSessionAlive` skip guard with a `kill + respawn` pattern.
If the session is alive, kill it first, then spawn the new one. This
ensures the new cataractae always gets a fresh session with the correct
working directory and prompt.