### PR TITLE
feat: add ct evaluate command for pipeline quality measurement

### DIFF
--- a/cmd/ct/cistern.go
+++ b/cmd/ct/cistern.go
@@ -1598,6 +1598,7 @@ func init() {
 		dropletExportCmd, dropletRenameCmd, dropletRestartCmd, dropletEditCmd,
 		dropletTailCmd, dropletHeartbeatCmd, dropletLogCmd, dropletHistoryCmd)
 	rootCmd.AddCommand(dropletCmd)
+	rootCmd.AddCommand(evaluateCmd)
 }
 
 // parseComplexity accepts "1"-"3" or names "standard","full","critical".

--- a/cmd/ct/evaluate.go
+++ b/cmd/ct/evaluate.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/MichielDean/cistern/internal/evaluate"
+	"github.com/spf13/cobra"
+)
+
+var evaluateCmd = &cobra.Command{
+	Use:   "evaluate",
+	Short: "Score code changes against the Cistern quality rubric",
+	Long: `Evaluate scores a diff or PR against the Cistern quality rubric.
+
+This produces structured scores across 8 dimensions, each on a 0-5 scale:
+  - contract_correctness: Does every method do what its signature promises?
+  - integration_coverage: Do new code paths have integration tests?
+  - coupling: Is new code coupled to specific entities when it could be generic?
+  - migration_safety: Do migrations follow safe practices?
+  - idiom_fit: Does the code use the framework's idiomatic patterns?
+  - dry: Are repeated patterns extracted into helpers?
+  - naming_clarity: Are types and methods honestly named?
+  - error_messages: Are error messages actionable?
+
+Use --diff to score an existing diff, --pr to score a PR, or leave flags
+empty to score the current branch against main.`,
+	RunE: runEvaluate,
+}
+
+var (
+	evalDiff   string
+	evalBase   string
+	evalHead   string
+	evalPR     int
+	evalTicket string
+	evalSource string
+	evalBranch string
+	evalCommit string
+	evalModel  string
+	evalOutput string
+	evalFormat string
+)
+
+func init() {
+	rootCmd.AddCommand(evaluateCmd)
+
+	evaluateCmd.Flags().StringVarP(&evalDiff, "diff", "d", "", "Raw diff content to evaluate")
+	evaluateCmd.Flags().StringVar(&evalBase, "base", "main", "Base branch for diff (default: main)")
+	evaluateCmd.Flags().StringVar(&evalHead, "head", "", "Head branch for diff (default: current branch)")
+	evaluateCmd.Flags().IntVarP(&evalPR, "pr", "p", 0, "PR number to evaluate")
+	evaluateCmd.Flags().StringVarP(&evalTicket, "ticket", "t", "", "Jira/ticket ID for comparative evaluation")
+	evaluateCmd.Flags().StringVar(&evalSource, "source", "cistern", "Source label (e.g., 'cistern' or 'vibe-coded')")
+	evaluateCmd.Flags().StringVar(&evalBranch, "branch", "", "Branch name (default: current branch)")
+	evaluateCmd.Flags().StringVar(&evalCommit, "commit", "", "Commit SHA (default: HEAD)")
+	evaluateCmd.Flags().StringVar(&evalModel, "model", "", "LLM model to use for evaluation (default: auto-detect)")
+	evaluateCmd.Flags().StringVarP(&evalOutput, "output", "o", "", "Output file path (default: stdout)")
+	evaluateCmd.Flags().StringVarP(&evalFormat, "format", "f", "json", "Output format: json or markdown")
+}
+
+func runEvaluate(cmd *cobra.Command, args []string) error {
+	diff, err := resolveDiff()
+	if err != nil {
+		return err
+	}
+
+	if diff == "" {
+		return fmt.Errorf("no diff provided -- use --diff, --base/--head, or --pr")
+	}
+
+	if evalSource == "" {
+		evalSource = "unknown"
+	}
+
+	if evalBranch == "" {
+		evalBranch = currentBranch()
+	}
+
+	if evalCommit == "" {
+		evalCommit = "HEAD"
+	}
+
+	if evalModel == "" {
+		evalModel = "auto"
+	}
+
+	result, err := evaluate.Evaluate(diff, evalModel, evalSource, evalTicket, evalBranch, evalCommit)
+	if err != nil {
+		return fmt.Errorf("evaluation failed: %w", err)
+	}
+
+	result.Timestamp = time.Now().UTC().Format(time.RFC3339)
+
+	var output []byte
+	switch strings.ToLower(evalFormat) {
+	case "markdown", "md":
+		output = []byte(formatMarkdown(result))
+	case "json":
+		output, err = json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshaling result: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown format: %s (use json or markdown)", evalFormat)
+	}
+
+	if evalOutput != "" {
+		if err := os.WriteFile(evalOutput, output, 0644); err != nil {
+			return fmt.Errorf("writing output: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Evaluation written to %s\n", evalOutput)
+	} else {
+		fmt.Println(string(output))
+	}
+
+	return nil
+}
+
+func resolveDiff() (string, error) {
+	if evalDiff != "" {
+		return evalDiff, nil
+	}
+
+	if evalPR > 0 {
+		input := evaluate.DiffInput{
+			Source:   evaluate.DiffFromPR,
+			PRNumber: evalPR,
+		}
+		return input.GetDiff()
+	}
+
+	if evalHead == "" {
+		evalHead = currentBranch()
+	}
+	input := evaluate.DiffInput{
+		Source:     evaluate.DiffFromBranches,
+		BaseBranch: evalBase,
+		HeadBranch: evalHead,
+	}
+	return input.GetDiff()
+}
+
+func currentBranch() string {
+	out, err := exec.Command("git", "branch", "--show-current").Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func formatMarkdown(r *evaluate.Result) string {
+	var sb strings.Builder
+
+	sb.WriteString("# Code Quality Evaluation\n\n")
+	sb.WriteString(fmt.Sprintf("- **Source:** %s\n", r.Source))
+	if r.Ticket != "" {
+		sb.WriteString(fmt.Sprintf("- **Ticket:** %s\n", r.Ticket))
+	}
+	sb.WriteString(fmt.Sprintf("- **Branch:** %s\n", r.Branch))
+	sb.WriteString(fmt.Sprintf("- **Model:** %s\n", r.Model))
+	sb.WriteString(fmt.Sprintf("- **Score:** %d/%d (%.0f%%)\n", r.TotalScore, r.MaxScore, r.Percentage()))
+	sb.WriteString(fmt.Sprintf("- **Evaluated:** %s\n\n", r.Timestamp))
+
+	sb.WriteString("| Dimension | Score | Evidence |\n")
+	sb.WriteString("|---|---|---|\n")
+	for _, s := range r.Scores {
+		sb.WriteString(fmt.Sprintf("| %s | %d/5 | %s |\n", s.Dimension, s.Score, s.Evidence))
+	}
+
+	if r.Notes != "" {
+		sb.WriteString(fmt.Sprintf("\n## Notes\n\n%s\n", r.Notes))
+	}
+
+	return sb.String()
+}

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -1,0 +1,150 @@
+package evaluate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// DiffSource represents where the diff comes from.
+type DiffSource int
+
+const (
+	// DiffFromBranches computes the merge-base diff between two branches.
+	DiffFromBranches DiffSource = iota
+	// DiffFromPR fetches the diff from an existing PR.
+	DiffFromPR
+	// DiffFromRaw is provided directly (e.g., from a file).
+	DiffFromRaw
+)
+
+// DiffInput specifies what to evaluate.
+type DiffInput struct {
+	Source DiffSource
+	// For DiffFromBranches: base and head branch names (e.g., "main", "feat/fix-thing")
+	BaseBranch string
+	HeadBranch string
+	// For DiffFromPR: PR number
+	PRNumber int
+	// For DiffFromRaw: the diff content
+	RawDiff string
+	// Working directory for git commands
+	WorkDir string
+}
+
+// GetDiff returns the diff content based on the source.
+func (d DiffInput) GetDiff() (string, error) {
+	switch d.Source {
+	case DiffFromBranches:
+		return d.getBranchDiff()
+	case DiffFromPR:
+		return d.getPRDiff()
+	case DiffFromRaw:
+		return d.RawDiff, nil
+	default:
+		return "", fmt.Errorf("unknown diff source: %d", d.Source)
+	}
+}
+
+func (d DiffInput) getBranchDiff() (string, error) {
+	if d.BaseBranch == "" {
+		d.BaseBranch = "main"
+	}
+	if d.HeadBranch == "" {
+		return "", fmt.Errorf("head branch is required for branch diff")
+	}
+	// git diff $(git merge-base HEAD origin/main)..HEAD
+	mergeBase, err := exec.Command("git", "merge-base", d.HeadBranch, d.BaseBranch).Output()
+	if err != nil {
+		return "", fmt.Errorf("git merge-base: %w", err)
+	}
+	cmd := exec.Command("git", "diff", strings.TrimSpace(string(mergeBase))+".."+d.HeadBranch)
+	if d.WorkDir != "" {
+		cmd.Dir = d.WorkDir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git diff: %w", err)
+	}
+	return string(out), nil
+}
+
+func (d DiffInput) getPRDiff() (string, error) {
+	if d.PRNumber == 0 {
+		return "", fmt.Errorf("PR number is required for PR diff")
+	}
+	cmd := exec.Command("gh", "pr", "diff", fmt.Sprintf("%d", d.PRNumber))
+	if d.WorkDir != "" {
+		cmd.Dir = d.WorkDir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh pr diff: %w", err)
+	}
+	return string(out), nil
+}
+
+// Evaluate uses an LLM to score the given diff against the rubric.
+// The model parameter specifies which LLM to use (e.g., "claude-sonnet-4-20250514").
+// The evaluator runs as an independent adversary, not as the code's author.
+func Evaluate(diff string, model string, source string, ticket string, branch string, commit string) (*Result, error) {
+	if diff == "" {
+		return nil, fmt.Errorf("diff is empty — nothing to evaluate")
+	}
+
+	// For now, return a placeholder result. The actual LLM invocation
+	// will be wired up in a follow-up commit when we integrate with
+	// the provider system.
+	//
+	// The prompt is ready in ScoringPrompt — we need to:
+	// 1. Format the prompt with the diff
+	// 2. Call the LLM
+	// 3. Parse the JSON response
+	// 4. Validate and return
+
+	result := &Result{
+		Source:     source,
+		Ticket:     ticket,
+		Branch:     branch,
+		Commit:     commit,
+		Model:      model,
+		Scores:     []Score{},
+		TotalScore: 0,
+		MaxScore:   len(AllDimensions()) * 5,
+		Notes:      "Evaluation not yet implemented — rubric and scoring structure is defined",
+		Timestamp:  "", // set by caller
+	}
+
+	return result, nil
+}
+
+// ParseEvaluationResult parses the LLM's JSON response into a Result.
+func ParseEvaluationResult(body string) (*Result, error) {
+	var result Result
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		return nil, fmt.Errorf("parsing evaluation result: %w", err)
+	}
+
+	// Validate dimensions
+	validDims := make(map[Dimension]bool)
+	for _, d := range AllDimensions() {
+		validDims[d] = true
+	}
+
+	totalScore := 0
+	for _, s := range result.Scores {
+		if !validDims[s.Dimension] {
+			return nil, fmt.Errorf("unknown dimension: %s", s.Dimension)
+		}
+		if s.Score < 0 || s.Score > 5 {
+			return nil, fmt.Errorf("score for %s must be 0-5, got %d", s.Dimension, s.Score)
+		}
+		totalScore += s.Score
+	}
+
+	result.TotalScore = totalScore
+	result.MaxScore = len(AllDimensions()) * 5
+
+	return &result, nil
+}

--- a/internal/evaluate/evaluate_test.go
+++ b/internal/evaluate/evaluate_test.go
@@ -1,0 +1,176 @@
+package evaluate
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAllDimensions(t *testing.T) {
+	dims := AllDimensions()
+	if len(dims) != 8 {
+		t.Errorf("expected 8 dimensions, got %d", len(dims))
+	}
+
+	seen := make(map[Dimension]bool)
+	for _, d := range dims {
+		if seen[d] {
+			t.Errorf("duplicate dimension: %s", d)
+		}
+		seen[d] = true
+		desc := DimensionDescription(d)
+		if desc == "unknown dimension" {
+			t.Errorf("dimension %s has no description", d)
+		}
+		if desc == "" {
+			t.Errorf("dimension %s has empty description", d)
+		}
+	}
+}
+
+func TestDimensionDescriptions(t *testing.T) {
+	desc := dimensionDescriptions()
+	if desc == "" {
+		t.Error("expected non-empty dimension descriptions")
+	}
+	for _, d := range AllDimensions() {
+		if !contains(desc, string(d)) {
+			t.Errorf("dimension descriptions missing: %s", d)
+		}
+	}
+}
+
+func TestScoringPrompt(t *testing.T) {
+	prompt := ScoringPrompt()
+	if prompt == "" {
+		t.Error("expected non-empty scoring prompt")
+	}
+	for _, d := range AllDimensions() {
+		if !contains(prompt, string(d)) {
+			t.Errorf("scoring prompt missing dimension: %s", d)
+		}
+	}
+}
+
+func TestParseEvaluationResult(t *testing.T) {
+	body := `{
+		"source": "cistern",
+		"ticket": "PROJ-123",
+		"branch": "feat/fix",
+		"commit": "abc123",
+		"model": "claude-sonnet-4-20250514",
+		"scores": [
+			{"dimension": "contract_correctness", "score": 4, "evidence": "all methods honor contracts", "suggested": "n/a"},
+			{"dimension": "integration_coverage", "score": 3, "evidence": "missing test for loadPermissions", "suggested": "add integration test"},
+			{"dimension": "coupling", "score": 2, "evidence": "hardcoded OrganizationTable.id", "suggested": "parameterize"},
+			{"dimension": "migration_safety", "score": 5, "evidence": "no migrations in diff", "suggested": "n/a"},
+			{"dimension": "idiom_fit", "score": 3, "evidence": "uses inSubQuery instead of Exists", "suggested": "use Exposed Exists DSL"},
+			{"dimension": "dry", "score": 1, "evidence": "same bool extraction repeated 13 times", "suggested": "extract boolPerm helper"},
+			{"dimension": "naming_clarity", "score": 2, "evidence": "PermissionColumnName is misleading", "suggested": "rename to PermissionName"},
+			{"dimension": "error_messages", "score": 4, "evidence": "requireCatalogPermissionId is specific", "suggested": "n/a"}
+		],
+		"notes": "Significant issues with DRY and coupling."
+	}`
+
+	result, err := ParseEvaluationResult(body)
+	if err != nil {
+		t.Fatalf("ParseEvaluationResult failed: %v", err)
+	}
+
+	if result.Source != "cistern" {
+		t.Errorf("expected source 'cistern', got %q", result.Source)
+	}
+	if result.Ticket != "PROJ-123" {
+		t.Errorf("expected ticket 'PROJ-123', got %q", result.Ticket)
+	}
+	if len(result.Scores) != 8 {
+		t.Errorf("expected 8 scores, got %d", len(result.Scores))
+	}
+	if result.TotalScore != 24 {
+		t.Errorf("expected total score 24, got %d", result.TotalScore)
+	}
+	if result.MaxScore != 40 {
+		t.Errorf("expected max score 40, got %d", result.MaxScore)
+	}
+	pct := result.Percentage()
+	if pct != 60.0 {
+		t.Errorf("expected 60%%, got %.0f%%", pct)
+	}
+}
+
+func TestParseEvaluationResult_UnknownDimension(t *testing.T) {
+	body := `{
+		"scores": [
+			{"dimension": "unknown_thing", "score": 5, "evidence": "test", "suggested": "test"}
+		]
+	}`
+
+	_, err := ParseEvaluationResult(body)
+	if err == nil {
+		t.Error("expected error for unknown dimension")
+	}
+}
+
+func TestParseEvaluationResult_InvalidScore(t *testing.T) {
+	body := `{
+		"scores": [
+			{"dimension": "contract_correctness", "score": 7, "evidence": "test", "suggested": "test"}
+		]
+	}`
+
+	_, err := ParseEvaluationResult(body)
+	if err == nil {
+		t.Error("expected error for score > 5")
+	}
+}
+
+func TestResultJSON(t *testing.T) {
+	r := &Result{
+		Source:     "cistern",
+		Ticket:     "PROJ-123",
+		Branch:     "feat/fix",
+		Commit:     "abc123",
+		Model:      "test",
+		Scores:     []Score{},
+		TotalScore: 0,
+		MaxScore:   40,
+		Notes:      "test",
+		Timestamp:  "2026-04-17T00:00:00Z",
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var r2 Result
+	if err := json.Unmarshal(data, &r2); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if r2.Source != "cistern" {
+		t.Errorf("expected source 'cistern', got %q", r2.Source)
+	}
+}
+
+func TestEvaluate_EmptyDiff(t *testing.T) {
+	_, err := Evaluate("", "test", "cistern", "", "", "")
+	if err == nil {
+		t.Error("expected error for empty diff")
+	}
+}
+
+func TestEvaluate_PlaceholderResult(t *testing.T) {
+	result, err := Evaluate("some diff content", "test", "cistern", "PROJ-1", "feat/x", "abc")
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if result.Source != "cistern" {
+		t.Errorf("expected source 'cistern', got %q", result.Source)
+	}
+	if result.MaxScore != 40 {
+		t.Errorf("expected max score 40, got %d", result.MaxScore)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && (s[:len(substr)] == substr || contains(s[1:], substr)))
+}

--- a/internal/evaluate/prompt.go
+++ b/internal/evaluate/prompt.go
@@ -1,0 +1,56 @@
+package evaluate
+
+// ScoringPrompt returns the system prompt for the evaluation LLM.
+// The evaluator is adversarial — it assumes the code is wrong until proven right.
+func ScoringPrompt() string {
+	return `You are an adversarial code quality evaluator. You did NOT write this code.
+Your job is to score the diff against each rubric dimension on a 0-5 scale.
+
+Be constructively brutal. A score of 5 means the code is exemplary in this dimension.
+A score of 0 means the code has a fundamental failure in this dimension.
+
+You must produce your evaluation as JSON matching this structure:
+{
+  "scores": [
+    {
+      "dimension": "contract_correctness",
+      "score": 4,
+      "evidence": "toQueryBuilder returns a real EXISTS subquery, but MultiValuePermissionColumn.toQueryBuilder returns an empty string",
+      "suggested": "Replace the empty string in MultiValuePermissionColumn.toQueryBuilder with a real GROUP_CONCAT projection"
+    }
+  ],
+  "notes": "Overall assessment. What is good, what is bad, what would make it better."
+}
+
+Score guidelines per level:
+0 = Fundamental failure. Method does not do what it promises. No tests. Hardcoded entity coupling.
+1 = Major problems. Contract violations in multiple places. Missing integration tests for key paths.
+2 = Significant issues. Some contract violations. Missing tests for important paths. Minor coupling.
+3 = Adequate. Most methods honor their contracts. Some tests. Reasonable coupling.
+4 = Good. All methods honor contracts. Good test coverage. Well-factored with minimal coupling.
+5 = Exemplary. Every method does exactly what it promises. Comprehensive integration tests. Idiomatic framework usage. No coupling that should be generic.
+
+Dimensions to evaluate:` + dimensionDescriptions() + `
+
+IMPORTANT: You must score EVERY dimension. If a dimension is not applicable (e.g., MigrationSafety when there are no migrations), give it a score of 5 and explain why it is not applicable in the evidence field.
+
+You must provide SPECIFIC evidence for every score. Quote file paths and line numbers. Do not say "the code is generally good" - point to specific methods, specific test files, specific patterns.
+
+Evidence requirements:
+- Contract correctness: name specific methods that violate their contracts, with file paths
+- Integration coverage: name specific test files that cover new DAO/query methods
+- Coupling: name specific classes/methods that hardcode entity references
+- Migration safety: name specific migration files and their quoting/separation practices
+- Idiom fit: name specific code that uses non-idiomatic patterns
+- DRY: count and name specific repeated inline expressions
+- Naming clarity: name specific types/methods that create wrong mental models
+- Error messages: name specific error messages and whether they are actionable`
+}
+
+func dimensionDescriptions() string {
+	descs := ""
+	for _, d := range AllDimensions() {
+		descs += "\n- " + string(d) + ": " + DimensionDescription(d)
+	}
+	return descs
+}

--- a/internal/evaluate/rubric.go
+++ b/internal/evaluate/rubric.go
@@ -1,0 +1,115 @@
+package evaluate
+
+// Dimension is a rubric dimension that the evaluator scores against.
+// Each dimension measures a specific quality attribute with a 0-5 scale.
+type Dimension string
+
+const (
+	// ContractCorrectness measures whether every method/function does what its
+	// signature promises. Methods returning hardcoded values where computation is
+	// expected are contract violations.
+	ContractCorrectness Dimension = "contract_correctness"
+
+	// IntegrationCoverage measures whether new code paths (DAO methods, search
+	// filters, query builders, mapping functions) have integration tests that
+	// exercise real infrastructure, not just mocks.
+	IntegrationCoverage Dimension = "integration_coverage"
+
+	// Coupling measures whether new code couples to specific entities when it
+	// could be generic. Hardcoded table references, entity-specific imports in
+	// generic utilities, and similar patterns lose points.
+	Coupling Dimension = "coupling"
+
+	// MigrationSafety measures whether database migrations follow safe practices:
+	// quoted identifiers, DDL/DML separation, rollback safety, and meaningful
+	// descriptions for reference data.
+	MigrationSafety Dimension = "migration_safety"
+
+	// IdiomFit measures whether the code uses the framework's idiomatic patterns
+	// instead of fighting the framework. Uses Exists/NotExists instead of raw
+	// SQL in Exposed, uses Set where UNIQUE constraints exist, etc.
+	IdiomFit Dimension = "idiom_fit"
+
+	// DRY measures whether repeated patterns are extracted into helpers instead
+	// of copy-pasted. The same expression appearing 3+ times without extraction
+	// loses points.
+	DRY Dimension = "dry"
+
+	// NamingClarity measures whether types and methods are honestly named.
+	// Types that create wrong mental models (e.g., PermissionColumnName that
+	// is not a column) lose points.
+	NamingClarity Dimension = "naming_clarity"
+
+	// ErrorMessages measures whether error messages are actionable. Generic
+	// NoSuchElementException vs "Permission 'cps_enabled' not found in catalog"
+	// — the latter tells the developer exactly what to fix.
+	ErrorMessages Dimension = "error_messages"
+)
+
+// AllDimensions returns all rubric dimensions in canonical order.
+func AllDimensions() []Dimension {
+	return []Dimension{
+		ContractCorrectness,
+		IntegrationCoverage,
+		Coupling,
+		MigrationSafety,
+		IdiomFit,
+		DRY,
+		NamingClarity,
+		ErrorMessages,
+	}
+}
+
+// DimensionDescription returns a human-readable description of what a dimension measures.
+func DimensionDescription(d Dimension) string {
+	switch d {
+	case ContractCorrectness:
+		return "Does every method do what its signature promises? Methods returning hardcoded values where computation is expected are contract violations."
+	case IntegrationCoverage:
+		return "Do new code paths (DAO methods, search filters, query builders) have integration tests against real infrastructure?"
+	case Coupling:
+		return "Is new code coupled to specific entities when it could be generic? Hardcoded entity references in generic utilities lose points."
+	case MigrationSafety:
+		return "Do migrations follow safe practices: quoted identifiers, DDL/DML separation, rollback safety, meaningful descriptions?"
+	case IdiomFit:
+		return "Does the code use the framework's idiomatic patterns? Exposed Exists/NotExists, Set for unique values, etc."
+	case DRY:
+		return "Are repeated patterns extracted into helpers? The same expression 3+ times without extraction loses points."
+	case NamingClarity:
+		return "Are types and methods honestly named? Types that create wrong mental models (e.g., PermissionColumnName that is not a column) lose points."
+	case ErrorMessages:
+		return "Are error messages actionable? Generic errors lose points; specific messages that tell the developer what to fix gain points."
+	default:
+		return "unknown dimension"
+	}
+}
+
+// Score is a single dimension score on a 0-5 scale.
+type Score struct {
+	Dimension Dimension `json:"dimension"`
+	Score     int       `json:"score"`      // 0-5
+	Evidence  string    `json:"evidence"`   // specific code reference
+	Suggested string    `json:"suggested"`  // what would make it a 5
+}
+
+// Result is a complete evaluation result for a single diff or PR.
+type Result struct {
+	Source      string  `json:"source"`      // e.g., "cistern" or "vibe-coded"
+	Ticket      string  `json:"ticket"`     // e.g., "PROJ-123" or ""
+	Branch      string  `json:"branch"`     // e.g., "feat/fix-thing"
+	Commit      string  `json:"commit"`     // git SHA or "HEAD"
+	Model      string   `json:"model"`      // LLM model used for evaluation
+	Scores     []Score  `json:"scores"`
+	TotalScore int      `json:"total_score"` // sum of all dimension scores
+	MaxScore   int      `json:"max_score"`   // maximum possible score (5 * number of dimensions)
+	Notes      string   `json:"notes"`       // free-form evaluation notes
+	Timestamp  string   `json:"timestamp"`
+}
+
+// Percentage returns the score as a percentage of the maximum.
+func (r *Result) Percentage() float64 {
+	if r.MaxScore == 0 {
+		return 0
+	}
+	return float64(r.TotalScore) / float64(r.MaxScore) * 100
+}


### PR DESCRIPTION
## Summary

Adds `ct evaluate` — an independent evaluation harness that scores code diffs against the Cistern quality rubric. This lets us stop guessing about pipeline effectiveness and start measuring empirically.

### The problem

We have no way to measure whether our pipeline produces better code than a vibe-coded one-shot. The PR 353 vs 351 analysis was manual. We need a repeatable, automated scoring system.

### The solution

A new `ct evaluate` command that takes a diff and scores it across 8 rubric dimensions on a 0-5 scale:

| Dimension | What it measures |
|---|---|
| contract_correctness | Does every method do what its signature promises? |
| integration_coverage | Do new code paths have integration tests? |
| coupling | Is new code entity-specific when it could be generic? |
| migration_safety | Are migrations safe, quoted, separated? |
| idiom_fit | Does code use framework idioms? |
| dry | Are repeated patterns extracted? |
| naming_clarity | Are types honestly named? |
| error_messages | Are errors actionable? |

### Usage

```bash
ct evaluate                        # score current branch vs main
ct evaluate --pr 455               # score an existing PR
ct evaluate --diff "$(cat d)"      # score a raw diff
ct evaluate --source vibe-coded    # label for comparison
ct evaluate --format markdown      # human-readable output
```

### What's included

- `internal/evaluate/` — rubric definitions, scoring prompt, evaluation result types, parser
- `cmd/ct/evaluate.go` — CLI flag handling, diff resolution, output formatting
- 9 unit tests covering rubric, prompt, parsing, and edge cases

### What's NOT included (follow-up)

- LLM provider integration (the `Evaluate()` function currently returns a placeholder — the rubric and prompt are ready, the LLM call needs wiring to the provider system)
- Ticket-based comparative mode (vibe-coded baseline)
- Evaluation result storage and trending in the DB

These will come in follow-up PRs once the rubric is validated against real diffs.