### PR TITLE
fix: observe cycle kills agent session after processing outcome

### DIFF
--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -740,8 +740,19 @@ func (s *Castellarius) observeRepo(_ context.Context, repo aqueduct.RepoConfig) 
 		}
 
 		// Release the aqueduct worker unconditionally — it is free for other droplets
-		// regardless of where this one routes next.
+		// regardless of where this one routes next. Also kill the agent's tmux
+		// session — the agent already signaled its outcome and the session is
+		// now stale. If the SIGUSR1 notification triggers an immediate tick,
+		// the dispatch cycle may try to spawn a new session for this worker
+		// before the old one has exited. Killing here prevents the spawn guard
+		// from seeing a live session for the wrong cataractae.
 		if assignee != "" {
+			sessionID := repo.Name + "-" + assignee
+			if isTmuxAlive(sessionID) {
+				exec.Command("tmux", "kill-session", "-t", sessionID).Run()
+				s.logger.Info("observe: killed agent session after outcome processed",
+					"repo", repo.Name, "droplet", item.ID, "session", sessionID)
+			}
 			if w := pool.FindByName(assignee); w != nil {
 				pool.Release(w)
 			}


### PR DESCRIPTION
## Root Cause

When `ct droplet pass` sends SIGUSR1, the castellarius processes the
outcome immediately via an event-driven tick. The observe cycle advances
the droplet to the next cataractae and releases the worker. The dispatch
cycle then re-assigns the same worker and calls `Spawn()` — but the old
agent's tmux session is still alive because the agent hasn't exited yet.

The spawn guard (`isSessionAlive`) saw the live session and returned nil
(success) without starting a new agent. The new cataractae never got
dispatched. The heartbeat eventually found the dead session and wrote
an `[scheduler:exit-no-outcome]` note.

## Fix

The observe cycle is the right place to clean up the session. When it
processes an outcome and releases the worker, it now also kills the
agent's tmux session. The agent already signaled — its work is done.
By the time the dispatch cycle runs, the session is gone and `Spawn()`
starts fresh for the new cataractae.

Combined with PR #443 (spawn kills stale session as safety net), this
provides two layers: observe kills proactively, spawn catches the edge
case where the kill hasn't taken effect yet.