### PR TITLE
fix: dispatch defers workers with live sessions instead of forcing

### DIFF
--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -934,10 +934,28 @@ func (s *Castellarius) dispatchRepo(ctx context.Context, repo aqueduct.RepoConfi
 	client := s.clients[repo.Name]
 	wf := s.workflows[repo.Name]
 
+	// Track workers whose tmux sessions are still alive from a previous
+	// cataractae. When SIGUSR1 triggers an immediate tick, the observe
+	// cycle may release a worker before its agent's tmux session has died.
+	// We can't assign new work to these workers until the session exits
+	// naturally — so we skip them and try the next idle worker.
+	sessionAlive := map[string]bool{}
+
 	for {
-		worker := pool.AvailableAqueduct()
+		worker := pool.AvailableAqueductExcluding(sessionAlive)
 		if worker == nil {
 			return
+		}
+
+		sessionID := repo.Name + "-" + worker.Name
+		if isTmuxAlive(sessionID) {
+			// Worker's previous session hasn't exited yet. Skip this worker
+			// and try another. The droplet stays open and will be retried
+			// on the next tick after the session dies naturally.
+			s.logger.Info("dispatch: worker session still alive — deferring",
+				"repo", repo.Name, "worker", worker.Name, "session", sessionID)
+			sessionAlive[worker.Name] = true
+			continue
 		}
 
 		// Each repo has its own pool — just get the next ready droplet for this repo.

--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -61,15 +61,16 @@ func (s *Session) Spawn() error {
 // spawn creates a new tmux session running the agent fresh. With exec prefix,
 // if the session is alive, the agent IS alive — no stale session is possible.
 func (s *Session) spawn() error {
-	// Kill any existing session for this worker. A session from a previous
-	// cataractae may still be running if the agent hasn't exited yet after
-	// signaling its outcome. The observe cycle advances the droplet to the
-	// next step, and the dispatch cycle re-assigns the same worker — but
-	// the running session is for the OLD step, not the new one.
+	// If the worker's session is still alive, we can't spawn a new one yet.
+	// The previous agent hasn't exited — the tmux session needs to die
+	// naturally (remain-on-exit off) before a fresh session can start.
+	// Return nil (success, no-op) so the dispatch cycle doesn't treat
+	// this as a failure. The scheduler's session-alive guard in dispatchRepo
+	// should prevent this path from being reached, but this is a safety net.
 	if isSessionAlive(s.ID) {
-		slog.Default().Info("session: killing existing session before respawn",
+		slog.Default().Info("session: already alive — skipping spawn",
 			"session", s.ID)
-		exec.Command("tmux", "kill-session", "-t", s.ID).Run() //nolint:errcheck
+		return nil
 	}
 
 	home, err := os.UserHomeDir()


### PR DESCRIPTION
## Summary

When SIGUSR1 triggers an immediate tick, the observe cycle processes the
outcome and releases the worker before the agent's tmux session has exited.
The dispatch cycle then picks up the same worker, calls Spawn(), and either
skips (leaving the droplet unassigned) or kills the session (wrong — agents
exit naturally).

The correct approach: the dispatch cycle checks if the worker's tmux session
is alive BEFORE assigning work. If alive, defer the worker and try the next
idle one. If all workers have live sessions, just return — the droplet stays
open and is retried next tick (10s max). No sessions are killed. Agents exit
naturally. The system is deterministic.

## Changes

- **dispatchRepo**: Uses `AvailableAqueductExcluding` to skip workers whose
  tmux sessions are still alive. Logs "deferring" and tries next worker.
- **session.spawn()**: Restored to original semantics — if session is alive,
  logs and returns nil (no-op). Safety net; the dispatch guard should prevent
  this.
- No sessions are killed anywhere. Agents exit naturally.