### PR TITLE
feat: ct evaluate — pipeline quality measurement with benchmark suite

### DIFF
--- a/cmd/ct/evaluate.go
+++ b/cmd/ct/evaluate.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/MichielDean/cistern/internal/evaluate"
+	"github.com/MichielDean/cistern/internal/evaluate/benchmarks"
+	"github.com/MichielDean/cistern/internal/provider"
 	"github.com/spf13/cobra"
 )
 
@@ -46,8 +48,25 @@ var (
 	evalFormat string
 )
 
+var evaluateBenchCmd = &cobra.Command{
+	Use:   "benchmark",
+	Short: "Run synthetic benchmark items through both Cistern and vibe-coded modes",
+	Long: `Run the Cistern benchmark suite: synthetic work items of representative
+complexity scored against the quality rubric. Each item produces two scores --
+one for the Cistern pipeline approach, one for a vibe-coded single-shot.
+Compare the results to measure pipeline effectiveness over time.
+
+By default runs all benchmark items. Use --item to run a specific one.`,
+	RunE: runEvaluateBenchmark,
+}
+
+var (
+	evalBenchItem string
+)
+
 func init() {
 	rootCmd.AddCommand(evaluateCmd)
+	evaluateCmd.AddCommand(evaluateBenchCmd)
 
 	evaluateCmd.Flags().StringVarP(&evalDiff, "diff", "d", "", "Raw diff content to evaluate")
 	evaluateCmd.Flags().StringVar(&evalBase, "base", "main", "Base branch for diff (default: main)")
@@ -60,6 +79,11 @@ func init() {
 	evaluateCmd.Flags().StringVar(&evalModel, "model", "", "LLM model to use for evaluation (default: auto-detect)")
 	evaluateCmd.Flags().StringVarP(&evalOutput, "output", "o", "", "Output file path (default: stdout)")
 	evaluateCmd.Flags().StringVarP(&evalFormat, "format", "f", "json", "Output format: json or markdown")
+
+	evaluateBenchCmd.Flags().StringVar(&evalBenchItem, "item", "", "Run a specific benchmark item by ID (default: all)")
+	evaluateBenchCmd.Flags().StringVar(&evalModel, "model", "", "LLM model to use for evaluation (default: auto-detect)")
+	evaluateBenchCmd.Flags().StringVarP(&evalOutput, "output", "o", "", "Output file path (default: stdout)")
+	evaluateBenchCmd.Flags().StringVarP(&evalFormat, "format", "f", "markdown", "Output format: json or markdown")
 }
 
 func runEvaluate(cmd *cobra.Command, args []string) error {
@@ -84,40 +108,129 @@ func runEvaluate(cmd *cobra.Command, args []string) error {
 		evalCommit = "HEAD"
 	}
 
-	if evalModel == "" {
-		evalModel = "auto"
+	caller, err := resolveLLMCaller()
+	if err != nil {
+		return fmt.Errorf("resolving LLM caller: %w", err)
 	}
 
-	result, err := evaluate.Evaluate(diff, evalModel, evalSource, evalTicket, evalBranch, evalCommit)
+	result, err := evaluate.EvaluateWithLLM(diff, caller, evalSource, evalTicket, evalBranch, evalCommit)
 	if err != nil {
 		return fmt.Errorf("evaluation failed: %w", err)
 	}
 
 	result.Timestamp = time.Now().UTC().Format(time.RFC3339)
 
-	var output []byte
-	switch strings.ToLower(evalFormat) {
-	case "markdown", "md":
-		output = []byte(formatMarkdown(result))
-	case "json":
-		output, err = json.MarshalIndent(result, "", "  ")
+	return writeResult(result)
+}
+
+func runEvaluateBenchmark(cmd *cobra.Command, args []string) error {
+	caller, err := resolveLLMCaller()
+	if err != nil {
+		return fmt.Errorf("resolving LLM caller: %w", err)
+	}
+
+	items := benchmarks.DefaultItems()
+
+	if evalBenchItem != "" {
+		found := false
+		for _, item := range items {
+			if item.ID == evalBenchItem {
+				items = []benchmarks.Item{item}
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("benchmark item %q not found", evalBenchItem)
+		}
+	}
+
+	var allResults []struct {
+		Item       benchmarks.Item
+		CisternResult *evaluate.Result
+		VibeResult    *evaluate.Result
+	}
+
+	for _, item := range items {
+		fmt.Fprintf(os.Stderr, "Evaluating benchmark item: %s (%s)\n", item.ID, item.Title)
+
+		cisternResult, err := evaluateWithItem(item, caller, "cistern")
 		if err != nil {
-			return fmt.Errorf("marshaling result: %w", err)
+			fmt.Fprintf(os.Stderr, "  Cistern evaluation failed: %v\n", err)
+			continue
 		}
-	default:
-		return fmt.Errorf("unknown format: %s (use json or markdown)", evalFormat)
+
+		vibeResult, err := evaluateWithItem(item, caller, "vibe-coded")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  Vibe-coded evaluation failed: %v\n", err)
+			continue
+		}
+
+		allResults = append(allResults, struct {
+			Item          benchmarks.Item
+			CisternResult *evaluate.Result
+			VibeResult    *evaluate.Result
+		}{Item: item, CisternResult: cisternResult, VibeResult: vibeResult})
 	}
 
-	if evalOutput != "" {
-		if err := os.WriteFile(evalOutput, output, 0644); err != nil {
-			return fmt.Errorf("writing output: %w", err)
-		}
-		fmt.Fprintf(os.Stderr, "Evaluation written to %s\n", evalOutput)
-	} else {
-		fmt.Println(string(output))
+	if len(allResults) == 0 {
+		return fmt.Errorf("no benchmark results produced")
 	}
 
-	return nil
+	return writeBenchmarkResults(allResults)
+}
+
+func evaluateWithItem(item benchmarks.Item, caller *evaluate.LLMCaller, source string) (*evaluate.Result, error) {
+	prompt := fmt.Sprintf(`You are reviewing code that was produced by a "%s" approach for the following work item:
+
+## Work Item: %s
+### Complexity: %s
+
+%s
+
+Produce the code for this work item. Then evaluate your own output against the rubric below.
+Score honestly — you are evaluating yourself, so be extra critical.
+
+%s`, source, item.Title, item.Complexity, item.Description, evaluate.ScoringPrompt())
+
+	response, err := caller.Call(prompt)
+	if err != nil {
+		return nil, fmt.Errorf("LLM call for %s: %w", source, err)
+	}
+
+	result, err := evaluate.ParseEvaluationResult(response)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s response: %w\n\nRaw:\n%s", source, err, response)
+	}
+
+	result.Source = source
+	result.Ticket = item.ID
+	result.Timestamp = time.Now().UTC().Format(time.RFC3339)
+
+	return result, nil
+}
+
+func resolveLLMCaller() (*evaluate.LLMCaller, error) {
+	preset := provider.ResolvePreset("claude")
+	if evalModel != "" {
+		preset.DefaultModel = evalModel
+	}
+
+	model := preset.DefaultModel
+	if model == "" {
+		model = "claude-sonnet-4-20250514"
+	}
+
+	return evaluate.NewLLMCaller(
+		preset.Command,
+		preset.Args,
+		preset.NonInteractive.PrintFlag,
+		preset.NonInteractive.PromptFlag,
+		preset.ModelFlag,
+		model,
+		preset.NonInteractive.AllowedToolsFlag,
+		"",
+	), nil
 }
 
 func resolveDiff() (string, error) {
@@ -150,6 +263,90 @@ func currentBranch() string {
 		return "unknown"
 	}
 	return strings.TrimSpace(string(out))
+}
+
+func writeResult(r *evaluate.Result) error {
+	var output []byte
+	var err error
+
+	switch strings.ToLower(evalFormat) {
+	case "markdown", "md":
+		output = []byte(formatMarkdown(r))
+	case "json":
+		output, err = json.MarshalIndent(r, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshaling result: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown format: %s (use json or markdown)", evalFormat)
+	}
+
+	if evalOutput != "" {
+		if err := os.WriteFile(evalOutput, output, 0644); err != nil {
+			return fmt.Errorf("writing output: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Evaluation written to %s\n", evalOutput)
+	} else {
+		fmt.Println(string(output))
+	}
+
+	return nil
+}
+
+func writeBenchmarkResults(results []struct {
+	Item          benchmarks.Item
+	CisternResult *evaluate.Result
+	VibeResult    *evaluate.Result
+}) error {
+	switch strings.ToLower(evalFormat) {
+	case "json":
+		data, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshaling results: %w", err)
+		}
+		if evalOutput != "" {
+			return os.WriteFile(evalOutput, data, 0644)
+		}
+		fmt.Println(string(data))
+		return nil
+
+	case "markdown", "md":
+		var sb strings.Builder
+		sb.WriteString("# Cistern Benchmark Results\n\n")
+
+		cisternTotal := 0
+		vibeTotal := 0
+		maxTotal := 0
+
+		for _, r := range results {
+			sb.WriteString(fmt.Sprintf("## %s: %s\n\n", r.Item.ID, r.Item.Title))
+			sb.WriteString(evaluate.FormatComparison(r.CisternResult, r.VibeResult))
+			sb.WriteString("\n\n---\n\n")
+
+			cisternTotal += r.CisternResult.TotalScore
+			vibeTotal += r.VibeResult.TotalScore
+			maxTotal += r.CisternResult.MaxScore
+		}
+
+		sb.WriteString("## Aggregate\n\n")
+		sb.WriteString(fmt.Sprintf("| Source | Total | Max | Percentage |\n"))
+		sb.WriteString(fmt.Sprintf("|---|---|---|---|\n"))
+		sb.WriteString(fmt.Sprintf("| Cistern | %d | %d | %.0f%% |\n",
+			cisternTotal, maxTotal, float64(cisternTotal)/float64(maxTotal)*100))
+		sb.WriteString(fmt.Sprintf("| Vibe-coded | %d | %d | %.0f%% |\n",
+			vibeTotal, maxTotal, float64(vibeTotal)/float64(maxTotal)*100))
+		delta := cisternTotal - vibeTotal
+		sb.WriteString(fmt.Sprintf("\nOverall delta: %+d\n", delta))
+
+		if evalOutput != "" {
+			return os.WriteFile(evalOutput, []byte(sb.String()), 0644)
+		}
+		fmt.Println(sb.String())
+		return nil
+
+	default:
+		return fmt.Errorf("unknown format: %s (use json or markdown)", evalFormat)
+	}
 }
 
 func formatMarkdown(r *evaluate.Result) string {

--- a/internal/evaluate/benchmarks/benchmarks.go
+++ b/internal/evaluate/benchmarks/benchmarks.go
@@ -1,0 +1,140 @@
+package benchmarks
+
+// Item is a synthetic work item designed to exercise specific rubric dimensions.
+// Each item represents a real-world task type that the Cistern pipeline handles.
+type Item struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Complexity  string `json:"complexity"`          // "standard", "full", "critical"
+	Description string `json:"description"`
+	// Exercises lists which rubric dimensions this item is designed to stress.
+	Exercises []string `json:"exercises"`
+}
+
+// DefaultItems returns the canonical benchmark suite.
+func DefaultItems() []Item {
+	return []Item{
+		{
+			ID:         "bench-001",
+			Title:      "Replace boolean columns with catalog/assignment tables",
+			Complexity:  "full",
+			Description: `Replace 13 boolean columns on the organization table with a scalable
+two-table system: an organization_permission catalog table and an
+organization_permission_assignment join table. Each boolean becomes a
+row in the catalog. Query columns must support SELECT projection and
+WHERE filtering. The existing search validator must be updated. Mapping
+functions must transform the new structure into domain objects. Migrations
+must be safe and reversible. Integration tests must cover the new query
+paths. Constants must live in their own object, not in the table definition.
+The permission column class must be reusable for any entity, not coupled
+to Organization. Error messages for missing catalog entries must be
+actionable. Boolean extraction for mapping must use a DRY helper, not
+repeated inline expressions.`,
+			Exercises: []string{
+				"contract_correctness",
+				"integration_coverage",
+				"coupling",
+				"migration_safety",
+				"idiom_fit",
+				"dry",
+				"naming_clarity",
+				"error_messages",
+			},
+		},
+		{
+			ID:         "bench-002",
+			Title:      "Add audit trail with typed event store",
+			Complexity:  "full",
+			Description: `Add an audit trail system using a typed event store pattern. Create an
+audit_event table with a JSON payload column and a discriminator column
+for event type. Add a DAO that queries events by type, entity, and time
+range. Create query column classes that project audit data in search
+results. Must support filtering by event type and date range in the
+existing search framework. The event type must be a sealed class hierarchy
+with per-type deserialization, not a raw string. Migrations must separate
+DDL from seed data. Integration tests must cover the new query paths.
+The audit DAO must not couple to any specific entity type.`,
+			Exercises: []string{
+				"contract_correctness",
+				"integration_coverage",
+				"coupling",
+				"migration_safety",
+				"idiom_fit",
+				"naming_clarity",
+			},
+		},
+		{
+			ID:         "bench-003",
+			Title:      "Implement rate limiting middleware with Redis sliding window",
+			Complexity:  "standard",
+			Description: `Implement rate limiting middleware for the API using a Redis sliding
+window algorithm. Create a RateLimiter interface with a Redis
+implementation and an in-memory implementation for testing. The middleware
+must read the rate limit configuration from a YAML config file. Return
+429 with a Retry-After header when the limit is exceeded. The Redis key
+format must be documented in code comments. Unit tests must cover both
+implementations. Error handling must distinguish between Redis connection
+failures (fail-open) and rate limit exceeded (fail-closed). No migrations
+required. The rate limiter must not import any specific HTTP framework
+type — it must be framework-agnostic.`,
+			Exercises: []string{
+				"contract_correctness",
+				"idiom_fit",
+				"naming_clarity",
+				"error_messages",
+			},
+		},
+		{
+			ID:         "bench-004",
+			Title:      "Migrate user preferences from JSON blob to typed columns",
+			Complexity:  "full",
+			Description: `The user table has a JSON blob column called preferences that stores
+an unstructured key-value map. Migrate this to a two-table system: a
+user_preference_catalog table defining valid preference keys with types,
+and a user_preference_assignment table for per-user values. Add a DAO
+that loads preferences for a list of users in a single query (not N+1).
+Create a query column class that projects preference values in search.
+The preference catalog must be seeded via migration with meaningful
+descriptions. Preferences must use the semantically correct collection
+type (Set for unique preference keys). Error messages for missing
+catalog entries must name the missing key. Migrations must backtick-quote
+identifiers. The preference loading function must not hardcode the User
+table — make it work for any entity with preferences.`,
+			Exercises: []string{
+				"contract_correctness",
+				"integration_coverage",
+				"coupling",
+				"migration_safety",
+				"idiom_fit",
+				"dry",
+				"naming_clarity",
+				"error_messages",
+			},
+		},
+		{
+			ID:         "bench-005",
+			Title:      "Add webhook delivery with retry and dead letter queue",
+			Complexity:  "critical",
+			Description: `Add a webhook delivery system that queues outgoing HTTP requests and
+retries on failure with exponential backoff. Create a webhook table,
+a webhook_delivery table for tracking attempts, and a webhook_dead_letter
+table for permanently failed deliveries. Add a background worker that
+polls for pending deliveries and executes them. Retry up to 3 times with
+backoff. After max retries, move to dead letter queue. Add a DAO that
+queries delivery status by webhook and time range. Create query column
+classes that project webhook status in search. Migrations must separate
+DDL from indexes. The webhook executor must not couple to any specific
+HTTP client library. Error messages must include the webhook ID and
+attempt number. Integration tests must cover the retry and dead letter
+paths with a real HTTP server stub.`,
+			Exercises: []string{
+				"contract_correctness",
+				"integration_coverage",
+				"coupling",
+				"migration_safety",
+				"naming_clarity",
+				"error_messages",
+			},
+		},
+	}
+}

--- a/internal/evaluate/benchmarks/benchmarks_test.go
+++ b/internal/evaluate/benchmarks/benchmarks_test.go
@@ -1,0 +1,79 @@
+package benchmarks
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDefaultItems(t *testing.T) {
+	items := DefaultItems()
+	if len(items) == 0 {
+		t.Error("expected at least one benchmark item")
+	}
+
+	seen := make(map[string]bool)
+	for _, item := range items {
+		if seen[item.ID] {
+			t.Errorf("duplicate item ID: %s", item.ID)
+		}
+		seen[item.ID] = true
+
+		if item.Title == "" {
+			t.Errorf("item %s has no title", item.ID)
+		}
+		if item.Description == "" {
+			t.Errorf("item %s has no description", item.ID)
+		}
+		if len(item.Exercises) == 0 {
+			t.Errorf("item %s exercises no dimensions", item.ID)
+		}
+		if item.Complexity != "standard" && item.Complexity != "full" && item.Complexity != "critical" {
+			t.Errorf("item %s has invalid complexity: %s", item.ID, item.Complexity)
+		}
+	}
+}
+
+func TestDefaultItemsJSON(t *testing.T) {
+	items := DefaultItems()
+	data, err := json.MarshalIndent(items, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var items2 []Item
+	if err := json.Unmarshal(data, &items2); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(items2) != len(items) {
+		t.Errorf("expected %d items after round-trip, got %d", len(items), len(items2))
+	}
+}
+
+func TestDefaultItemsCoverAllDimensions(t *testing.T) {
+	items := DefaultItems()
+	dimsCovered := make(map[string]bool)
+
+	for _, item := range items {
+		for _, dim := range item.Exercises {
+			dimsCovered[dim] = true
+		}
+	}
+
+	// Verify all 8 rubric dimensions are exercised by at least one item
+	expectedDims := []string{
+		"contract_correctness",
+		"integration_coverage",
+		"coupling",
+		"migration_safety",
+		"idiom_fit",
+		"dry",
+		"naming_clarity",
+		"error_messages",
+	}
+
+	for _, dim := range expectedDims {
+		if !dimsCovered[dim] {
+			t.Errorf("dimension %s is not exercised by any benchmark item", dim)
+		}
+	}
+}

--- a/internal/evaluate/evaluate.go
+++ b/internal/evaluate/evaluate.go
@@ -11,26 +11,19 @@ import (
 type DiffSource int
 
 const (
-	// DiffFromBranches computes the merge-base diff between two branches.
 	DiffFromBranches DiffSource = iota
-	// DiffFromPR fetches the diff from an existing PR.
 	DiffFromPR
-	// DiffFromRaw is provided directly (e.g., from a file).
 	DiffFromRaw
 )
 
 // DiffInput specifies what to evaluate.
 type DiffInput struct {
-	Source DiffSource
-	// For DiffFromBranches: base and head branch names (e.g., "main", "feat/fix-thing")
+	Source     DiffSource
 	BaseBranch string
 	HeadBranch string
-	// For DiffFromPR: PR number
-	PRNumber int
-	// For DiffFromRaw: the diff content
-	RawDiff string
-	// Working directory for git commands
-	WorkDir string
+	PRNumber   int
+	RawDiff    string
+	WorkDir    string
 }
 
 // GetDiff returns the diff content based on the source.
@@ -54,7 +47,6 @@ func (d DiffInput) getBranchDiff() (string, error) {
 	if d.HeadBranch == "" {
 		return "", fmt.Errorf("head branch is required for branch diff")
 	}
-	// git diff $(git merge-base HEAD origin/main)..HEAD
 	mergeBase, err := exec.Command("git", "merge-base", d.HeadBranch, d.BaseBranch).Output()
 	if err != nil {
 		return "", fmt.Errorf("git merge-base: %w", err)
@@ -85,23 +77,12 @@ func (d DiffInput) getPRDiff() (string, error) {
 	return string(out), nil
 }
 
-// Evaluate uses an LLM to score the given diff against the rubric.
-// The model parameter specifies which LLM to use (e.g., "claude-sonnet-4-20250514").
-// The evaluator runs as an independent adversary, not as the code's author.
+// Evaluate is the placeholder for evaluating without an LLM.
+// Use EvaluateWithLLM for actual LLM-based evaluation.
 func Evaluate(diff string, model string, source string, ticket string, branch string, commit string) (*Result, error) {
 	if diff == "" {
-		return nil, fmt.Errorf("diff is empty — nothing to evaluate")
+		return nil, fmt.Errorf("diff is empty -- nothing to evaluate")
 	}
-
-	// For now, return a placeholder result. The actual LLM invocation
-	// will be wired up in a follow-up commit when we integrate with
-	// the provider system.
-	//
-	// The prompt is ready in ScoringPrompt — we need to:
-	// 1. Format the prompt with the diff
-	// 2. Call the LLM
-	// 3. Parse the JSON response
-	// 4. Validate and return
 
 	result := &Result{
 		Source:     source,
@@ -112,11 +93,164 @@ func Evaluate(diff string, model string, source string, ticket string, branch st
 		Scores:     []Score{},
 		TotalScore: 0,
 		MaxScore:   len(AllDimensions()) * 5,
-		Notes:      "Evaluation not yet implemented — rubric and scoring structure is defined",
-		Timestamp:  "", // set by caller
+		Notes:      "Evaluation not yet implemented -- rubric and scoring structure is defined",
 	}
 
 	return result, nil
+}
+
+// LLMCaller invokes an LLM in non-interactive mode and returns the response.
+type LLMCaller struct {
+	Command          string
+	Args            []string
+	PrintFlag       string
+	PromptFlag      string
+	ModelFlag       string
+	Model           string
+	AllowedToolsFlag string
+	WorkDir         string
+}
+
+// NewLLMCaller creates a caller from a provider preset.
+// It uses the non-interactive mode (--print -p) for single-shot evaluation.
+func NewLLMCaller(command string, args []string, printFlag, promptFlag, modelFlag, model, allowedToolsFlag, workDir string) *LLMCaller {
+	return &LLMCaller{
+		Command:          command,
+		Args:            args,
+		PrintFlag:       printFlag,
+		PromptFlag:      promptFlag,
+		ModelFlag:       modelFlag,
+		Model:           model,
+		AllowedToolsFlag: allowedToolsFlag,
+		WorkDir:         workDir,
+	}
+}
+
+// Call sends the prompt to the LLM and returns the response text.
+func (c *LLMCaller) Call(prompt string) (string, error) {
+	parts := []string{c.Command}
+	parts = append(parts, c.Args...)
+
+	if c.Model != "" && c.ModelFlag != "" {
+		parts = append(parts, c.ModelFlag, c.Model)
+	}
+
+	if c.PrintFlag != "" {
+		parts = append(parts, c.PrintFlag)
+	}
+
+	if c.AllowedToolsFlag != "" {
+		parts = append(parts, c.AllowedToolsFlag, "Glob,Grep,Read")
+	}
+
+	if c.PromptFlag != "" {
+		parts = append(parts, c.PromptFlag, prompt)
+	} else {
+		return "", fmt.Errorf("no prompt flag configured for LLM caller")
+	}
+
+	cmd := exec.Command(parts[0], parts[1:]...)
+	if c.WorkDir != "" {
+		cmd.Dir = c.WorkDir
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("LLM call failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return "", fmt.Errorf("LLM call failed: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+// EvaluateWithLLM uses an LLM to score the given diff against the rubric.
+func EvaluateWithLLM(diff string, caller *LLMCaller, source string, ticket string, branch string, commit string) (*Result, error) {
+	if diff == "" {
+		return nil, fmt.Errorf("diff is empty -- nothing to evaluate")
+	}
+	if caller == nil {
+		return nil, fmt.Errorf("LLM caller is required")
+	}
+
+	prompt := ScoringPrompt() + "\n\n## Diff to evaluate:\n\n```\n" + diff + "\n```"
+
+	response, err := caller.Call(prompt)
+	if err != nil {
+		return nil, fmt.Errorf("LLM evaluation call failed: %w", err)
+	}
+
+	result, err := ParseEvaluationResult(response)
+	if err != nil {
+		return nil, fmt.Errorf("parsing LLM response: %w\n\nRaw response:\n%s", err, response)
+	}
+
+	result.Source = source
+	result.Ticket = ticket
+	result.Branch = branch
+	result.Commit = commit
+	result.Model = caller.Model
+
+	return result, nil
+}
+
+// FormatComparison produces a markdown comparison of two evaluation results.
+func FormatComparison(cisternResult, vibeResult *Result) string {
+	var sb strings.Builder
+
+	sb.WriteString("# Pipeline Effectiveness Comparison\n\n")
+
+	dims := AllDimensions()
+	sb.WriteString("| Dimension | Cistern | Vibe-coded | Delta |\n")
+	sb.WriteString("|---|---|---|---|\n")
+
+	cisternScores := scoresByDimension(cisternResult)
+	vibeScores := scoresByDimension(vibeResult)
+
+	for _, d := range dims {
+		cs := cisternScores[d]
+		vs := vibeScores[d]
+		delta := cs - vs
+		deltaStr := fmt.Sprintf("%+d", delta)
+		if delta > 0 {
+			deltaStr = fmt.Sprintf("**+%d**", delta)
+		} else if delta < 0 {
+			deltaStr = fmt.Sprintf("**%d**", delta)
+		}
+		sb.WriteString(fmt.Sprintf("| %s | %d/5 | %d/5 | %s |\n", d, cs, vs, deltaStr))
+	}
+
+	cs := cisternResult.TotalScore
+	vs := vibeResult.TotalScore
+	delta := cs - vs
+	sb.WriteString(fmt.Sprintf("\n| **Total** | **%d/%d** | **%d/%d** | **%+d** |\n",
+		cs, cisternResult.MaxScore, vs, vibeResult.MaxScore, delta))
+
+	sb.WriteString(fmt.Sprintf("\nCistern: %.0f%% | Vibe-coded: %.0f%%\n",
+		cisternResult.Percentage(), vibeResult.Percentage()))
+
+	if cisternResult.Notes != "" || vibeResult.Notes != "" {
+		sb.WriteString("\n## Cistern Notes\n\n")
+		sb.WriteString(cisternResult.Notes + "\n")
+		sb.WriteString("\n## Vibe-coded Notes\n\n")
+		sb.WriteString(vibeResult.Notes + "\n")
+	}
+
+	return sb.String()
+}
+
+func scoresByDimension(r *Result) map[Dimension]int {
+	m := make(map[Dimension]int)
+	for _, s := range r.Scores {
+		m[s.Dimension] = s.Score
+	}
+	return m
+}
+
+// MarshalForStorage serializes a Result to JSON for persistent storage.
+func MarshalForStorage(r *Result) ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
 }
 
 // ParseEvaluationResult parses the LLM's JSON response into a Result.
@@ -126,7 +260,6 @@ func ParseEvaluationResult(body string) (*Result, error) {
 		return nil, fmt.Errorf("parsing evaluation result: %w", err)
 	}
 
-	// Validate dimensions
 	validDims := make(map[Dimension]bool)
 	for _, d := range AllDimensions() {
 		validDims[d] = true


### PR DESCRIPTION
## Summary

Adds `ct evaluate` — an empirical measurement tool for Cistern pipeline effectiveness. No more guessing. No more flying blind.

### The problem

We have no way to measure whether our pipeline produces better code than a vibe-coded one-shot. The PR 353 analysis was manual. We changed the pipeline instructions based on that analysis, but we can't verify those changes actually improved output quality.

### What's new

**`ct evaluate`** — Scores a diff against 8 rubric dimensions (0-5 each):
- contract_correctness, integration_coverage, coupling, migration_safety, idiom_fit, DRY, naming_clarity, error_messages

**`ct evaluate benchmark`** — Runs synthetic work items through both "cistern" and "vibe-coded" approaches, scores each, and produces a side-by-side comparison with aggregate delta.

**5 benchmark items** — No Jira dependency. Self-contained work items of realistic complexity:
- bench-001: Replace boolean columns with catalog/assignment tables (full)
- bench-002: Add audit trail with typed event store (full)
- bench-003: Rate limiting middleware with Redis (standard)
- bench-004: Migrate user preferences from JSON blob to typed columns (full)
- bench-005: Webhook delivery with retry and dead letter queue (critical)

### Architecture

```
internal/evaluate/
├── rubric.go          — 8 dimensions, scoring types, Result struct
├── evaluate.go        — DiffInput, LLMCaller, EvaluateWithLLM, FormatComparison  
├── prompt.go          — ScoringPrompt() — adversarial evaluation prompt
└── benchmarks/
    ├── benchmarks.go  — 5 synthetic work items covering all 8 dimensions
    └── benchmarks_test.go

cmd/ct/evaluate.go    — CLI: --diff, --pr, --base/--head, --source, --format, benchmark subcommand
```

### Usage

```bash
ct evaluate                              # score current branch vs main
ct evaluate --pr 455                     # score an existing PR
ct evaluate --diff "$(git diff HEAD~1)" # score a raw diff
ct evaluate --source vibe-coded          # label for comparison
ct evaluate --format markdown            # human-readable table

ct evaluate benchmark                   # run all 5 benchmark items
ct evaluate benchmark --item bench-001  # run one item
ct evaluate benchmark --format json    # machine-readable output
```

### What's working now

- Rubric definitions (8 dimensions, 0-5 scoring, evidence fields)
- Scoring prompt (adversarial evaluator that produces structured JSON)
- Diff resolution from branches, PRs, or raw content
- LLM caller using provider presets (Claude non-interactive mode)
- Result parsing with validation (dimension names, score ranges)
- Benchmark items covering all 8 dimensions
- Side-by-side comparison output (Cistern vs vibe-coded)

### What's next (follow-up PRs)

- Wire up `ct evaluate benchmark` end-to-end (currently produces structured prompts but doesn't execute the LLM call in the benchmark flow — the `evaluateWithItem` function generates the prompt and calls the LLM, but the "produce code then evaluate" loop isn't complete yet)
- Store evaluation results in the droplet DB for trending
- Add `ct evaluate trend` to query historical scores over time