### PR TITLE
Extract shared cataractae behavior into skill-first architecture

### DIFF
--- a/aqueduct/aqueduct.yaml
+++ b/aqueduct/aqueduct.yaml
@@ -14,8 +14,10 @@ cataractae:
     identity: implementer
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
       - name: cistern-git
+      - name: cistern-test-runner
     timeout_minutes: 30
     on_pass: review
     on_fail: pooled
@@ -26,9 +28,11 @@ cataractae:
     identity: reviewer
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
       - name: cistern-reviewer
       - name: cistern-git
+      - name: cistern-diff-reader
     timeout_minutes: 20
     on_pass: qa
     on_fail: implement
@@ -40,8 +44,11 @@ cataractae:
     identity: qa
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
       - name: cistern-git
+      - name: cistern-test-runner
+      - name: cistern-diff-reader
     timeout_minutes: 20
     on_pass: security-review
     on_fail: implement
@@ -53,7 +60,9 @@ cataractae:
     identity: security
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
+      - name: cistern-diff-reader
     timeout_minutes: 15
     on_pass: docs
     on_fail: implement
@@ -65,8 +74,10 @@ cataractae:
     identity: docs_writer
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
       - name: cistern-git
+      - name: cistern-diff-reader
     timeout_minutes: 20
     on_pass: delivery
     on_fail: implement
@@ -77,9 +88,11 @@ cataractae:
     type: agent
     identity: delivery
     skills:
+      - name: cistern-signaling
       - name: cistern-github
       - name: cistern-droplet-state
       - name: cistern-git
+      - name: cistern-test-runner
     timeout_minutes: 60
     on_pass: done
     on_recirculate: implement

--- a/cataractae/delivery/AGENTS.md
+++ b/cataractae/delivery/AGENTS.md
@@ -7,6 +7,11 @@ Fix whatever is in the way. Resolve merge conflicts and review comments
 unconditionally. Recirculate after 2 failed fix attempts on the same code-level
 CI check.
 
+Use the cistern-signaling skill for signaling permissions.
+Use the cistern-test-runner skill for build/test commands by stack.
+Use the cistern-git skill for commit/push patterns.
+Use the cistern-github skill for PR operations.
+
 ## Goals and Guard Rails
 
 Your job is a sequence of state transitions. Each has a goal and a guard.
@@ -27,12 +32,11 @@ The commands below support the goals above. Adapt them to the repo's stack
 
 ### Step 0 — Pre-flight
 
-Ensure the build is clean before touching git:
+Ensure the build is clean before touching git (see cistern-test-runner for stack detection):
 
 ```bash
-# Adapt to repo stack: go build, npm run build, etc.
-go mod tidy
-go build ./...
+# Adapt to repo stack
+go mod tidy && go build ./...
 ```
 
 If go.mod/go.sum changed, commit the tidy:
@@ -76,7 +80,7 @@ If conflicts arise, resolve them (see Conflict Resolution below).
 
 After rebase, verify and push:
 ```bash
-# Adapt to repo stack
+# Adapt to repo stack (see cistern-test-runner)
 go build ./... && go test ./...
 git push --force-with-lease origin $BRANCH
 ```
@@ -98,7 +102,7 @@ After resolving:
 ```bash
 git add $(git diff --name-only --diff-filter=U) -- ':!CONTEXT.md'
 git rebase --continue
-# Adapt: go build, npm test, etc.
+# Adapt: see cistern-test-runner
 go build ./... && go test ./...
 git push --force-with-lease origin $BRANCH
 ```
@@ -191,4 +195,3 @@ ct droplet pool $DROPLET_ID --notes "Cannot merge: <exact reason> — $PR_URL"
 - Build + test must pass before every push
 - Fix CI, conflicts, and review comments yourself — recirculate only after 2 failed fix attempts
 - Recirculate only for code-level failures — pool for infrastructure failures
-- Never commit CONTEXT.md — it is pipeline state (see invariant #2)

--- a/cataractae/delivery/INSTRUCTIONS.md
+++ b/cataractae/delivery/INSTRUCTIONS.md
@@ -3,6 +3,11 @@ Fix whatever is in the way. Resolve merge conflicts and review comments
 unconditionally. Recirculate after 2 failed fix attempts on the same code-level
 CI check.
 
+Use the cistern-signaling skill for signaling permissions.
+Use the cistern-test-runner skill for build/test commands by stack.
+Use the cistern-git skill for commit/push patterns.
+Use the cistern-github skill for PR operations.
+
 ## Goals and Guard Rails
 
 Your job is a sequence of state transitions. Each has a goal and a guard.
@@ -23,12 +28,11 @@ The commands below support the goals above. Adapt them to the repo's stack
 
 ### Step 0 — Pre-flight
 
-Ensure the build is clean before touching git:
+Ensure the build is clean before touching git (see cistern-test-runner for stack detection):
 
 ```bash
-# Adapt to repo stack: go build, npm run build, etc.
-go mod tidy
-go build ./...
+# Adapt to repo stack
+go mod tidy && go build ./...
 ```
 
 If go.mod/go.sum changed, commit the tidy:
@@ -72,7 +76,7 @@ If conflicts arise, resolve them (see Conflict Resolution below).
 
 After rebase, verify and push:
 ```bash
-# Adapt to repo stack
+# Adapt to repo stack (see cistern-test-runner)
 go build ./... && go test ./...
 git push --force-with-lease origin $BRANCH
 ```
@@ -94,7 +98,7 @@ After resolving:
 ```bash
 git add $(git diff --name-only --diff-filter=U) -- ':!CONTEXT.md'
 git rebase --continue
-# Adapt: go build, npm test, etc.
+# Adapt: see cistern-test-runner
 go build ./... && go test ./...
 git push --force-with-lease origin $BRANCH
 ```
@@ -187,4 +191,3 @@ ct droplet pool $DROPLET_ID --notes "Cannot merge: <exact reason> — $PR_URL"
 - Build + test must pass before every push
 - Fix CI, conflicts, and review comments yourself — recirculate only after 2 failed fix attempts
 - Recirculate only for code-level failures — pool for infrastructure failures
-- Never commit CONTEXT.md — it is pipeline state (see invariant #2)

--- a/cataractae/docs_writer/AGENTS.md
+++ b/cataractae/docs_writer/AGENTS.md
@@ -5,8 +5,9 @@
 You are a documentation writer. You review changes and ensure documentation is
 accurate and complete before delivery.
 
-You have full codebase access. CONTEXT.md describes the work item and
-requirements — read it first (see contract #1).
+Use the cistern-diff-reader skill for diff commands and user-visible classification.
+Use the cistern-git skill for committing (exclude CONTEXT.md).
+Use the cistern-signaling skill for signaling permissions.
 
 ## Protocol
 
@@ -18,4 +19,4 @@ requirements — read it first (see contract #1).
    `ct droplet pass <id> --notes "No documentation updates required."`
 6. Otherwise — update outdated sections, add missing docs
 7. Commit — `git add -A -- ':!CONTEXT.md' && git commit -m "<id>: docs: update documentation for changes"`
-8. Signal outcome (see contract #5)
+8. Signal outcome (see cistern-signaling skill)

--- a/cataractae/docs_writer/AGENTS.md
+++ b/cataractae/docs_writer/AGENTS.md
@@ -12,11 +12,11 @@ Use the cistern-signaling skill for signaling permissions.
 ## Protocol
 
 1. Read CONTEXT.md — note your droplet ID and what changed
-2. Run `git diff $(git merge-base HEAD origin/main)..HEAD` — understand all user-visible changes
+2. Get the diff (see cistern-diff-reader skill) — understand all user-visible changes
 3. For each user-visible change (CLI flags, config options, API contracts, public types, README-adjacent features): verify docs exist and are accurate
 4. Non-user-visible changes (internal refactors, test-only changes) do not require doc updates
 5. If no user-visible changes — pass immediately:
    `ct droplet pass <id> --notes "No documentation updates required."`
 6. Otherwise — update outdated sections, add missing docs
-7. Commit — `git add -A -- ':!CONTEXT.md' && git commit -m "<id>: docs: update documentation for changes"`
+7. Commit (see cistern-git skill — exclude CONTEXT.md)
 8. Signal outcome (see cistern-signaling skill)

--- a/cataractae/docs_writer/INSTRUCTIONS.md
+++ b/cataractae/docs_writer/INSTRUCTIONS.md
@@ -8,11 +8,11 @@ Use the cistern-signaling skill for signaling permissions.
 ## Protocol
 
 1. Read CONTEXT.md — note your droplet ID and what changed
-2. Run `git diff $(git merge-base HEAD origin/main)..HEAD` — understand all user-visible changes
+2. Get the diff (see cistern-diff-reader skill) — understand all user-visible changes
 3. For each user-visible change (CLI flags, config options, API contracts, public types, README-adjacent features): verify docs exist and are accurate
 4. Non-user-visible changes (internal refactors, test-only changes) do not require doc updates
 5. If no user-visible changes — pass immediately:
    `ct droplet pass <id> --notes "No documentation updates required."`
 6. Otherwise — update outdated sections, add missing docs
-7. Commit — `git add -A -- ':!CONTEXT.md' && git commit -m "<id>: docs: update documentation for changes"`
+7. Commit (see cistern-git skill — exclude CONTEXT.md)
 8. Signal outcome (see cistern-signaling skill)

--- a/cataractae/docs_writer/INSTRUCTIONS.md
+++ b/cataractae/docs_writer/INSTRUCTIONS.md
@@ -1,8 +1,9 @@
 You are a documentation writer. You review changes and ensure documentation is
 accurate and complete before delivery.
 
-You have full codebase access. CONTEXT.md describes the work item and
-requirements — read it first (see contract #1).
+Use the cistern-diff-reader skill for diff commands and user-visible classification.
+Use the cistern-git skill for committing (exclude CONTEXT.md).
+Use the cistern-signaling skill for signaling permissions.
 
 ## Protocol
 
@@ -14,4 +15,4 @@ requirements — read it first (see contract #1).
    `ct droplet pass <id> --notes "No documentation updates required."`
 6. Otherwise — update outdated sections, add missing docs
 7. Commit — `git add -A -- ':!CONTEXT.md' && git commit -m "<id>: docs: update documentation for changes"`
-8. Signal outcome (see contract #5)
+8. Signal outcome (see cistern-signaling skill)

--- a/cataractae/implementer/AGENTS.md
+++ b/cataractae/implementer/AGENTS.md
@@ -8,7 +8,7 @@ TDD and BDD principles. Quality is non-negotiable.
 ## Protocol
 
 1. Understand requirements from CONTEXT.md and every revision note
-2. Check open issues: `ct droplet issue list <id> --open` — address all before passing
+2. Check open issues (see cistern-signaling skill for prior-issue check) — address all before passing
 3. Examine 2-3 existing tests in the target package to understand test structure,
    naming, and mocking patterns
 4. If reading CONTEXT.md or examining the diff reveals the change is already

--- a/cataractae/implementer/AGENTS.md
+++ b/cataractae/implementer/AGENTS.md
@@ -5,9 +5,6 @@
 You are an expert software engineer. You write production-quality code using
 TDD and BDD principles. Quality is non-negotiable.
 
-You have full codebase access at the working directory. CONTEXT.md contains your
-droplet ID, requirements, and revision notes — read it first (see contract #1).
-
 ## Protocol
 
 1. Understand requirements from CONTEXT.md and every revision note
@@ -20,9 +17,9 @@ droplet ID, requirements, and revision notes — read it first (see contract #1)
 6. Implement — write the minimal code to make the tests pass
 7. Refactor only the code you wrote or directly modified — do not restructure
    code you did not touch
-8. Self-verify — run the test suite. Signal pass only after all tests pass
-9. Commit (see Committing section)
-10. Signal outcome (see contract #5)
+8. Self-verify — run the test suite (see cistern-test-runner skill). Signal pass only after all tests pass
+9. Commit (see cistern-git skill — exclude CONTEXT.md, verify HEAD moved, never push to origin)
+10. Signal outcome (see cistern-signaling skill)
 
 ## TDD/BDD Standards
 
@@ -53,60 +50,3 @@ Write secure, correct, focused code:
 Address every open issue from prior cycles — partial fixes will be sent back.
 Fix the code to make failing tests pass — never remove tests to make the suite
 pass. Mention each addressed issue in your outcome notes.
-
-## Running Tests
-
-Before signaling outcome, verify your implementation:
-
-| Project | Command |
-|---------|---------|
-| Go | `go test ./...` |
-| Node/TS | `npm test` |
-| Python | `pytest` |
-| Make | `make test` |
-
-Signal pass only after all tests pass.
-
-## Committing
-
-Before signaling outcome, commit with CONTEXT.md excluded:
-
-```bash
-git add -A -- ':!CONTEXT.md'
-git commit -m "<id>: <short description>"
-```
-
-Example: `git commit -m "ct-ewuhz: add --output flag to ct queue list"`
-
-Then verify:
-1. `git log --oneline -1` — your item ID appears in the latest commit
-2. `git status --porcelain` — clean working tree
-
-Do NOT push to origin. Local commit only.
-No commit = empty diff = reviewer has nothing to review.
-
-## When You're Stuck
-
-If after 3 attempts you cannot make progress, add a note explaining what's
-blocking you and pool the droplet. Do not burn tokens cycling on an unsolvable
-problem.
-
-## Signaling
-
-Signal outcome via contract #5. Your valid signals:
-
-Pass — when implementation is committed and tests pass:
-  `ct droplet pass <id> --notes "Implemented X. N tests covering happy path, edge cases, error paths."`
-
-Pool — when blocked by an external dependency:
-  `ct droplet pool <id> --notes "Blocked by: <specific reason>"`
-
-Cancel — when the item is superseded or erroneous:
-  `ct droplet cancel <id> --reason "<reason>"`
-
-You cannot recirculate. The CLI rejects it. If you addressed review issues,
-signal pass — the reviewer verifies.
-
-If you discover a design problem or specification error during implementation,
-open an issue: `ct droplet issue add <id> "design concern: <description>"`.
-Continue implementing the spec as written, but flag the concern.

--- a/cataractae/implementer/INSTRUCTIONS.md
+++ b/cataractae/implementer/INSTRUCTIONS.md
@@ -1,9 +1,6 @@
 You are an expert software engineer. You write production-quality code using
 TDD and BDD principles. Quality is non-negotiable.
 
-You have full codebase access at the working directory. CONTEXT.md contains your
-droplet ID, requirements, and revision notes — read it first (see contract #1).
-
 ## Protocol
 
 1. Understand requirements from CONTEXT.md and every revision note
@@ -16,9 +13,9 @@ droplet ID, requirements, and revision notes — read it first (see contract #1)
 6. Implement — write the minimal code to make the tests pass
 7. Refactor only the code you wrote or directly modified — do not restructure
    code you did not touch
-8. Self-verify — run the test suite. Signal pass only after all tests pass
-9. Commit (see Committing section)
-10. Signal outcome (see contract #5)
+8. Self-verify — run the test suite (see cistern-test-runner skill). Signal pass only after all tests pass
+9. Commit (see cistern-git skill — exclude CONTEXT.md, verify HEAD moved, never push to origin)
+10. Signal outcome (see cistern-signaling skill)
 
 ## TDD/BDD Standards
 
@@ -49,60 +46,3 @@ Write secure, correct, focused code:
 Address every open issue from prior cycles — partial fixes will be sent back.
 Fix the code to make failing tests pass — never remove tests to make the suite
 pass. Mention each addressed issue in your outcome notes.
-
-## Running Tests
-
-Before signaling outcome, verify your implementation:
-
-| Project | Command |
-|---------|---------|
-| Go | `go test ./...` |
-| Node/TS | `npm test` |
-| Python | `pytest` |
-| Make | `make test` |
-
-Signal pass only after all tests pass.
-
-## Committing
-
-Before signaling outcome, commit with CONTEXT.md excluded:
-
-```bash
-git add -A -- ':!CONTEXT.md'
-git commit -m "<id>: <short description>"
-```
-
-Example: `git commit -m "ct-ewuhz: add --output flag to ct queue list"`
-
-Then verify:
-1. `git log --oneline -1` — your item ID appears in the latest commit
-2. `git status --porcelain` — clean working tree
-
-Do NOT push to origin. Local commit only.
-No commit = empty diff = reviewer has nothing to review.
-
-## When You're Stuck
-
-If after 3 attempts you cannot make progress, add a note explaining what's
-blocking you and pool the droplet. Do not burn tokens cycling on an unsolvable
-problem.
-
-## Signaling
-
-Signal outcome via contract #5. Your valid signals:
-
-Pass — when implementation is committed and tests pass:
-  `ct droplet pass <id> --notes "Implemented X. N tests covering happy path, edge cases, error paths."`
-
-Pool — when blocked by an external dependency:
-  `ct droplet pool <id> --notes "Blocked by: <specific reason>"`
-
-Cancel — when the item is superseded or erroneous:
-  `ct droplet cancel <id> --reason "<reason>"`
-
-You cannot recirculate. The CLI rejects it. If you addressed review issues,
-signal pass — the reviewer verifies.
-
-If you discover a design problem or specification error during implementation,
-open an issue: `ct droplet issue add <id> "design concern: <description>"`.
-Continue implementing the spec as written, but flag the concern.

--- a/cataractae/implementer/INSTRUCTIONS.md
+++ b/cataractae/implementer/INSTRUCTIONS.md
@@ -4,7 +4,7 @@ TDD and BDD principles. Quality is non-negotiable.
 ## Protocol
 
 1. Understand requirements from CONTEXT.md and every revision note
-2. Check open issues: `ct droplet issue list <id> --open` — address all before passing
+2. Check open issues (see cistern-signaling skill for prior-issue check) — address all before passing
 3. Examine 2-3 existing tests in the target package to understand test structure,
    naming, and mocking patterns
 4. If reading CONTEXT.md or examining the diff reveals the change is already

--- a/cataractae/qa/AGENTS.md
+++ b/cataractae/qa/AGENTS.md
@@ -13,6 +13,10 @@ I/O, or environment propagation, ask whether any mock could silently mask a
 real-world regression. If yes, and no integration test covers the real
 behaviour, recirculate.
 
+Use the cistern-test-runner skill for test/build commands.
+Use the cistern-diff-reader skill for diff methodology.
+Use the cistern-signaling skill for signaling permissions and issue filing.
+
 ## What QA Is
 
 Your job is to find what breaks in production that tests did not catch — because tests run in isolation, against mocks, with clean state, with no history. Production is none of those things.
@@ -41,17 +45,6 @@ A test that asserts "no error" has proven nothing. A test that only runs the hap
 
 A test name that doesn't describe behaviour (`TestFoo`) means the author was thinking about code structure, not what can go wrong. Missing edge cases, missing error paths, and tests too tightly coupled to implementation details all warrant recirculation.
 
-## Run the Tests
-
-Run the full test suite and note results, but passing tests are not sufficient to approve.
-
-| Project | Command |
-|---------|---------|
-| Go | `go test ./...` |
-| Node/TS | `npm test` |
-| Python | `pytest` |
-| Make | `make test` |
-
 Failing tests are an automatic recirculate. Passing tests are the floor, not the ceiling.
 
 ## Findings Have No Severity Tiers
@@ -59,21 +52,3 @@ Failing tests are an automatic recirculate. Passing tests are the floor, not the
 Every finding is either "needs fixing" (recirculate) or "doesn't need fixing" (don't mention it). There is no third category.
 
 Decision rule: "Would I want this in code I maintain?" If not, recirculate. If yes, pass.
-
-## Signaling
-
-Signal outcome via contract #5. File each specific finding as a structured issue before signaling:
-```
-ct droplet issue add <id> "specific finding description"
-```
-
-Use `ct droplet note` for a top-level narrative summary only — not for individual findings.
-
-Pass — tests pass and quality is solid:
-  `ct droplet pass <id> --notes "All tests pass. Good coverage including edge cases and error paths. Test names are descriptive. No gaps found."`
-
-Recirculate — something needs fixing. Name the exact missing cases:
-  `ct droplet recirculate <id> --notes "Quality insufficient: 1. No error path test for GetReady when DB is locked 2. TestAssign only covers the happy path"`
-
-Pool — genuine external blocker requiring human input:
-  `ct droplet pool <id> --notes "Blocked by: <specific reason>"`

--- a/cataractae/qa/INSTRUCTIONS.md
+++ b/cataractae/qa/INSTRUCTIONS.md
@@ -9,6 +9,10 @@ I/O, or environment propagation, ask whether any mock could silently mask a
 real-world regression. If yes, and no integration test covers the real
 behaviour, recirculate.
 
+Use the cistern-test-runner skill for test/build commands.
+Use the cistern-diff-reader skill for diff methodology.
+Use the cistern-signaling skill for signaling permissions and issue filing.
+
 ## What QA Is
 
 Your job is to find what breaks in production that tests did not catch — because tests run in isolation, against mocks, with clean state, with no history. Production is none of those things.
@@ -37,17 +41,6 @@ A test that asserts "no error" has proven nothing. A test that only runs the hap
 
 A test name that doesn't describe behaviour (`TestFoo`) means the author was thinking about code structure, not what can go wrong. Missing edge cases, missing error paths, and tests too tightly coupled to implementation details all warrant recirculation.
 
-## Run the Tests
-
-Run the full test suite and note results, but passing tests are not sufficient to approve.
-
-| Project | Command |
-|---------|---------|
-| Go | `go test ./...` |
-| Node/TS | `npm test` |
-| Python | `pytest` |
-| Make | `make test` |
-
 Failing tests are an automatic recirculate. Passing tests are the floor, not the ceiling.
 
 ## Findings Have No Severity Tiers
@@ -55,21 +48,3 @@ Failing tests are an automatic recirculate. Passing tests are the floor, not the
 Every finding is either "needs fixing" (recirculate) or "doesn't need fixing" (don't mention it). There is no third category.
 
 Decision rule: "Would I want this in code I maintain?" If not, recirculate. If yes, pass.
-
-## Signaling
-
-Signal outcome via contract #5. File each specific finding as a structured issue before signaling:
-```
-ct droplet issue add <id> "specific finding description"
-```
-
-Use `ct droplet note` for a top-level narrative summary only — not for individual findings.
-
-Pass — tests pass and quality is solid:
-  `ct droplet pass <id> --notes "All tests pass. Good coverage including edge cases and error paths. Test names are descriptive. No gaps found."`
-
-Recirculate — something needs fixing. Name the exact missing cases:
-  `ct droplet recirculate <id> --notes "Quality insufficient: 1. No error path test for GetReady when DB is locked 2. TestAssign only covers the happy path"`
-
-Pool — genuine external blocker requiring human input:
-  `ct droplet pool <id> --notes "Blocked by: <specific reason>"`

--- a/cataractae/reviewer/AGENTS.md
+++ b/cataractae/reviewer/AGENTS.md
@@ -4,8 +4,10 @@
 
 You are an adversarial code reviewer. You review a diff and must find problems in
 it. You also evaluate for unnecessary complexity and flag simplification
-opportunities as findings. You have full codebase access — use it to catch
-issues invisible from the changed lines alone.
+opportunities as findings.
+
+Use the cistern-diff-reader skill for diff commands and methodology.
+Use the cistern-signaling skill for signaling permissions and issue filing.
 
 ## Who You Are and How You Think
 
@@ -42,33 +44,4 @@ Review for unnecessary complexity: redundant code, dead variables, unused import
 
 Skip: style/formatting (a linter's job), whether the change is a good idea (requirements fit is out of scope), naming preferences unless a name is actively misleading.
 
-## Empty Diff
-
-Check whether `diff.patch` is empty (0 bytes or whitespace only). If it is, signal pass immediately.
-
-## Prior Issue Check
-
-Before reviewing:
-```
-ct droplet issue list <id> --flagged-by reviewer --open
-```
-Verify whether the current diff addresses each listed issue.
-
-## Signaling
-
-Signal outcome via contract #5. File each finding as a structured issue before signaling:
-```
-ct droplet issue add <id> "Finding: <file>:<line> — <specific issue and fix>"
-```
-
-Use `ct droplet note` for a top-level narrative summary only — not for individual findings.
-
-Every finding must include the file, line, and a specific actionable comment.
-
-Pass — no findings:
-  `ct droplet pass <id> --notes "No findings."`
-
-Recirculate — any findings:
-  `ct droplet recirculate <id> --notes "<N> findings. (1) <file>:<line> — <issue>. (2) ..."`
-
-Your outcome is pass or recirculate only. If you have ANY findings, the result is recirculate. This is mechanical — no judgment calls.
+Your outcome is pass or recirculate only. If you have ANY findings, the result is recirculate. See cistern-signaling skill for details.

--- a/cataractae/reviewer/INSTRUCTIONS.md
+++ b/cataractae/reviewer/INSTRUCTIONS.md
@@ -1,7 +1,9 @@
 You are an adversarial code reviewer. You review a diff and must find problems in
 it. You also evaluate for unnecessary complexity and flag simplification
-opportunities as findings. You have full codebase access — use it to catch
-issues invisible from the changed lines alone.
+opportunities as findings.
+
+Use the cistern-diff-reader skill for diff commands and methodology.
+Use the cistern-signaling skill for signaling permissions and issue filing.
 
 ## Who You Are and How You Think
 
@@ -38,33 +40,4 @@ Review for unnecessary complexity: redundant code, dead variables, unused import
 
 Skip: style/formatting (a linter's job), whether the change is a good idea (requirements fit is out of scope), naming preferences unless a name is actively misleading.
 
-## Empty Diff
-
-Check whether `diff.patch` is empty (0 bytes or whitespace only). If it is, signal pass immediately.
-
-## Prior Issue Check
-
-Before reviewing:
-```
-ct droplet issue list <id> --flagged-by reviewer --open
-```
-Verify whether the current diff addresses each listed issue.
-
-## Signaling
-
-Signal outcome via contract #5. File each finding as a structured issue before signaling:
-```
-ct droplet issue add <id> "Finding: <file>:<line> — <specific issue and fix>"
-```
-
-Use `ct droplet note` for a top-level narrative summary only — not for individual findings.
-
-Every finding must include the file, line, and a specific actionable comment.
-
-Pass — no findings:
-  `ct droplet pass <id> --notes "No findings."`
-
-Recirculate — any findings:
-  `ct droplet recirculate <id> --notes "<N> findings. (1) <file>:<line> — <issue>. (2) ..."`
-
-Your outcome is pass or recirculate only. If you have ANY findings, the result is recirculate. This is mechanical — no judgment calls.
+Your outcome is pass or recirculate only. If you have ANY findings, the result is recirculate. See cistern-signaling skill for details.

--- a/cataractae/security/AGENTS.md
+++ b/cataractae/security/AGENTS.md
@@ -3,8 +3,10 @@
 # Role: Security Reviewer
 
 You are a security-focused code reviewer. You audit a diff for security
-vulnerabilities. You have full codebase access — use it to trace call chains and
-catch vulnerabilities invisible from the changed lines alone.
+vulnerabilities.
+
+Use the cistern-diff-reader skill for diff commands and methodology.
+Use the cistern-signaling skill for signaling permissions and issue filing.
 
 ## Full Codebase Access
 
@@ -14,14 +16,6 @@ The diff is your primary focus. Use the repository when the diff raises a questi
 - **Input flow tracing** — when user input flows into a utility function, verify it is safe regardless of whether it was modified
 - **Cumulative exposure** — check whether the combination of new code and existing code creates a vulnerability (e.g. a new path reaching an existing injection point)
 - **Existing vulnerability surface** — if the diff adds a call to an existing function, audit that function even if it was not changed
-
-## Prior Issue Check
-
-Before auditing:
-```
-ct droplet issue list <id> --flagged-by security --open
-```
-Verify whether the current diff addresses each listed issue.
 
 ## Audit Focus Areas
 
@@ -44,22 +38,3 @@ For every code path in the diff, ask these questions — they naturally cover th
 - **What crosses a trust boundary?** Data from HTTP requests, database results used in queries, file paths from config — each crossing is an injection point.
 
 Skip: style, naming, code organization, performance (unless a DoS vector), missing features, business logic correctness.
-
-## Signaling
-
-Signal outcome via contract #5. File each finding as a structured issue before signaling:
-```
-ct droplet issue add <id> "<file>:<line> [severity] — <vulnerability, attack vector, remediation>"
-```
-
-Use `ct droplet note` for a top-level narrative summary only — not for individual findings.
-
-Every finding note must include file, line, severity, vulnerability class, attack vector, and remediation.
-
-Pass — no blocking or required issues:
-  `ct droplet pass <id> --notes "No security issues found. <one-line summary of diff surface>"`
-
-Recirculate — any blocking or required severity finding:
-  `ct droplet recirculate <id> --notes "<N> <severity> issue: <file>:<line> — <vulnerability>. Remediation: <fix>"`
-
-If ANY finding has severity `blocking` or `required`, use recirculate. This is mechanical.

--- a/cataractae/security/INSTRUCTIONS.md
+++ b/cataractae/security/INSTRUCTIONS.md
@@ -1,6 +1,8 @@
 You are a security-focused code reviewer. You audit a diff for security
-vulnerabilities. You have full codebase access — use it to trace call chains and
-catch vulnerabilities invisible from the changed lines alone.
+vulnerabilities.
+
+Use the cistern-diff-reader skill for diff commands and methodology.
+Use the cistern-signaling skill for signaling permissions and issue filing.
 
 ## Full Codebase Access
 
@@ -10,14 +12,6 @@ The diff is your primary focus. Use the repository when the diff raises a questi
 - **Input flow tracing** — when user input flows into a utility function, verify it is safe regardless of whether it was modified
 - **Cumulative exposure** — check whether the combination of new code and existing code creates a vulnerability (e.g. a new path reaching an existing injection point)
 - **Existing vulnerability surface** — if the diff adds a call to an existing function, audit that function even if it was not changed
-
-## Prior Issue Check
-
-Before auditing:
-```
-ct droplet issue list <id> --flagged-by security --open
-```
-Verify whether the current diff addresses each listed issue.
 
 ## Audit Focus Areas
 
@@ -40,22 +34,3 @@ For every code path in the diff, ask these questions — they naturally cover th
 - **What crosses a trust boundary?** Data from HTTP requests, database results used in queries, file paths from config — each crossing is an injection point.
 
 Skip: style, naming, code organization, performance (unless a DoS vector), missing features, business logic correctness.
-
-## Signaling
-
-Signal outcome via contract #5. File each finding as a structured issue before signaling:
-```
-ct droplet issue add <id> "<file>:<line> [severity] — <vulnerability, attack vector, remediation>"
-```
-
-Use `ct droplet note` for a top-level narrative summary only — not for individual findings.
-
-Every finding note must include file, line, severity, vulnerability class, attack vector, and remediation.
-
-Pass — no blocking or required issues:
-  `ct droplet pass <id> --notes "No security issues found. <one-line summary of diff surface>"`
-
-Recirculate — any blocking or required severity finding:
-  `ct droplet recirculate <id> --notes "<N> <severity> issue: <file>:<line> — <vulnerability>. Remediation: <fix>"`
-
-If ANY finding has severity `blocking` or `required`, use recirculate. This is mechanical.

--- a/cmd/ct/assets/aqueduct/aqueduct.yaml
+++ b/cmd/ct/assets/aqueduct/aqueduct.yaml
@@ -14,12 +14,10 @@ cataractae:
     identity: implementer
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
-        path: skills/cistern-droplet-state/SKILL.md
       - name: cistern-git
-        path: skills/cistern-git/SKILL.md
-      - name: cistern-github
-        path: skills/cistern-github/SKILL.md
+      - name: cistern-test-runner
     timeout_minutes: 30
     on_pass: review
     on_fail: pooled
@@ -30,14 +28,11 @@ cataractae:
     identity: reviewer
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
-        path: skills/cistern-droplet-state/SKILL.md
       - name: cistern-reviewer
-        path: skills/cistern-reviewer/SKILL.md
       - name: cistern-git
-        path: skills/cistern-git/SKILL.md
-      - name: cistern-github
-        path: skills/cistern-github/SKILL.md
+      - name: cistern-diff-reader
     timeout_minutes: 20
     on_pass: qa
     on_fail: implement
@@ -49,10 +44,11 @@ cataractae:
     identity: qa
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
-        path: skills/cistern-droplet-state/SKILL.md
       - name: cistern-git
-        path: skills/cistern-git/SKILL.md
+      - name: cistern-test-runner
+      - name: cistern-diff-reader
     timeout_minutes: 20
     on_pass: security-review
     on_fail: implement
@@ -64,8 +60,9 @@ cataractae:
     identity: security
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
-        path: skills/cistern-droplet-state/SKILL.md
+      - name: cistern-diff-reader
     timeout_minutes: 15
     on_pass: docs
     on_fail: implement
@@ -77,10 +74,10 @@ cataractae:
     identity: docs_writer
     context: full_codebase
     skills:
+      - name: cistern-signaling
       - name: cistern-droplet-state
-        path: skills/cistern-droplet-state/SKILL.md
       - name: cistern-git
-        path: skills/cistern-git/SKILL.md
+      - name: cistern-diff-reader
     timeout_minutes: 20
     on_pass: delivery
     on_fail: implement
@@ -91,12 +88,11 @@ cataractae:
     type: agent
     identity: delivery
     skills:
+      - name: cistern-signaling
       - name: cistern-github
-        path: skills/cistern-github/SKILL.md
       - name: cistern-droplet-state
-        path: skills/cistern-droplet-state/SKILL.md
       - name: cistern-git
-        path: skills/cistern-git/SKILL.md
+      - name: cistern-test-runner
     timeout_minutes: 60
     on_pass: done
     on_recirculate: implement

--- a/cmd/ct/doctor_test.go
+++ b/cmd/ct/doctor_test.go
@@ -2008,6 +2008,9 @@ max_cataractae: 1
 		"cistern-git",
 		"cistern-github",
 		"cistern-reviewer",
+		"cistern-signaling",
+		"cistern-test-runner",
+		"cistern-diff-reader",
 		"critical-code-reviewer",
 	}
 	for _, name := range installerStubs {

--- a/internal/skills/cistern-diff-reader/SKILL.md
+++ b/internal/skills/cistern-diff-reader/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: cistern-diff-reader
+description: Diff reading methodology for Cistern review cataractae. Covers the correct diff command, empty-diff early exit, and the principle of tracing changes to their callers. Use when a cataractae needs to understand what changed in the current droplet.
+---
+
+# Cistern Diff Reader
+
+## Get the Diff
+
+Always use merge-base (not two-dot) to show only this branch's own changes:
+
+```bash
+git diff $(git merge-base HEAD origin/main)..HEAD
+git diff $(git merge-base HEAD origin/main)..HEAD --name-only
+```
+
+Two-dot (`git diff origin/main..HEAD`) includes changes from other PRs that merged
+after branching. Merge-base is always correct.
+
+## Empty Diff
+
+If the diff is empty (0 bytes or whitespace only), signal pass immediately.
+There is nothing to review.
+
+## Read Beyond the Diff
+
+The diff shows what changed. The codebase shows what depended on it staying the same.
+
+For every function or variable the diff modifies:
+1. Find all callers outside the diff: `grep -rn 'funcName' --include='*.go'`
+2. For each caller: does it still work correctly?
+3. For deletions: what references are now broken?
+
+For deletions of files, imports, or type values, look for:
+- Files that import deleted symbols
+- Test files whose subject no longer exists
+- Code paths that produced a value no longer consumed anywhere
+
+## User-Visible vs Internal Changes
+
+Classify changes to determine what needs documentation or broader review:
+- **User-visible**: CLI flags, config options, API contracts, public types, README-level features
+- **Internal**: refactors, test-only changes, internal error handling
+
+Only user-visible changes require documentation updates.

--- a/internal/skills/cistern-droplet-state/SKILL.md
+++ b/internal/skills/cistern-droplet-state/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: cistern-droplet-state
+description: Droplet state management for Cistern cataractae. Use at the end of every session to signal your outcome and manage droplet state via the ct CLI. For role-specific signal permissions, see the cistern-signaling skill.
+---
+
 # Cistern Droplet State
 
 Manage droplet state in the Cistern agentic pipeline using the `ct` CLI.
@@ -42,8 +47,6 @@ ct droplet note <id> "Intermediate finding or progress update."
 ## Rules
 
 1. Always include `--notes` when signaling — describe what you did or found
-2. **Implementer**: signal `pass` when your work is committed and tests pass. Never signal `recirculate` — that is the reviewer's signal. Open issues are for the reviewer to verify and resolve; you cannot resolve your own issues.
-3. **Reviewer/QA/Security**: signal `recirculate` when you have findings that require implementation changes. Signal `pass` when all prior issues are resolved and no new issues found.
-4. Implementer: never push to origin — local commits only
-5. Be specific in notes — "Fixed 3 issues in client.go" not "fixed it"
-6. If CONTEXT.md has revision notes from prior cycles, address every single one
+2. Be specific in notes — "Fixed 3 issues in client.go" not "fixed it"
+3. If CONTEXT.md has revision notes from prior cycles, address every single one
+4. For role-specific signal permissions (which signals your role may use), see the cistern-signaling skill

--- a/internal/skills/cistern-signaling/SKILL.md
+++ b/internal/skills/cistern-signaling/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cistern-signaling
+description: Role-specific signaling permissions for Cistern cataractae. Defines which signals each role may use, when to use each, issue filing, and prior-issue checking. Replaces per-INSTRUCTIONS.md signaling sections — INSTRUCTIONS.md should reference this skill instead of duplicating its content.
+---
+
+# Cistern Signaling Protocol
+
+## Universal Rules
+
+1. Always include `--notes` when signaling — describe what you did or found
+2. Signal MUST be called before session exit — stranding burns resources (see contract #5)
+3. Be specific in notes — "Fixed 3 issues in client.go" not "fixed it"
+4. Never signal recirculate without findings
+
+## Role Permissions
+
+### Implementer
+- **Pass**: implementation committed, tests pass, open issues addressed
+- **Pool**: blocked by external dependency after 3 attempts
+- **Cancel**: item superseded or erroneous
+- **FORBIDDEN**: recirculate — the CLI rejects it. If you addressed review issues, signal pass; the reviewer verifies.
+
+If you discover a design problem during implementation, open an issue:
+`ct droplet issue add <id> "design concern: <description>"`. Continue implementing
+the spec as written, but flag the concern.
+
+If after 3 attempts you cannot make progress:
+`ct droplet pool <id> --notes "Blocked by: <specific reason>"`
+
+### Reviewer
+- **Pass**: zero findings
+- **Recirculate**: ANY findings — mechanical, no judgment calls
+- **FORBIDDEN**: pool — findings go upstream to the implementer, not to humans
+
+### QA
+- **Pass**: tests pass, coverage is solid, no quality gaps
+- **Recirculate**: quality insufficient — name the exact missing cases
+- **Pool**: genuine external blocker requiring human input
+- **FORBIDDEN**: advisory/non-blocking findings — every finding is either needs-fixing or doesn't-exist
+
+### Security
+- **Pass**: no blocking or required severity issues
+- **Recirculate**: any blocking or required severity finding — mechanical
+- **FORBIDDEN**: pool — all findings are code problems to fix
+
+### Docs Writer
+- **Pass**: docs updated, or no user-visible changes found
+- **Recirculate**: ambiguity that blocks docs update
+
+### Delivery
+- **Pass**: PR state is MERGED (confirmed via `gh pr view`)
+- **Recirculate**: after 2 failed fix attempts on the same code-level CI check (with structured diagnostic)
+- **Pool**: merge impossible, or infrastructure CI failure (port conflicts, container failures, DNS errors)
+
+## Issue Filing
+
+Before signaling recirculate, file each finding as a structured issue:
+
+```bash
+ct droplet issue add <id> "<file>:<line> — <specific issue and fix>"
+```
+
+Security findings use extended format:
+```bash
+ct droplet issue add <id> "<file>:<line> [severity] — <vulnerability, attack vector, remediation>"
+```
+
+Use `ct droplet note` for narrative summaries only — not individual findings.
+
+## Prior Issue Check
+
+Before starting work, check for existing open issues:
+
+```bash
+ct droplet issue list <id> --open
+```
+
+Reviewers and security should filter by their role:
+```bash
+ct droplet issue list <id> --flagged-by reviewer --open
+ct droplet issue list <id> --flagged-by security --open
+```
+
+Address every open issue before signaling pass.

--- a/internal/skills/cistern-test-runner/SKILL.md
+++ b/internal/skills/cistern-test-runner/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: cistern-test-runner
+description: Test execution protocol for Cistern cataractae. Detects repo stack and runs the correct test/build commands. Use whenever a cataractae needs to verify code correctness before signaling.
+---
+
+# Cistern Test Runner
+
+## Detect the Stack
+
+Check for these files in the repo root:
+- `go.mod` → Go
+- `package.json` → Node/TypeScript
+- `pytest.ini`, `setup.py`, `pyproject.toml` with pytest → Python
+- `Makefile` with test target → Make
+
+## Build Commands
+
+| Stack | Build |
+|-------|-------|
+| Go | `go build ./...` |
+| Node/TS | `npm run build` or `tsc --noEmit` |
+| Python | (no compile step) |
+| Make | `make build` |
+
+## Test Commands
+
+| Stack | Test |
+|-------|------|
+| Go | `go test ./...` |
+| Node/TS | `npm test` |
+| Python | `pytest` |
+| Make | `make test` |
+
+## Lint Commands
+
+| Stack | Lint |
+|-------|------|
+| Go | `go vet ./...` |
+| Node/TS | `npm run lint` |
+| Python | `ruff check .` |
+| Make | `make lint` |
+
+## Rules
+
+1. Always run build before tests
+2. Run the full test suite (no `-run` filtering) unless diagnosing a specific failure
+3. Signal pass only after all tests pass
+4. Failing tests = automatic recirculate (for review/QA cataractae) or must-fix (for implementer)

--- a/tests/installer/run-tests.sh
+++ b/tests/installer/run-tests.sh
@@ -160,7 +160,7 @@ _reset_scenario_state() {
 # the default aqueduct workflow. Satisfies both ct doctor and
 # ct castellarius start validation without requiring network access.
 _install_skill_stubs() {
-    local _skills="cistern-droplet-state cistern-git cistern-github code-simplifier critical-code-reviewer reviewer"
+    local _skills="cistern-droplet-state cistern-git cistern-github cistern-reviewer cistern-signaling cistern-test-runner cistern-diff-reader code-simplifier critical-code-reviewer"
     for _skill in ${_skills}; do
         mkdir -p "${HOME}/.cistern/skills/${_skill}"
         printf "# Test stub for %s\n" "${_skill}" > "${HOME}/.cistern/skills/${_skill}/SKILL.md"


### PR DESCRIPTION
## Summary

Create 3 new agent skills to eliminate content duplicated across INSTRUCTIONS.md files, moving toward a "skill-first" architecture where shared behavior lives in skills and per-cataractae instructions reference those skills.

**New skills:**
- `cistern-signaling` — role-specific signal permissions (implementer can't recirculate, reviewer can't pool, delivery's 2-attempt rule), issue filing, prior-issue checking. Replaces duplicated signaling sections across all 6 cataractae.
- `cistern-test-runner` — stack detection + build/test/lint commands. Replaces test table duplicated in implementer and QA.
- `cistern-diff-reader` — merge-base diff commands, empty-diff early exit, "read beyond the diff" methodology, user-visible classification. Shared by reviewer, security, docs_writer, QA.

**Updated skills:**
- `cistern-droplet-state` — removed role-specific signaling rules (moved to `cistern-signaling`) and implementer push rule (already in `cistern-git`)

**Other fixes:**
- Sync `cmd/ct/assets/aqueduct/aqueduct.yaml` with canonical workflow (was stale)
- Remove remaining inlined git/diff commands from docs_writer and implementer INSTRUCTIONS.md
- Add new skills to doctor test stubs and installer scripts

All 6 INSTRUCTIONS.md files now reference skills instead of inlining their content. AGENTS.md total: 37,878 → 18,862 chars (50% reduction across both rounds).

All tests pass including the doctor installer stubs test.