### PR TITLE
Exclude instructions file (AGENTS.md) from git operations in worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Exclude provider InstructionsFile from git operations in worktrees (ci-czkeg)
+
+The Castellarius now excludes the provider's InstructionsFile (e.g. `AGENTS.md` for opencode/codex, `CLAUDE.md` for claude, `GEMINI.md` for gemini) from all git operations in worktrees, alongside `CONTEXT.md` and `.current-stage`. Previously, the cataractae prompt overwritten into the InstructionsFile by the Castellarius could be committed back to the repo, replacing the repo's own content (e.g. Lobsterdog's personality file being replaced with the Cistern cataractae template).
+
+**Key changes:**
+- **`uncommittedFiles()` exclusion**: The provider's InstructionsFile is now excluded from the uncommitted-files check at dispatch time, preventing it from appearing in the "Uncommitted Files from Prior Session" section of CONTEXT.md
+- **`cistern-git` skill updated**: Staging and committing rules now exclude the InstructionsFile alongside CONTEXT.md (`git add -A -- ':!CONTEXT.md' ':!<InstructionsFile>'`)
+- **Delivery cataractae updated**: All `git add` commands in `cataractae/delivery/INSTRUCTIONS.md` now exclude the InstructionsFile
+- **Dynamic filename**: The filename is resolved from the active provider preset (not hardcoded), so all providers (claude, codex, gemini, copilot, opencode) are handled correctly
+
+**Files changed:**
+- `internal/cataractae/context.go` — `InstructionsFile` field on `ContextParams`, passed to `uncommittedFiles()` exclusion map
+- `internal/cataractae/runner.go` — passes `r.preset.InstrFile()` to `ContextParams`
+- `internal/cataractae/context_test.go` — tests for InstructionsFile exclusion, backward compatibility, and custom filenames
+- `internal/skills/cistern-git/SKILL.md` — staging and committing rules updated
+- `cataractae/delivery/INSTRUCTIONS.md` — git add exclusions and rule added
+
 <<### ct status / dashboard: show droplet stage age alongside overall elapsed (ci-r2cby)
 
 All display surfaces now show how long each flowing droplet has been in its current cataractae stage (e.g., `2m14s (stage 30s)`), helping operators quickly identify stale or slow droplets without checking the full log.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ myproject-virgo: 1 windows (review)
 myproject-marcia: 1 windows (implement)
 ```
 
-Before dispatching a droplet, the Castellarius checks the worktree for uncommitted files. If non-`CONTEXT.md` files are dirty, the droplet is recirculated with a diagnostic note rather than spawning an agent into inconsistent state.
+Before dispatching a droplet, the Castellarius checks the worktree for uncommitted files. If files are dirty (excluding `CONTEXT.md`, `.current-stage`, and the provider's InstructionsFile like `AGENTS.md` or `CLAUDE.md`), the droplet is recirculated with a diagnostic note rather than spawning an agent into inconsistent state.
 
 By convention, aqueduct names are drawn from historic Roman aqueducts (`virgo`, `marcia`, `claudia`, `traiana`, `julia`, `appia`, `anio`, `tepula`, `alexandrina`, …), but any names work.
 
@@ -284,11 +284,11 @@ Skills are referenced by name in your aqueduct YAML under each cataractae's `ski
 | Skill | Purpose | Cataractae |
 |---|---|---|
 | `cistern-droplet-state` | Signal pass/recirculate/block with `ct` CLI | All |
-| `cistern-git` | Git conventions: exclude CONTEXT.md, merge-base diff, no stash | implement, docs, delivery |
+| `cistern-git` | Git conventions: exclude CONTEXT.md and InstructionsFile, merge-base diff, no stash | implement, docs, delivery |
 | `cistern-github` | PR creation, CI checks, squash-merge, and automatic conflict resolution for Cistern delivery | implement, review, delivery |
 | `cistern-reviewer` | Adversarial code review for Go, TypeScript/Next.js, and TypeScript/React — all findings equal, recirculate on any finding, pass only when nothing remains | review |
 
-The `cistern-git` skill encodes hard-won rules: always use `git add -A -- ':!CONTEXT.md'`, always use merge-base diff (`git diff $(git merge-base HEAD origin/main)..HEAD`) instead of two-dot — two-dot includes other PRs that merged to main after branching on unrebased branches, never stash in per-droplet worktrees.
+The `cistern-git` skill encodes hard-won rules: always use `git add -A -- ':!CONTEXT.md' ':!<InstructionsFile>'` (where `<InstructionsFile>` is the provider-specific filename like `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`), always use merge-base diff (`git diff $(git merge-base HEAD origin/main)..HEAD`) instead of two-dot — two-dot includes other PRs that merged to main after branching on unrebased branches, never stash in per-droplet worktrees.
 
 ## Drought Protocols
 

--- a/cataractae/delivery/INSTRUCTIONS.md
+++ b/cataractae/delivery/INSTRUCTIONS.md
@@ -37,7 +37,7 @@ go mod tidy && go build ./...
 
 If go.mod/go.sum changed, commit the tidy:
 ```bash
-git add go.mod go.sum -- ':!CONTEXT.md'
+git add go.mod go.sum -- ':!CONTEXT.md' ':!<InstructionsFile>'
 git commit -m "chore: go mod tidy"
 ```
 
@@ -96,7 +96,7 @@ For each conflicted file:
 
 After resolving:
 ```bash
-git add $(git diff --name-only --diff-filter=U) -- ':!CONTEXT.md'
+git add $(git diff --name-only --diff-filter=U) -- ':!CONTEXT.md' ':!<InstructionsFile>'
 git rebase --continue
 # Adapt: see cistern-test-runner
 go build ./... && go test ./...
@@ -140,7 +140,7 @@ recirculate with a structured diagnostic (see below).
 
 Attempt 1: apply a fix or rerun the check. Commit:
 ```bash
-git add -A -- ':!CONTEXT.md'
+git add -A -- ':!CONTEXT.md' ':!<InstructionsFile>'
 git commit -m "fix: <specific issue>" && git push
 ```
 
@@ -191,3 +191,4 @@ ct droplet pool $DROPLET_ID --notes "Cannot merge: <exact reason> — $PR_URL"
 - Build + test must pass before every push
 - Fix CI, conflicts, and review comments yourself — recirculate only after 2 failed fix attempts
 - Recirculate only for code-level failures — pool for infrastructure failures
+- Never commit the provider's InstructionsFile (AGENTS.md for opencode/codex, CLAUDE.md for claude, GEMINI.md for gemini) — it is overwritten by the Castellarius and must be excluded from all git add operations alongside CONTEXT.md

--- a/internal/cataractae/context.go
+++ b/internal/cataractae/context.go
@@ -50,6 +50,11 @@ type ContextParams struct {
 	// Logger is used to log non-fatal errors (e.g. SetLastReviewedCommit failures).
 	// If nil, slog.Default() is used.
 	Logger *slog.Logger
+	// InstructionsFile is the provider-specific filename written into the worktree
+	// (e.g. "AGENTS.md" for opencode/codex, "CLAUDE.md" for claude, "GEMINI.md" for gemini).
+	// It is excluded from all git operations alongside CONTEXT.md and .current-stage
+	// to prevent the cataractae prompt from being committed back to the repo.
+	InstructionsFile string
 }
 
 func (p ContextParams) logger() *slog.Logger {
@@ -180,7 +185,7 @@ func writeContextFile(path string, p ContextParams) error {
 	}
 
 	if p.Level == aqueduct.ContextFullCodebase || p.Level == "" {
-		if dirty, err := uncommittedFiles(p.SandboxDir); err == nil && len(dirty) > 0 {
+		if dirty, err := uncommittedFiles(p.SandboxDir, []string{p.InstructionsFile}); err == nil && len(dirty) > 0 {
 			b.WriteString("### Uncommitted Files from Prior Session\n\n")
 			b.WriteString("The worktree has uncommitted changes from a prior agent session.\n")
 			b.WriteString("You MUST commit these changes before making new ones.\n")
@@ -431,13 +436,23 @@ func skillDescription(name string) string {
 }
 
 // uncommittedFiles returns a list of modified/staged files (excluding CONTEXT.md,
-// .current-stage, and untracked files) in the given directory. Returns nil on error.
-func uncommittedFiles(dir string) ([]string, error) {
+// .current-stage, untracked files, and any additional filenames in exclude) in the
+// given directory. Returns nil on error.
+func uncommittedFiles(dir string, exclude []string) ([]string, error) {
 	cmd := exec.Command("git", "status", "--porcelain")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
+	}
+	excluded := map[string]bool{
+		"CONTEXT.md":     true,
+		".current-stage": true,
+	}
+	for _, name := range exclude {
+		if name != "" {
+			excluded[name] = true
+		}
 	}
 	var files []string
 	for _, line := range strings.Split(string(out), "\n") {
@@ -449,7 +464,7 @@ func uncommittedFiles(dir string) ([]string, error) {
 			continue
 		}
 		name := strings.TrimSpace(line[3:])
-		if name != "CONTEXT.md" && name != ".current-stage" {
+		if !excluded[name] {
 			files = append(files, name)
 		}
 	}

--- a/internal/cataractae/context_test.go
+++ b/internal/cataractae/context_test.go
@@ -489,7 +489,8 @@ func TestWriteContextFile_RecentStepNotes_MatchesByIdentity(t *testing.T) {
 // TestWriteContextFile_ExternalRef_WrittenToContextMd verifies that when a
 // droplet has an ExternalRef set, writeContextFile emits it in the exact format
 // that the delivery cataractae shell script greps for:
-//   grep '^\*\*External Ref:\*\*' CONTEXT.md | awk '{print $3}'
+//
+//	grep '^\*\*External Ref:\*\*' CONTEXT.md | awk '{print $3}'
 //
 // Given: a droplet with ExternalRef "jira:DPF-456"
 // When:  writeContextFile is called
@@ -673,5 +674,167 @@ func TestReadSkillDescription_WithFrontmatter_DoesNotReturnDashes(t *testing.T) 
 	}
 	if got == "" {
 		t.Error("readSkillDescription must return a non-empty description")
+	}
+}
+
+// TestUncommittedFiles_ExcludesInstructionsFile verifies that uncommittedFiles
+// excludes the provider's InstructionsFile (e.g. AGENTS.md) from the list of
+// dirty files, preventing the cataractae's overwritten prompt from being
+// committed back to the repo (bug ci-czkeg).
+//
+// Given: a repo with modified CONTEXT.md, .current-stage, and AGENTS.md
+// When:  uncommittedFiles is called with exclude=[]string{"AGENTS.md"}
+// Then:  AGENTS.md is excluded alongside CONTEXT.md and .current-stage
+func TestUncommittedFiles_ExcludesInstructionsFile(t *testing.T) {
+	dir := initTestRepo(t)
+
+	// Modify files to make them appear in git status --porcelain.
+	for _, name := range []string{"CONTEXT.md", ".current-stage", "AGENTS.md", "feature.go"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("modified\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Stage them so they appear as modified (not untracked).
+	runGit(t, dir, "add", "CONTEXT.md", ".current-stage", "AGENTS.md", "feature.go")
+
+	files, err := uncommittedFiles(dir, []string{"AGENTS.md"})
+	if err != nil {
+		t.Fatalf("uncommittedFiles: %v", err)
+	}
+
+	hasFile := func(name string) bool {
+		for _, f := range files {
+			if f == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	if hasFile("CONTEXT.md") {
+		t.Error("CONTEXT.md must be excluded from uncommittedFiles")
+	}
+	if hasFile(".current-stage") {
+		t.Error(".current-stage must be excluded from uncommittedFiles")
+	}
+	if hasFile("AGENTS.md") {
+		t.Error("AGENTS.md (InstructionsFile) must be excluded from uncommittedFiles (bug ci-czkeg)")
+	}
+	if !hasFile("feature.go") {
+		t.Error("feature.go must appear in uncommittedFiles — it is a legitimate change")
+	}
+}
+
+// TestUncommittedFiles_NoExcludeKeepsAll verifies that when no extra exclude
+// list is provided (nil), only CONTEXT.md and .current-stage are excluded —
+// backward-compatible behavior.
+func TestUncommittedFiles_NoExcludeKeepsAll(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("modified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "feature.go"), []byte("modified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "AGENTS.md", "feature.go")
+
+	files, err := uncommittedFiles(dir, nil)
+	if err != nil {
+		t.Fatalf("uncommittedFiles: %v", err)
+	}
+
+	hasFile := func(name string) bool {
+		for _, f := range files {
+			if f == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	if hasFile("CONTEXT.md") {
+		t.Error("CONTEXT.md must always be excluded")
+	}
+	if !hasFile("AGENTS.md") {
+		t.Error("AGENTS.md must appear when not in exclude list (backward compat)")
+	}
+	if !hasFile("feature.go") {
+		t.Error("feature.go must appear in uncommittedFiles")
+	}
+}
+
+// TestUncommittedFiles_CustomInstructionsFile verifies that a non-default
+// InstructionsFile (e.g. GEMINI.md, CLAUDE.md) is also excluded when specified.
+func TestUncommittedFiles_CustomInstructionsFile(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := os.WriteFile(filepath.Join(dir, "GEMINI.md"), []byte("modified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "GEMINI.md")
+
+	files, err := uncommittedFiles(dir, []string{"GEMINI.md"})
+	if err != nil {
+		t.Fatalf("uncommittedFiles: %v", err)
+	}
+
+	for _, f := range files {
+		if f == "GEMINI.md" {
+			t.Error("GEMINI.md must be excluded when passed in exclude list (ci-czkeg)")
+		}
+	}
+}
+
+// TestWriteContextFile_UncommittedFilesSectionExcludesInstructionsFile verifies
+// that when a worktree has a dirty InstructionsFile, the "Uncommitted Files from
+// Prior Session" section in CONTEXT.md does NOT list it (ci-czkeg).
+//
+// Given: a repo with modified AGENTS.md and feature.go
+// When:  writeContextFile is called with InstructionsFile="AGENTS.md"
+// Then:  the uncommitted files section lists feature.go but NOT AGENTS.md
+func TestWriteContextFile_UncommittedFilesSectionExcludesInstructionsFile(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("modified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "AGENTS.md", "feature.go")
+
+	item := &cistern.Droplet{ID: "ci-czkeg-t1", Title: "Test", Status: "in_progress"}
+	step := &aqueduct.WorkflowCataractae{Name: "implement", Type: "agent"}
+
+	p := ContextParams{
+		Item:             item,
+		Step:             step,
+		SandboxDir:       dir,
+		InstructionsFile: "AGENTS.md",
+	}
+
+	ctxPath := filepath.Join(t.TempDir(), "CONTEXT.md")
+	if err := writeContextFile(ctxPath, p); err != nil {
+		t.Fatalf("writeContextFile: %v", err)
+	}
+
+	content, err := os.ReadFile(ctxPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(content)
+
+	sectionIdx := strings.Index(got, "Uncommitted Files from Prior Session")
+	if sectionIdx == -1 {
+		t.Skip("No uncommitted files section — test expects dirty worktree")
+	}
+	section := got[sectionIdx:]
+
+	if strings.Contains(section, "AGENTS.md") {
+		t.Error("AGENTS.md must NOT appear in uncommitted files section (ci-czkeg)")
+	}
+	if !strings.Contains(section, "feature.go") {
+		t.Error("feature.go must appear in uncommitted files section")
 	}
 }

--- a/internal/cataractae/runner.go
+++ b/internal/cataractae/runner.go
@@ -224,13 +224,14 @@ func (r *Runner) SpawnStep(w *Worker, item *cistern.Droplet, step *aqueduct.Work
 	}
 
 	ctxDir, cleanup, err := PrepareContext(ContextParams{
-		Level:       step.Context,
-		SandboxDir:  sandboxDir,
-		Item:        item,
-		Step:        step,
-		Notes:       notes,
-		OpenIssues:  openIssues,
-		QueueClient: r.queue,
+		Level:            step.Context,
+		SandboxDir:       sandboxDir,
+		Item:             item,
+		Step:             step,
+		Notes:            notes,
+		OpenIssues:       openIssues,
+		QueueClient:      r.queue,
+		InstructionsFile: r.preset.InstrFile(),
 	})
 	if err != nil {
 		return fmt.Errorf("context: %w", err)

--- a/internal/skills/cistern-git/SKILL.md
+++ b/internal/skills/cistern-git/SKILL.md
@@ -10,20 +10,26 @@ description: Git conventions for Cistern aqueduct cataractae. Use for all git op
 Each droplet has an isolated worktree at `~/.cistern/sandboxes/<repo>/<droplet-id>/`.
 The Castellarius creates and cleans up worktrees. Agents never run `git worktree add/remove`.
 
-## Staging — always exclude CONTEXT.md
+## Staging — always exclude CONTEXT.md and InstructionsFile
 
-CONTEXT.md is written by the Castellarius on every dispatch. Never commit it.
+CONTEXT.md is written by the Castellarius on every dispatch. The provider's
+InstructionsFile (e.g. AGENTS.md for opencode/codex, CLAUDE.md for claude,
+GEMINI.md for gemini) is also overwritten by the Castellarius with the
+cataractae prompt. Never commit either file.
 
 ```bash
-git add -A -- ':!CONTEXT.md'
-git status --short   # verify no CONTEXT.md, no binaries
+git add -A -- ':!CONTEXT.md' ':!<InstructionsFile>'
+git status --short   # verify no CONTEXT.md, no InstructionsFile, no binaries
 ```
+
+Replace `<InstructionsFile>` with the provider-specific filename from the
+active preset (determined by `provider.ProviderPreset.InstrFile()`).
 
 ## Committing — verify HEAD advances
 
 ```bash
 BEFORE=$(git rev-parse HEAD)
-git add -A -- ':!CONTEXT.md'
+git add -A -- ':!CONTEXT.md' ':!<InstructionsFile>'
 git commit -m "<droplet-id>: <description>"
 AFTER=$(git rev-parse HEAD)
 if [ "$BEFORE" = "$AFTER" ]; then
@@ -32,6 +38,9 @@ if [ "$BEFORE" = "$AFTER" ]; then
   exit 1
 fi
 ```
+
+Replace `<InstructionsFile>` with the provider-specific filename (e.g. AGENTS.md
+for opencode/codex, CLAUDE.md for claude).
 
 ## Diffing — always use merge-base
 


### PR DESCRIPTION
Closes droplet ci-czkeg.