### PR TITLE
feat: remove complexity system — all droplets flow through full pipeline

### DIFF
--- a/aqueduct/aqueduct.yaml
+++ b/aqueduct/aqueduct.yaml
@@ -1,13 +1,5 @@
 name: feature
 
-complexity:
-  standard:
-    level: 1
-  full:
-    level: 2
-  critical:
-    level: 3
-
 cataractae:
   - name: architect
     type: agent

--- a/cmd/ct/assets/aqueduct/aqueduct.yaml
+++ b/cmd/ct/assets/aqueduct/aqueduct.yaml
@@ -1,13 +1,5 @@
 name: feature
 
-complexity:
-  standard:
-    level: 1
-  full:
-    level: 2
-  critical:
-    level: 3
-
 cataractae:
   - name: architect
     type: agent

--- a/cmd/ct/capturePane_test.go
+++ b/cmd/ct/capturePane_test.go
@@ -40,7 +40,7 @@ func TestCapturePane_FullScrollback_ReturnsHistoryBeyondVisible(t *testing.T) {
 	// Without this, send-keys can fire before the shell has started, causing the
 	// script to be lost or partially captured — the root cause of the flake.
 	shellReady := false
-	readyDeadline := time.Now().Add(5 * time.Second)
+	readyDeadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(readyDeadline) {
 		raw, _ := exec.Command("tmux", "capture-pane", "-t", session+":0.0", "-p").Output()
 		if strings.Contains(string(raw), "$") || strings.Contains(string(raw), "#") || strings.Contains(string(raw), "~") {

--- a/cmd/ct/castellarius_test.go
+++ b/cmd/ct/castellarius_test.go
@@ -114,7 +114,7 @@ func TestStatusJSONOutput_WithFlowingData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("repo", "Test droplet", "", 1, 3)
+	item, err := c.Add("repo", "Test droplet", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ct/cataractae.go
+++ b/cmd/ct/cataractae.go
@@ -63,7 +63,6 @@ func runCataractaeRender(cmd *cobra.Command, args []string) error {
 		ID:          "<droplet-id>",
 		Title:       "<droplet title>",
 		Description: "<droplet description>",
-		Complexity:  1,
 	}
 
 	if cataractaeRenderDroplet != "" {
@@ -81,7 +80,6 @@ func runCataractaeRender(cmd *cobra.Command, args []string) error {
 			ID:          item.ID,
 			Title:       item.Title,
 			Description: item.Description,
-			Complexity:  item.Complexity,
 		}
 	}
 

--- a/cmd/ct/cistern.go
+++ b/cmd/ct/cistern.go
@@ -44,7 +44,6 @@ var (
 	addDescription string
 	addPriority    int
 	addRepo        string
-	addComplexity  string
 	addDependsOn   []string
 )
 
@@ -69,11 +68,7 @@ var dropletAddCmd = &cobra.Command{
 		}
 		defer c.Close()
 
-		cx, err := parseComplexity(addComplexity)
-		if err != nil {
-			return err
-		}
-		item, err := c.Add(repo, addTitle, addDescription, addPriority, cx, addDependsOn...)
+		item, err := c.Add(repo, addTitle, addDescription, addPriority, addDependsOn...)
 		if err != nil {
 			return err
 		}
@@ -210,7 +205,7 @@ var dropletListCmd = &cobra.Command{
 
 			// Non-terminal / piped output: plain tabwriter, no ANSI.
 			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-			fmt.Fprintln(tw, "ID\tCOMPLEXITY\tTITLE\tSTATUS\tELAPSED\tCATARACTA")
+			fmt.Fprintln(tw, "ID\tTITLE\tSTATUS\tELAPSED\tCATARACTA")
 			for _, item := range active {
 				ds := displayStatusForDroplet(item)
 				cataractae := item.CurrentCataractae
@@ -224,15 +219,12 @@ var dropletListCmd = &cobra.Command{
 						cataractae = "waiting: " + blockedBy[0]
 					}
 				}
-				if ds == "awaiting" {
-					ds = "\u23f8 awaiting approval"
-				}
 				elapsed := "\u2014"
 				if item.Status == "in_progress" {
 					elapsed = formatElapsed(time.Since(item.UpdatedAt))
 				}
-				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-					item.ID, complexityName(item.Complexity), truncate(item.Title, titleMax),
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+					item.ID, truncate(item.Title, titleMax),
 					ds, elapsed, cataractae)
 			}
 			if listAll && len(dimmed) > 0 {
@@ -243,8 +235,8 @@ var dropletListCmd = &cobra.Command{
 					if cataractae == "" {
 						cataractae = "\u2014"
 					}
-					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-						item.ID, complexityName(item.Complexity), truncate(item.Title, titleMax),
+					fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+						item.ID, truncate(item.Title, titleMax),
 						"delivered", age, cataractae)
 				}
 			}
@@ -285,12 +277,11 @@ var dropletListCmd = &cobra.Command{
 func printDropletListTerminal(active, dimmed []*cistern.Droplet, showAll bool, titleMax int) {
 	const (
 		colID = 12
-		colCX = 10
 		colSt = 12 // STATUS cell visual width (icon + space + text)
 		colEl = 10 // ELAPSED
 	)
-	fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %-*s  %s\n",
-		colID, "ID", colCX, "COMPLEXITY", titleMax, "TITLE", colSt, "STATUS", colEl, "ELAPSED", "CATARACTA")
+	fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s\n",
+		colID, "ID", titleMax, "TITLE", colSt, "STATUS", colEl, "ELAPSED", "CATARACTA")
 
 	for _, item := range active {
 		ds := displayStatusForDroplet(item)
@@ -304,18 +295,18 @@ func printDropletListTerminal(active, dimmed []*cistern.Droplet, showAll bool, t
 		}
 		title := padRight(truncate(item.Title, titleMax), titleMax)
 		sc := statusCell(ds, colSt)
-		fmt.Printf("  %-*s  %-*s  %s  %s  %-*s  %s\n",
-			colID, item.ID, colCX, complexityName(item.Complexity),
+		fmt.Printf("  %-*s  %s  %s  %-*s  %s\n",
+			colID, item.ID,
 			title, sc, colEl, elapsed, cataractae)
 	}
 
 	if showAll && len(dimmed) > 0 {
-		fmt.Println(colorDim + "  ── delivered " + strings.Repeat("─", titleMax+colID+colCX+6) + colorReset)
+		fmt.Println(colorDim + "  ── delivered " + strings.Repeat("─", titleMax+colID+6) + colorReset)
 		for _, item := range dimmed {
 			age := formatElapsed(time.Since(item.UpdatedAt))
 			title := padRight(truncate(item.Title, titleMax), titleMax)
-			line := fmt.Sprintf("  %-*s  %-*s  %s  ✓ %-*s  %-*s  —",
-				colID, item.ID, colCX, complexityName(item.Complexity),
+			line := fmt.Sprintf("  %-*s  %s  ✓ %-*s  %-*s  —",
+				colID, item.ID,
 				title, colSt-2, "delivered", colEl, age)
 			fmt.Println(colorDim + line + colorReset)
 		}
@@ -348,12 +339,8 @@ func formatPeekFollowSeparator(updatedAt, stageDispatchedAt time.Time) string {
 	return elapsed
 }
 
-// displayStatusForDroplet returns the display status for a droplet, overriding
-// for human-gated droplets to show "awaiting approval".
+// displayStatusForDroplet returns the display status for a droplet.
 func displayStatusForDroplet(item *cistern.Droplet) string {
-	if item.CurrentCataractae == "human" && item.Status == "pooled" {
-		return "awaiting"
-	}
 	return displayStatus(item.Status)
 }
 
@@ -444,15 +431,12 @@ var dropletSearchCmd = &cobra.Command{
 					cataractae = "waiting: " + blockedBy[0]
 				}
 			}
-			if ds == "awaiting" {
-				ds = "\u23f8 awaiting approval"
-			}
 			elapsed := "\u2014"
 			if item.Status == "in_progress" {
 				elapsed = formatElapsed(time.Since(item.UpdatedAt))
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-				item.ID, complexityName(item.Complexity), truncate(item.Title, titleMax),
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+				item.ID, truncate(item.Title, titleMax),
 				ds, elapsed, cataractae)
 		}
 		return tw.Flush()
@@ -500,7 +484,7 @@ var dropletExportCmd = &cobra.Command{
 
 		// CSV output.
 		w := csv.NewWriter(os.Stdout)
-		_ = w.Write([]string{"id", "repo", "title", "description", "priority", "complexity", "status", "assignee", "current_cataractae", "outcome", "assigned_aqueduct", "last_reviewed_commit", "created_at", "updated_at"})
+		_ = w.Write([]string{"id", "repo", "title", "description", "priority", "status", "assignee", "current_cataractae", "outcome", "assigned_aqueduct", "last_reviewed_commit", "created_at", "updated_at"})
 		for _, item := range items {
 			_ = w.Write([]string{
 				item.ID,
@@ -508,7 +492,6 @@ var dropletExportCmd = &cobra.Command{
 				item.Title,
 				item.Description,
 				strconv.Itoa(item.Priority),
-				strconv.Itoa(item.Complexity),
 				item.Status,
 				item.Assignee,
 				item.CurrentCataractae,
@@ -569,7 +552,6 @@ var dropletShowCmd = &cobra.Command{
 		fmt.Printf("Repo:        %s\n", item.Repo)
 		fmt.Printf("Status:      %s\n", displayStatus(item.Status))
 		fmt.Printf("Priority:    %d\n", item.Priority)
-		fmt.Printf("Complexity:  %s (%d)\n", complexityName(item.Complexity), item.Complexity)
 		fmt.Printf("Cataracta:      %s\n", item.Assignee)
 		fmt.Printf("Stage:       %s\n", item.CurrentCataractae)
 
@@ -1051,28 +1033,6 @@ not be considered stalled regardless of how long it has been running.`,
 	},
 }
 
-// --- cistern approve ---
-
-var dropletApproveCmd = &cobra.Command{
-	Use:   "approve <id>",
-	Short: "Approve a human-gated droplet for delivery",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		id := args[0]
-		c, err := cistern.New(resolveDBPath(), "")
-		if err != nil {
-			return err
-		}
-		defer c.Close()
-
-		if err := c.Approve(id, cataractaeName()); err != nil {
-			return err
-		}
-		fmt.Printf("Droplet %s approved for delivery\n", id)
-		return nil
-	},
-}
-
 // --- cistern peek ---
 
 var (
@@ -1257,20 +1217,19 @@ var dropletPeekCmd = &cobra.Command{
 var (
 	editTitle       string
 	editDescription string
-	editComplexity  string
 	editPriority    int
 )
 
 var dropletEditCmd = &cobra.Command{
 	Use:   "edit <id>",
-	Short: "Update title, description, complexity, or priority of a queued droplet",
+	Short: "Update title, description, or priority of a queued droplet",
 	Long: `Edit mutable fields on a droplet that has not yet been picked up.
 
 If no flags are provided, opens the droplet in your editor ($EDITOR, defaults to vi).
 Only the flags you pass are updated.
 
   ct droplet edit <id> -t "new title"
-  ct droplet edit <id> -x critical -p 1
+  ct droplet edit <id> -p 1
 
 To replace the description with multi-line text from stdin:
   echo 'new description' | ct droplet edit <id> --description -
@@ -1283,7 +1242,6 @@ droplet is in_progress or delivered.`,
 
 		titleChanged := cmd.Flags().Changed("title")
 		descChanged := cmd.Flags().Changed("description")
-		cxChanged := cmd.Flags().Changed("complexity")
 		prioChanged := cmd.Flags().Changed("priority")
 
 		c, err := cistern.New(resolveDBPath(), "")
@@ -1292,7 +1250,7 @@ droplet is in_progress or delivered.`,
 		}
 		defer c.Close()
 
-		if !titleChanged && !descChanged && !cxChanged && !prioChanged {
+		if !titleChanged && !descChanged && !prioChanged {
 			return editInteractive(c, id)
 		}
 
@@ -1315,14 +1273,6 @@ droplet is in_progress or delivered.`,
 				desc = strings.TrimSuffix(string(b), "\n")
 			}
 			fields.Description = &desc
-		}
-
-		if cxChanged {
-			cx, err := parseComplexity(editComplexity)
-			if err != nil {
-				return err
-			}
-			fields.Complexity = &cx
 		}
 
 		if prioChanged {
@@ -1398,9 +1348,8 @@ func editInteractive(c *cistern.Client, id string) error {
 			"# Lines starting with # are comments.\n"+
 			"title: %s\n"+
 			"description: %s\n"+
-			"complexity: %s\n"+
 			"priority: %d\n",
-		id, escapeNewlines(d.Title), escapeNewlines(d.Description), complexityName(d.Complexity), d.Priority)
+		id, escapeNewlines(d.Title), escapeNewlines(d.Description), d.Priority)
 
 	tmp, err := os.CreateTemp("", "ct-edit-*.txt")
 	if err != nil {
@@ -1453,14 +1402,6 @@ func editInteractive(c *cistern.Client, id string) error {
 			if unescaped != d.Description {
 				fields.Description = &unescaped
 			}
-		case "complexity":
-			cx, err := parseComplexity(val)
-			if err != nil {
-				return fmt.Errorf("invalid complexity %q: %w", val, err)
-			}
-			if cx != d.Complexity {
-				fields.Complexity = &cx
-			}
 		case "priority":
 			p, err := strconv.Atoi(val)
 			if err != nil {
@@ -1493,7 +1434,6 @@ func init() {
 	dropletAddCmd.Flags().StringVar(&addDescription, "description", "", "droplet description")
 	dropletAddCmd.Flags().IntVar(&addPriority, "priority", 2, "priority (1=highest)")
 	dropletAddCmd.Flags().StringVar(&addRepo, "repo", "", "target repository (required)")
-	dropletAddCmd.Flags().StringVarP(&addComplexity, "complexity", "x", "2", "droplet complexity: 1/standard, 2/full (default), 3/critical")
 	dropletAddCmd.Flags().StringArrayVar(&addDependsOn, "depends-on", nil, "dependency droplet ID (repeatable)")
 
 	dropletDepsCmd.Flags().StringVar(&depsAdd, "add", "", "add a dependency (dep ID)")
@@ -1540,7 +1480,6 @@ func init() {
 
 	dropletEditCmd.Flags().StringVarP(&editTitle, "title", "t", "", "new title")
 	dropletEditCmd.Flags().StringVar(&editDescription, "description", "", "new description (use - to read from stdin)")
-	dropletEditCmd.Flags().StringVarP(&editComplexity, "complexity", "x", "", "new complexity: standard|full|critical (or 1-3)")
 	dropletEditCmd.Flags().IntVarP(&editPriority, "priority", "p", 0, "new priority (positive integer)")
 
 	dropletTailCmd.Flags().StringVar(&tailFmt, "format", "text", "output format: text or json")
@@ -1553,37 +1492,12 @@ func init() {
 
 	dropletCmd.AddCommand(dropletAddCmd, dropletListCmd, dropletShowCmd, dropletNoteCmd,
 		dropletCloseCmd, dropletReopenCmd, dropletPurgeCmd,
-		dropletPassCmd, dropletRecirculateCmd, dropletPoolCmd, dropletCancelCmd, dropletApproveCmd,
+		dropletPassCmd, dropletRecirculateCmd, dropletPoolCmd, dropletCancelCmd,
 		dropletStatsCmd, dropletDepsCmd, dropletPeekCmd, dropletIssueCmd, dropletSearchCmd,
 		dropletExportCmd, dropletRenameCmd, dropletRestartCmd, dropletEditCmd,
 		dropletTailCmd, dropletHeartbeatCmd, dropletLogCmd, dropletHistoryCmd)
 	rootCmd.AddCommand(dropletCmd)
 	rootCmd.AddCommand(evaluateCmd)
-}
-
-// parseComplexity accepts "1"-"3" or names "standard","full","critical".
-func parseComplexity(s string) (int, error) {
-	switch s {
-	case "1", "standard":
-		return 1, nil
-	case "2", "full", "":
-		return 2, nil
-	case "3", "critical":
-		return 3, nil
-	}
-	return 0, fmt.Errorf("invalid complexity %q: use 1/standard, 2/full, 3/critical", s)
-}
-
-// complexityName returns the human name for a complexity level.
-func complexityName(cx int) string {
-	switch cx {
-	case 1:
-		return "standard"
-	case 3:
-		return "critical"
-	default:
-		return "full"
-	}
 }
 
 // inferPrefix extracts a short prefix from a repo path for ID generation.

--- a/cmd/ct/cistern_test.go
+++ b/cmd/ct/cistern_test.go
@@ -89,7 +89,7 @@ func TestCisternListOutputFlag(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		item, err := c.Add("github.com/test/repo", "Test item", "", 1, 3)
+		item, err := c.Add("github.com/test/repo", "Test item", "", 1)
 		c.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -164,7 +164,7 @@ func TestCisternListTableOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = c.Add("github.com/test/repo", "Test droplet", "", 1, 3)
+	_, err = c.Add("github.com/test/repo", "Test droplet", "", 1)
 	c.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -213,8 +213,8 @@ func TestCisternList_PooledItems_NoFlowingMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s1, _ := c.Add("repo", "Pooled one", "", 1, 3)
-	s2, _ := c.Add("repo", "Pooled two", "", 1, 3)
+	s1, _ := c.Add("repo", "Pooled one", "", 1)
+	s2, _ := c.Add("repo", "Pooled two", "", 1)
 	c.Pool(s1.ID, "timed out")
 	c.Pool(s2.ID, "timed out")
 	c.Close()
@@ -272,10 +272,10 @@ func TestCisternList_FlowingAndPooled_ShowsNoMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Create one in_progress (flowing) droplet.
-	ip, _ := c.Add("repo", "In-progress work", "", 1, 3)
+	ip, _ := c.Add("repo", "In-progress work", "", 1)
 	c.UpdateStatus(ip.ID, "in_progress")
 	// Create one pooled droplet.
-	stuck, _ := c.Add("repo", "Stuck item", "", 1, 3)
+	stuck, _ := c.Add("repo", "Stuck item", "", 1)
 	c.Pool(stuck.ID, "timed out")
 	c.Close()
 
@@ -296,63 +296,6 @@ func TestCisternList_FlowingAndPooled_ShowsNoMessage(t *testing.T) {
 	got := strings.TrimSpace(out)
 	if got != "" {
 		t.Fatalf("expected no output when flowing droplets exist, got: %q", got)
-	}
-}
-
-func TestParseComplexity(t *testing.T) {
-	tests := []struct {
-		input   string
-		want    int
-		wantErr bool
-	}{
-		{"1", 1, false},
-		{"2", 2, false},
-		{"3", 3, false},
-		{"standard", 1, false},
-		{"full", 2, false},
-		{"critical", 3, false},
-		{"", 2, false},
-		{"trivial", 0, true},
-		{"4", 0, true},
-		{"5", 0, true},
-		{"foo", 0, true},
-	}
-
-	for _, tt := range tests {
-		got, err := parseComplexity(tt.input)
-		if tt.wantErr {
-			if err == nil {
-				t.Errorf("parseComplexity(%q) = %d, want error", tt.input, got)
-			}
-			continue
-		}
-		if err != nil {
-			t.Errorf("parseComplexity(%q) error: %v", tt.input, err)
-			continue
-		}
-		if got != tt.want {
-			t.Errorf("parseComplexity(%q) = %d, want %d", tt.input, got, tt.want)
-		}
-	}
-}
-
-func TestComplexityName(t *testing.T) {
-	tests := []struct {
-		level int
-		want  string
-	}{
-		{1, "standard"},
-		{2, "full"},
-		{3, "critical"},
-		{0, "full"},
-		{4, "full"},
-		{99, "full"},
-	}
-	for _, tt := range tests {
-		got := complexityName(tt.level)
-		if got != tt.want {
-			t.Errorf("complexityName(%d) = %q, want %q", tt.level, got, tt.want)
-		}
 	}
 }
 
@@ -479,14 +422,12 @@ func TestDropletAddCmd_NormalizesRepoCase(t *testing.T) {
 
 	addTitle = "Test droplet"
 	addRepo = "portfoliowebsite"
-	addComplexity = "1"
 	addDescription = ""
 	addPriority = 1
 	addDependsOn = nil
 	defer func() {
 		addTitle = ""
 		addRepo = ""
-		addComplexity = ""
 		addPriority = 0
 		addDependsOn = nil
 	}()
@@ -522,11 +463,9 @@ func TestDropletAddCmd_UnknownRepo_ReturnsError(t *testing.T) {
 
 	addTitle = "Test droplet"
 	addRepo = "nonexistent"
-	addComplexity = "1"
 	defer func() {
 		addTitle = ""
 		addRepo = ""
-		addComplexity = ""
 	}()
 
 	err := dropletAddCmd.RunE(dropletAddCmd, nil)
@@ -577,13 +516,13 @@ func TestDropletStats_WithData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("repo", "q1", "", 1, 3)
-	c.Add("repo", "q2", "", 1, 3)
-	ip, _ := c.Add("repo", "ip1", "", 1, 3)
-	d1, _ := c.Add("repo", "d1", "", 1, 3)
-	d2, _ := c.Add("repo", "d2", "", 1, 3)
-	d3, _ := c.Add("repo", "d3", "", 1, 3)
-	s1, _ := c.Add("repo", "s1", "", 1, 3)
+	c.Add("repo", "q1", "", 1)
+	c.Add("repo", "q2", "", 1)
+	ip, _ := c.Add("repo", "ip1", "", 1)
+	d1, _ := c.Add("repo", "d1", "", 1)
+	d2, _ := c.Add("repo", "d2", "", 1)
+	d3, _ := c.Add("repo", "d3", "", 1)
+	s1, _ := c.Add("repo", "s1", "", 1)
 	c.UpdateStatus(ip.ID, "in_progress")
 	c.CloseItem(d1.ID)
 	c.CloseItem(d2.ID)
@@ -638,7 +577,7 @@ func TestDropletCancel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("repo", "Old feature", "", 1, 3)
+	item, err := c.Add("repo", "Old feature", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -675,7 +614,7 @@ func TestDropletCancel_WithReason(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("repo", "Superseded feature", "", 1, 3)
+	item, err := c.Add("repo", "Superseded feature", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -730,7 +669,7 @@ func TestDropletCancel_TerminalStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, _ := c.Add("repo", "Done feature", "", 1, 3)
+	item, _ := c.Add("repo", "Done feature", "", 1)
 	c.CloseItem(item.ID)
 	c.Close()
 
@@ -768,7 +707,7 @@ func TestDropletCancel_NotesAliasBackwardCompat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("repo", "Old feature", "", 1, 3)
+	item, err := c.Add("repo", "Old feature", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -802,8 +741,8 @@ func TestDropletList_HidesCancelledByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	active, _ := c.Add("repo", "Active feature", "", 1, 3)
-	cancelled, _ := c.Add("repo", "Old feature", "", 1, 3)
+	active, _ := c.Add("repo", "Active feature", "", 1)
+	cancelled, _ := c.Add("repo", "Old feature", "", 1)
 	c.Cancel(cancelled.ID, "not needed")
 	c.Close()
 
@@ -850,8 +789,8 @@ func TestDropletList_CancelledFlag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("repo", "Active feature", "", 1, 3)
-	cancelled, _ := c.Add("repo", "Old feature", "", 1, 3)
+	c.Add("repo", "Active feature", "", 1)
+	cancelled, _ := c.Add("repo", "Old feature", "", 1)
 	c.Cancel(cancelled.ID, "not needed")
 	c.Close()
 
@@ -880,107 +819,6 @@ func TestDropletList_CancelledFlag(t *testing.T) {
 	}
 }
 
-func TestDropletApprove(t *testing.T) {
-	dir := t.TempDir()
-	db := filepath.Join(dir, "test.db")
-	t.Setenv("CT_DB", db)
-
-	c, err := cistern.New(db, "ts")
-	if err != nil {
-		t.Fatal(err)
-	}
-	item, err := c.Add("repo", "Critical feature", "", 1, 4)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Simulate scheduler routing to human gate.
-	c.UpdateStatus(item.ID, "pooled")
-	c.SetCataractae(item.ID, "human")
-	c.Close()
-
-	t.Run("approve releases to delivery", func(t *testing.T) {
-		old := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
-		err := dropletApproveCmd.RunE(dropletApproveCmd, []string{item.ID})
-
-		w.Close()
-		os.Stdout = old
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		var buf bytes.Buffer
-		buf.ReadFrom(r)
-		out := buf.String()
-		if !strings.Contains(out, "approved for delivery") {
-			t.Errorf("expected 'approved for delivery' in output, got: %q", out)
-		}
-
-		// Verify DB state: status=open, current_cataractae=delivery.
-		c2, _ := cistern.New(db, "")
-		defer c2.Close()
-		got, err := c2.Get(item.ID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got.Status != "open" {
-			t.Errorf("expected status 'open', got %q", got.Status)
-		}
-		if got.CurrentCataractae != "delivery" {
-			t.Errorf("expected current_cataractae 'delivery', got %q", got.CurrentCataractae)
-		}
-	})
-}
-
-func TestDropletApprove_NotHumanGated(t *testing.T) {
-	dir := t.TempDir()
-	db := filepath.Join(dir, "test.db")
-	t.Setenv("CT_DB", db)
-
-	c, err := cistern.New(db, "ts")
-	if err != nil {
-		t.Fatal(err)
-	}
-	item, err := c.Add("repo", "Normal feature", "", 1, 3)
-	c.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = dropletApproveCmd.RunE(dropletApproveCmd, []string{item.ID})
-	if err == nil {
-		t.Fatal("expected error for non-human-gated droplet")
-	}
-	if !strings.Contains(err.Error(), "not awaiting human approval") {
-		t.Errorf("expected 'not awaiting human approval' in error, got: %v", err)
-	}
-}
-
-func TestDisplayStatusForDroplet_AwaitingApproval(t *testing.T) {
-	// Human-gated droplet should display as "awaiting".
-	d := &cistern.Droplet{Status: "pooled", CurrentCataractae: "human"}
-	got := displayStatusForDroplet(d)
-	if got != "awaiting" {
-		t.Errorf("expected 'awaiting', got %q", got)
-	}
-
-	// Non-human pooled droplet should display as "pooled".
-	d2 := &cistern.Droplet{Status: "pooled", CurrentCataractae: "implement"}
-	got2 := displayStatusForDroplet(d2)
-	if got2 != "pooled" {
-		t.Errorf("expected 'pooled', got %q", got2)
-	}
-
-	// Icon for awaiting should be present in statusIcon.
-	icon := statusIcon("awaiting")
-	if !strings.Contains(icon, "⏸") {
-		t.Errorf("expected ⏸ icon for 'awaiting', got %q", icon)
-	}
-}
-
 func TestDropletSearch(t *testing.T) {
 	dir := t.TempDir()
 	db := filepath.Join(dir, "test.db")
@@ -991,9 +829,9 @@ func TestDropletSearch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("repo", "Fix login bug", "", 1, 3)
-	c.Add("repo", "Add dashboard", "", 2, 3)
-	ip, _ := c.Add("repo", "Fix payments", "", 1, 3)
+	c.Add("repo", "Fix login bug", "", 1)
+	c.Add("repo", "Add dashboard", "", 2)
+	ip, _ := c.Add("repo", "Fix payments", "", 1)
 	c.UpdateStatus(ip.ID, "in_progress")
 	c.Close()
 
@@ -1138,7 +976,7 @@ func TestDropletSearch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		stuck, _ := cs.Add("repo", "Stuck integration", "", 1, 3)
+		stuck, _ := cs.Add("repo", "Stuck integration", "", 1)
 		cs.Pool(stuck.ID, "timed out")
 		cs.Close()
 
@@ -1175,7 +1013,7 @@ func TestDropletExport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("repo", "Export test droplet", "", 1, 3)
+	item, err := c.Add("repo", "Export test droplet", "", 1)
 	c.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -1326,7 +1164,7 @@ func TestDropletRename(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("repo", "Original Title", "", 1, 3)
+	item, err := c.Add("repo", "Original Title", "", 1)
 	c.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -1360,7 +1198,6 @@ func resetEditFlags() {
 	dropletEditCmd.ResetFlags()
 	dropletEditCmd.Flags().StringVarP(&editTitle, "title", "t", "", "")
 	dropletEditCmd.Flags().StringVar(&editDescription, "description", "", "")
-	dropletEditCmd.Flags().StringVarP(&editComplexity, "complexity", "x", "", "")
 	dropletEditCmd.Flags().IntVarP(&editPriority, "priority", "p", 0, "")
 }
 
@@ -1431,7 +1268,7 @@ func TestDropletEdit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("repo", "Original title", "old description", 3, 3)
+	item, err := c.Add("repo", "Original title", "old description", 3)
 	c.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -1466,10 +1303,6 @@ func TestDropletEdit(t *testing.T) {
 		if got.Title != "Original title" {
 			t.Errorf("title changed unexpectedly: %q", got.Title)
 		}
-		// Complexity unchanged.
-		if got.Complexity != 3 {
-			t.Errorf("complexity changed unexpectedly: %d", got.Complexity)
-		}
 	})
 
 	t.Run("description from stdin", func(t *testing.T) {
@@ -1502,28 +1335,6 @@ func TestDropletEdit(t *testing.T) {
 		}
 		if got.Description != "stdin description" {
 			t.Errorf("description = %q, want %q", got.Description, "stdin description")
-		}
-	})
-
-	t.Run("update complexity", func(t *testing.T) {
-		resetEditFlags()
-		dropletEditCmd.Flags().Set("complexity", "standard")
-
-		if err := dropletEditCmd.RunE(dropletEditCmd, []string{item.ID}); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		c2, err := cistern.New(db, "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer c2.Close()
-		got, err := c2.Get(item.ID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got.Complexity != 1 {
-			t.Errorf("complexity = %d, want 1", got.Complexity)
 		}
 	})
 
@@ -1569,7 +1380,7 @@ func TestDropletEdit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		ip, err := c2.Add("repo", "Flowing droplet", "", 1, 3)
+		ip, err := c2.Add("repo", "Flowing droplet", "", 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1596,7 +1407,7 @@ func TestDropletEdit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		item2, err := c2.Add("repo", "Old Title", "desc", 2, 3)
+		item2, err := c2.Add("repo", "Old Title", "desc", 2)
 		c2.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -1675,7 +1486,7 @@ func TestDropletHeartbeat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("repo", "Feature", "", 1, 3)
+	item, err := c.Add("repo", "Feature", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1756,7 +1567,7 @@ func TestEditInteractive_LiteralBackslashN(t *testing.T) {
 		t.Fatal(err)
 	}
 	literalDesc := `Use \n for newlines`
-	item, err := c.Add("repo", "Test title", literalDesc, 1, 3)
+	item, err := c.Add("repo", "Test title", literalDesc, 1)
 	c.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -1796,7 +1607,7 @@ func TestEditInteractive_TitleWithNewlines(t *testing.T) {
 		t.Fatal(err)
 	}
 	multilineTitle := "line1\nline2"
-	item, err := c.Add("repo", multilineTitle, "desc", 1, 3)
+	item, err := c.Add("repo", multilineTitle, "desc", 1)
 	c.Close()
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/ct/cockpit_tui.go
+++ b/cmd/ct/cockpit_tui.go
@@ -130,7 +130,7 @@ func (p dropletsPanel) PaletteActions(droplet *cistern.Droplet) []PaletteAction 
 		dropletPaletteAction("pool", "move droplet to pool", id, actionPool),
 		dropletPaletteAction("restart", "restart this droplet", id, actionRestart),
 		dropletPaletteAction("add note", "add a note to this droplet", id, actionAddNote),
-		dropletPaletteAction("edit metadata", "edit title, priority, complexity, description", id, actionEditMeta),
+		dropletPaletteAction("edit metadata", "edit title, priority, description", id, actionEditMeta),
 		dropletPaletteAction("add dependency", "add a droplet dependency", id, actionAddDep),
 		dropletPaletteAction("remove dependency", "remove a droplet dependency", id, actionRemoveDep),
 		dropletPaletteAction("file issue", "file an issue against this droplet", id, actionFileIssue),

--- a/cmd/ct/color_test.go
+++ b/cmd/ct/color_test.go
@@ -213,11 +213,10 @@ func TestPrintDropletListTerminal(t *testing.T) {
 		return &cistern.Droplet{
 			ID:                id,
 			Title:             title,
-			Status:            status,
-			CurrentCataractae: cataractae,
-			Complexity:        2,
-			UpdatedAt:         time.Now(),
-		}
+ 			Status:            status,
+ 			CurrentCataractae: cataractae,
+ 			UpdatedAt:         time.Now(),
+ 		}
 	}
 
 	t.Run("empty lists print only header", func(t *testing.T) {
@@ -225,7 +224,7 @@ func TestPrintDropletListTerminal(t *testing.T) {
 			printDropletListTerminal(nil, nil, false, 30)
 		})
 		// Header must contain all column labels.
-		for _, label := range []string{"ID", "COMPLEXITY", "TITLE", "STATUS", "ELAPSED", "CATARACTA"} {
+		for _, label := range []string{"ID", "TITLE", "STATUS", "ELAPSED", "CATARACTA"} {
 			if !strings.Contains(out, label) {
 				t.Errorf("header missing column %q:\n%s", label, out)
 			}

--- a/cmd/ct/dashboard_api_test.go
+++ b/cmd/ct/dashboard_api_test.go
@@ -47,7 +47,7 @@ func TestAPI_GetDroplets_ReturnsJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("myrepo", "Test droplet", "", 1, 2)
+	c.Add("myrepo", "Test droplet", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -85,8 +85,8 @@ func TestAPI_GetDroplets_FiltersByRepo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("repo-a", "Drop A", "", 1, 2)
-	c.Add("repo-b", "Drop B", "", 1, 2)
+	c.Add("repo-a", "Drop A", "", 1)
+	c.Add("repo-b", "Drop B", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -111,10 +111,10 @@ func TestAPI_GetDroplets_FiltersByStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Active", "", 1, 2)
+	d, _ := c.Add("myrepo", "Active", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(d.ID, "virgo", "implement")
-	c.Add("myrepo", "Queued", "", 2, 2)
+	c.Add("myrepo", "Queued", "", 2)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -150,7 +150,7 @@ func TestAPI_GetDroplets_Pagination(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < 5; i++ {
-		c.Add("myrepo", fmt.Sprintf("Drop %d", i), "", 1, 2)
+		c.Add("myrepo", fmt.Sprintf("Drop %d", i), "", 1)
 	}
 	c.Close()
 
@@ -208,7 +208,7 @@ func TestAPI_GetDroplets_PerPageCap(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < 5; i++ {
-		c.Add("myrepo", fmt.Sprintf("Drop %d", i), "", 1, 2)
+		c.Add("myrepo", fmt.Sprintf("Drop %d", i), "", 1)
 	}
 	c.Close()
 
@@ -241,9 +241,9 @@ func TestAPI_GetDroplets_Sort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("myrepo", "Bravo", "", 2, 2)
-	c.Add("myrepo", "Alpha", "", 1, 2)
-	c.Add("myrepo", "Charlie", "", 3, 2)
+	c.Add("myrepo", "Bravo", "", 2)
+	c.Add("myrepo", "Alpha", "", 1)
+	c.Add("myrepo", "Charlie", "", 3)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -286,7 +286,7 @@ func TestAPI_GetDropletByID_ReturnsDroplet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Specific", "a description", 1, 2)
+	d, _ := c.Add("myrepo", "Specific", "a description", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -325,8 +325,8 @@ func TestAPI_GetDropletsSearch_ReturnsMatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("myrepo", "Feature Alpha", "", 1, 2)
-	c.Add("myrepo", "Bug Fix Beta", "", 2, 2)
+	c.Add("myrepo", "Feature Alpha", "", 1)
+	c.Add("myrepo", "Bug Fix Beta", "", 2)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -367,7 +367,7 @@ func TestAPI_SearchDroplets_Pagination(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < 5; i++ {
-		c.Add("myrepo", fmt.Sprintf("Search Hit %d", i), "", 1, 2)
+		c.Add("myrepo", fmt.Sprintf("Search Hit %d", i), "", 1)
 	}
 	c.Close()
 
@@ -419,7 +419,7 @@ func TestAPI_SearchDroplets_Pagination(t *testing.T) {
 
 func TestAPI_CreateDroplet_Success(t *testing.T) {
 	mux := newDashboardMux(tempCfg(t), tempDB(t))
-	body := `{"repo":"myrepo","title":"New Feature","description":"desc","priority":1,"complexity":2}`
+	body := `{"repo":"myrepo","title":"New Feature","description":"desc","priority":1}`
 	req := httptest.NewRequest(http.MethodPost, "/api/droplets", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -473,7 +473,7 @@ func TestAPI_EditDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Original", "", 1, 2)
+	d, _ := c.Add("myrepo", "Original", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -501,7 +501,7 @@ func TestAPI_RenameDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Old Name", "", 1, 2)
+	d, _ := c.Add("myrepo", "Old Name", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -524,7 +524,7 @@ func TestAPI_PassDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -545,7 +545,7 @@ func TestAPI_RecirculateDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -566,7 +566,7 @@ func TestAPI_PoolDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -587,7 +587,7 @@ func TestAPI_CloseDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -606,7 +606,7 @@ func TestAPI_ReopenDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.CloseItem(d.ID)
 	c.Close()
 
@@ -626,7 +626,7 @@ func TestAPI_CancelDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -647,7 +647,7 @@ func TestAPI_RestartDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -668,7 +668,7 @@ func TestAPI_ApproveDroplet_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Assign(d.ID, "", "human")
 	c.Close()
 
@@ -688,7 +688,7 @@ func TestAPI_Heartbeat_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -709,7 +709,7 @@ func TestAPI_GetNotes_ReturnsNotes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.AddNote(d.ID, "implementer", "hello world")
 	c.AddNote(d.ID, "reviewer", "looks good")
 	c.Close()
@@ -737,7 +737,7 @@ func TestAPI_AddNote_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -758,7 +758,7 @@ func TestAPI_AddNote_MissingContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -780,7 +780,7 @@ func TestAPI_GetIssues_ReturnsIssues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.AddIssue(d.ID, "reviewer", "bug found")
 	c.Close()
 
@@ -807,7 +807,7 @@ func TestAPI_GetIssues_FilterOpen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	iss, _ := c.AddIssue(d.ID, "reviewer", "open bug")
 	c.ResolveIssue(iss.ID, "fixed")
 	c.Close()
@@ -832,7 +832,7 @@ func TestAPI_AddIssue_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -853,7 +853,7 @@ func TestAPI_ResolveIssue_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	iss, _ := c.AddIssue(d.ID, "reviewer", "to fix")
 	c.Close()
 
@@ -875,7 +875,7 @@ func TestAPI_RejectIssue_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	iss, _ := c.AddIssue(d.ID, "reviewer", "to reject")
 	c.Close()
 
@@ -899,8 +899,8 @@ func TestAPI_GetDependencies_ReturnsDeps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	parent, _ := c.Add("myrepo", "Parent", "", 1, 2)
-	child, _ := c.Add("myrepo", "Child", "", 2, 2, parent.ID)
+	parent, _ := c.Add("myrepo", "Parent", "", 1)
+	child, _ := c.Add("myrepo", "Child", "", 2, parent.ID)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -935,9 +935,9 @@ func TestAPI_GetDependencies_ResolvesAndBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	parent, _ := c.Add("myrepo", "Parent", "", 1, 2)
-	child, _ := c.Add("myrepo", "Child", "", 2, 2, parent.ID)
-	grandchild, _ := c.Add("myrepo", "Grandchild", "", 3, 2, child.ID)
+	parent, _ := c.Add("myrepo", "Parent", "", 1)
+	child, _ := c.Add("myrepo", "Child", "", 2, parent.ID)
+	grandchild, _ := c.Add("myrepo", "Grandchild", "", 3, child.ID)
 	c.CloseItem(parent.ID)
 	c.Close()
 
@@ -1011,8 +1011,8 @@ func TestAPI_AddDependency_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	parent, _ := c.Add("myrepo", "Parent", "", 1, 2)
-	child, _ := c.Add("myrepo", "Child", "", 2, 2)
+	parent, _ := c.Add("myrepo", "Parent", "", 1)
+	child, _ := c.Add("myrepo", "Child", "", 2)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1046,8 +1046,8 @@ func TestAPI_RemoveDependency_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	parent, _ := c.Add("myrepo", "Parent", "", 1, 2)
-	child, _ := c.Add("myrepo", "Child", "", 2, 2, parent.ID)
+	parent, _ := c.Add("myrepo", "Parent", "", 1)
+	child, _ := c.Add("myrepo", "Child", "", 2, parent.ID)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1068,7 +1068,7 @@ func TestAPI_GetDropletLog_ReturnsTimeline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.AddNote(d.ID, "implementer", "started")
 	c.Close()
 
@@ -1095,7 +1095,7 @@ func TestAPI_GetDropletChanges_ReturnsChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.AddNote(d.ID, "implementer", "half done")
 	c.Close()
 
@@ -1117,7 +1117,7 @@ func TestAPI_GetStats_ReturnsStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("myrepo", "Test", "", 1, 2)
+	c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1145,7 +1145,7 @@ func TestAPI_ExportJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("myrepo", "Export Test", "", 1, 2)
+	c.Add("myrepo", "Export Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1168,7 +1168,7 @@ func TestAPI_ExportCSV(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("myrepo", "Export CSV", "a description", 1, 2)
+	c.Add("myrepo", "Export CSV", "a description", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1414,7 +1414,7 @@ func TestAPI_ApproveDroplet_NotHumanGated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	// Not assigning to "human" — default is not human-gated
 	c.Close()
 
@@ -1445,8 +1445,8 @@ func TestAPI_ExportWithRepoFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("repo-a", "Drop A", "", 1, 2)
-	c.Add("repo-b", "Drop B", "", 1, 2)
+	c.Add("repo-a", "Drop A", "", 1)
+	c.Add("repo-b", "Drop B", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1475,9 +1475,9 @@ func TestAPI_ExportWithRepoAndStatusFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("repo-a", "Drop A", "", 1, 2)
-	dropB, _ := c.Add("repo-a", "Drop B", "", 1, 2)
-	c.Add("repo-b", "Drop C", "", 1, 2)
+	c.Add("repo-a", "Drop A", "", 1)
+	dropB, _ := c.Add("repo-a", "Drop B", "", 1)
+	c.Add("repo-b", "Drop C", "", 1)
 	c.CloseItem(dropB.ID)
 	c.Close()
 
@@ -1512,9 +1512,9 @@ func TestAPI_ExportWithRepoAndStatusFilter_CSV(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("repo-a", "Drop A", "", 1, 2)
-	dropB, _ := c.Add("repo-a", "Drop B", "", 1, 2)
-	c.Add("repo-b", "Drop C", "", 1, 2)
+	c.Add("repo-a", "Drop A", "", 1)
+	dropB, _ := c.Add("repo-a", "Drop B", "", 1)
+	c.Add("repo-b", "Drop C", "", 1)
 	c.CloseItem(dropB.ID)
 	c.Close()
 
@@ -1557,7 +1557,7 @@ func TestAPI_DropletEvents_SSE(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1606,7 +1606,7 @@ func TestAPI_DropletLog_FormatNotes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.AddNote(d.ID, "implementer", "note one")
 	c.AddNote(d.ID, "reviewer", "note two")
 	c.Close()
@@ -1634,7 +1634,7 @@ func TestAPI_DropletLog_FormatDefault_ReturnsTimeline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.AddNote(d.ID, "implementer", "started")
 	c.Close()
 
@@ -1721,7 +1721,7 @@ func TestAPI_PassDroplet_InvalidJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1740,7 +1740,7 @@ func TestAPI_RecirculateDroplet_InvalidJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1759,7 +1759,7 @@ func TestAPI_PoolDroplet_InvalidJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1778,7 +1778,7 @@ func TestAPI_CancelDroplet_InvalidJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1799,7 +1799,7 @@ func TestAPI_PassDroplet_EmptyBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1817,7 +1817,7 @@ func TestAPI_CancelDroplet_EmptyBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1873,7 +1873,7 @@ func TestAPI_RestartDroplet_EmptyBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -1938,7 +1938,7 @@ func TestAPI_Auth_ValidBearer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("myrepo", "Auth Test", "", 1, 2)
+	c.Add("myrepo", "Auth Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(cfgPath, db)
@@ -2105,7 +2105,7 @@ func TestAPI_InputLimit_RenameTitleTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Original", "", 1, 2)
+	d, _ := c.Add("myrepo", "Original", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2126,7 +2126,7 @@ func TestAPI_InputLimit_AddNoteContentTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2147,7 +2147,7 @@ func TestAPI_InputLimit_AddIssueDescriptionTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2168,7 +2168,7 @@ func TestAPI_InputLimit_AddDependencyDepTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2189,7 +2189,7 @@ func TestAPI_SSALimit_ConnectionLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	original := currentDropletSSEConnections
@@ -2286,7 +2286,7 @@ func TestAPI_ApproveDroplet_NotHumanGated_NoLeak(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2313,7 +2313,7 @@ func TestAPI_DropletLog_LimitCapsAt1000(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2332,7 +2332,7 @@ func TestAPI_DropletChanges_LimitCapsAt1000(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2351,7 +2351,7 @@ func TestAPI_CSVEscape_FormulaInjection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Add("myrepo", "=SUM(A1:A10)", "starts with equals", 1, 2)
+	c.Add("myrepo", "=SUM(A1:A10)", "starts with equals", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2485,7 +2485,7 @@ func TestAPI_InputLimit_EditDropletTitleTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Original", "", 1, 2)
+	d, _ := c.Add("myrepo", "Original", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2506,7 +2506,7 @@ func TestAPI_InputLimit_EditDropletDescriptionTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Original", "", 1, 2)
+	d, _ := c.Add("myrepo", "Original", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -2527,7 +2527,7 @@ func TestAPI_InputLimit_PassDropletNotesTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.GetReady("myrepo")
 	c.Close()
 
@@ -2707,7 +2707,7 @@ func TestAPI_InputLimit_CancelDropletReasonTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.GetReady("myrepo")
 	c.Close()
 
@@ -3213,7 +3213,7 @@ func TestAPI_SSE_SeparateConnectionPools(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	d, _ := c.Add("myrepo", "Test", "", 1)
 	c.Close()
 
 	mux := newDashboardMux(tempCfg(t), db)
@@ -3660,7 +3660,7 @@ func TestAPI_ImportHandler_RepoError_Sanitized(t *testing.T) {
 	t.Setenv("CT_CONFIG", cfgPath)
 	mux := newDashboardMux(cfgPath, tempDB(t))
 
-	body := `{"provider":"jira","key":"PROJ-123","repo":"nonexistent","complexity":2,"priority":1}`
+	body := `{"provider":"jira","key":"PROJ-123","repo":"nonexistent","priority":1}`
 	req := httptest.NewRequest(http.MethodPost, "/api/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/cmd/ct/dashboard_test.go
+++ b/cmd/ct/dashboard_test.go
@@ -131,13 +131,13 @@ func TestFetchDashboardData_FeedsDataCorrectly(t *testing.T) {
 	}
 
 	// Add: 1 flowing assigned to "virgo", 1 queued, 1 closed.
-	flowing, _ := c.Add("myrepo", "Feature A", "", 1, 2)
+	flowing, _ := c.Add("myrepo", "Feature A", "", 1)
 	c.GetReady("myrepo") // marks it in_progress
 	c.Assign(flowing.ID, "virgo", "implement")
 
-	_, _ = c.Add("myrepo", "Feature B", "", 2, 2) // stays open/queued
+	_, _ = c.Add("myrepo", "Feature B", "", 2) // stays open/queued
 
-	closed, _ := c.Add("myrepo", "Feature C", "", 1, 2)
+	closed, _ := c.Add("myrepo", "Feature C", "", 1)
 	c.CloseItem(closed.ID)
 	c.Close()
 
@@ -521,7 +521,7 @@ func TestRenderDashboard_ContainsExpectedSections(t *testing.T) {
 			{Name: "marcia", Steps: steps},
 		},
 		CisternItems: []*cistern.Droplet{
-			{ID: "ci-abc12", Repo: "cistern", Status: "in_progress", CurrentCataractae: "implement", Complexity: 2},
+			{ID: "ci-abc12", Repo: "cistern", Status: "in_progress", CurrentCataractae: "implement"},
 		},
 		RecentItems: []*cistern.Droplet{
 			{ID: "ci-xyz99", Status: "delivered", CurrentCataractae: "merge", UpdatedAt: time.Now()},
@@ -780,11 +780,11 @@ func TestFetchDashboardData_PooledItems_PopulatedCorrectly(t *testing.T) {
 	}
 
 	// Add a pooled item and a delivered item.
-	pooled, _ := c.Add("myrepo", "Stuck Feature", "", 1, 2)
+	pooled, _ := c.Add("myrepo", "Stuck Feature", "", 1)
 	c.GetReady("myrepo")
 	c.Pool(pooled.ID, "test pooling")
 
-	delivered, _ := c.Add("myrepo", "Done Feature", "", 1, 2)
+	delivered, _ := c.Add("myrepo", "Done Feature", "", 1)
 	c.GetReady("myrepo")
 	c.CloseItem(delivered.ID)
 	c.Close()
@@ -813,7 +813,7 @@ func TestFetchDashboardData_PooledItems_EmptyWhenNonePooled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	delivered, _ := c.Add("myrepo", "Done Feature", "", 1, 2)
+	delivered, _ := c.Add("myrepo", "Done Feature", "", 1)
 	c.GetReady("myrepo")
 	c.CloseItem(delivered.ID)
 	c.Close()
@@ -1033,7 +1033,7 @@ func TestFetchDashboardData_ActiveAqueduct_ShowsAllSteps(t *testing.T) {
 
 	// Complexity 1 droplet assigned at "merge" (the 3rd step). All 3 steps must
 	// appear and CataractaeIndex must correctly reflect position in the full list.
-	item, _ := c.Add("myrepo", "Trivial task", "", 1, 1)
+	item, _ := c.Add("myrepo", "Trivial task", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(item.ID, "virgo", "merge")
 	c.Close()
@@ -1674,7 +1674,7 @@ func TestFetchDashboardData_InProgressWithEmptyAssignee_AppearsAsUnassigned(t *t
 	}
 
 	// Add and immediately mark in_progress — skip Assign so Assignee stays empty.
-	orphan, _ := c.Add("myrepo", "Orphaned Feature", "", 1, 2)
+	orphan, _ := c.Add("myrepo", "Orphaned Feature", "", 1)
 	c.GetReady("myrepo")
 	c.Close()
 
@@ -1708,12 +1708,12 @@ func TestFetchDashboardData_InProgressWithEmptyAssignee_FlowingCountMatchesVisib
 	}
 
 	// Assigned item — visible in the "virgo" aqueduct row.
-	assigned, _ := c.Add("myrepo", "Assigned Feature", "", 1, 2)
+	assigned, _ := c.Add("myrepo", "Assigned Feature", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(assigned.ID, "virgo", "implement")
 
 	// Unassigned item — in_progress but no Assign call.
-	_, _ = c.Add("myrepo", "Orphaned Feature", "", 1, 2)
+	_, _ = c.Add("myrepo", "Orphaned Feature", "", 1)
 	c.GetReady("myrepo")
 
 	c.Close()
@@ -1744,7 +1744,7 @@ func TestFetchDashboardData_AssignedInProgress_NotInUnassigned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	item, _ := c.Add("myrepo", "Normal Feature", "", 1, 2)
+	item, _ := c.Add("myrepo", "Normal Feature", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(item.ID, "virgo", "implement")
 	c.Close()
@@ -1887,7 +1887,7 @@ func TestFetchDashboardData_AssignedToRemovedAqueduct_AppearsAsUnassigned(t *tes
 		t.Fatal(err)
 	}
 
-	item, _ := c.Add("myrepo", "Stale Assignment", "", 1, 2)
+	item, _ := c.Add("myrepo", "Stale Assignment", "", 1)
 	c.GetReady("myrepo")
 	// Assign to an aqueduct that no longer exists in the config.
 	c.Assign(item.ID, "deleted-aqueduct", "implement")
@@ -1940,7 +1940,7 @@ func TestFetchDashboardData_StageElapsed_UsesStageDispatchedAt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	flowing, _ := c.Add("myrepo", "Stage elapsed test", "", 1, 2)
+	flowing, _ := c.Add("myrepo", "Stage elapsed test", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(flowing.ID, "virgo", "implement")
 	c.Close()
@@ -1975,7 +1975,7 @@ func TestFetchDashboardData_StageElapsed_ZeroWhenNotDispatched(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	flowing, _ := c.Add("myrepo", "No stage dispatch test", "", 1, 2)
+	flowing, _ := c.Add("myrepo", "No stage dispatch test", "", 1)
 	c.GetReady("myrepo")
 	c.Close()
 

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -1558,7 +1558,6 @@ type createDropletRequest struct {
 	Title       string   `json:"title"`
 	Description string   `json:"description"`
 	Priority    int      `json:"priority"`
-	Complexity  int      `json:"complexity"`
 	DependsOn   []string `json:"depends_on"`
 }
 
@@ -1588,14 +1587,11 @@ func handleCreateDroplet(dbPath string) http.HandlerFunc {
 			writeAPIError(w, http.StatusBadRequest, fmt.Sprintf("description exceeds maximum length (%d)", maxDescriptionLen))
 			return
 		}
-		if req.Complexity < 1 || req.Complexity > 3 {
-			req.Complexity = 2
-		}
 		if req.Priority < 1 {
 			req.Priority = 2
 		}
 		apiClient(dbPath, w, func(c *cistern.Client) error {
-			d, err := c.Add(req.Repo, req.Title, req.Description, req.Priority, req.Complexity, req.DependsOn...)
+			d, err := c.Add(req.Repo, req.Title, req.Description, req.Priority, req.DependsOn...)
 			if err != nil {
 				return err
 			}
@@ -1608,7 +1604,6 @@ func handleCreateDroplet(dbPath string) http.HandlerFunc {
 type editDropletRequest struct {
 	Title       *string `json:"title,omitempty"`
 	Description *string `json:"description,omitempty"`
-	Complexity  *int    `json:"complexity,omitempty"`
 	Priority    *int    `json:"priority,omitempty"`
 }
 
@@ -1631,7 +1626,6 @@ func handleEditDroplet(dbPath string) http.HandlerFunc {
 			if err := c.EditDroplet(id, cistern.EditDropletFields{
 				Title:       req.Title,
 				Description: req.Description,
-				Complexity:  req.Complexity,
 				Priority:    req.Priority,
 			}); err != nil {
 				return err
@@ -1719,13 +1713,13 @@ func handleExportDroplets(dbPath string) http.HandlerFunc {
 			case "csv":
 				w.Header().Set("Content-Type", "text/csv")
 				cw := csv.NewWriter(w)
-				if err := cw.Write([]string{"id", "repo", "title", "description", "priority", "complexity", "status", "assignee", "current_cataractae", "outcome", "created_at", "updated_at"}); err != nil {
+				if err := cw.Write([]string{"id", "repo", "title", "description", "priority", "status", "assignee", "current_cataractae", "outcome", "created_at", "updated_at"}); err != nil {
 					return err
 				}
 				for _, item := range items {
 					if err := cw.Write([]string{
 						csvSanitizeCell(item.ID), csvSanitizeCell(item.Repo), csvSanitizeCell(item.Title), csvSanitizeCell(item.Description),
-						strconv.Itoa(item.Priority), strconv.Itoa(item.Complexity),
+						strconv.Itoa(item.Priority),
 						csvSanitizeCell(item.Status), csvSanitizeCell(item.Assignee), csvSanitizeCell(item.CurrentCataractae), csvSanitizeCell(item.Outcome),
 						item.CreatedAt.Format(time.RFC3339), item.UpdatedAt.Format(time.RFC3339),
 					}); err != nil {
@@ -3347,11 +3341,10 @@ func handleFilterSession(dbPath string) http.HandlerFunc {
 // ── Import handler ──
 
 type importRequest struct {
-	Provider   string `json:"provider"`
-	Key        string `json:"key"`
-	Repo       string `json:"repo"`
-	Complexity int    `json:"complexity"`
-	Priority   int    `json:"priority"`
+	Provider string `json:"provider"`
+	Key      string `json:"key"`
+	Repo     string `json:"repo"`
+	Priority int    `json:"priority"`
 }
 
 func handleImport(cfgPath, dbPath string) http.HandlerFunc {
@@ -3414,15 +3407,11 @@ func handleImport(cfgPath, dbPath string) http.HandlerFunc {
 		if req.Priority > 0 {
 			priority = req.Priority
 		}
-		complexity := req.Complexity
-		if complexity < 1 || complexity > 3 {
-			complexity = 2
-		}
 
 		externalRef := req.Provider + ":" + req.Key
 
 		apiClient(dbPath, w, func(c *cistern.Client) error {
-			d, err := c.AddDroplet(repo, issue.Title, issue.Description, externalRef, priority, complexity)
+			d, err := c.AddDroplet(repo, issue.Title, issue.Description, externalRef, priority)
 			if err != nil {
 				return err
 			}

--- a/cmd/ct/dashboard_web_test.go
+++ b/cmd/ct/dashboard_web_test.go
@@ -193,10 +193,10 @@ func TestDashboardWebMux_APIReturnsCorrectCounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	flowing, _ := c.Add("myrepo", "Feature A", "", 1, 2)
+	flowing, _ := c.Add("myrepo", "Feature A", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(flowing.ID, "virgo", "implement")
-	c.Add("myrepo", "Feature B", "", 2, 2)
+	c.Add("myrepo", "Feature B", "", 2)
 	c.Close()
 
 	mux := newDashboardMux(cfgPath, dbPath)
@@ -224,7 +224,7 @@ func TestDashboardWebMux_NoteFieldsRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	droplet, _ := c.Add("myrepo", "Note Test", "", 1, 2)
+	droplet, _ := c.Add("myrepo", "Note Test", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(droplet.ID, "virgo", "implement")
 	if err := c.AddNote(droplet.ID, "implementer", "hello world"); err != nil {
@@ -264,7 +264,7 @@ func TestDashboardWebMux_NoteFieldsSnakeCaseJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	droplet, _ := c.Add("myrepo", "Snake Case Test", "", 1, 2)
+	droplet, _ := c.Add("myrepo", "Snake Case Test", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(droplet.ID, "virgo", "implement")
 	if err := c.AddNote(droplet.ID, "implementer", "snake test"); err != nil {
@@ -425,7 +425,7 @@ func TestLookupAqueductSession_NoMatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, _ := c.Add("myrepo", "Some work", "", 1, 2)
+	item, _ := c.Add("myrepo", "Some work", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(item.ID, "other-aqueduct", "implement")
 	c.Close()
@@ -444,7 +444,7 @@ func TestLookupAqueductSession_Found(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, _ := c.Add("myrepo", "Peek target", "", 1, 2)
+	item, _ := c.Add("myrepo", "Peek target", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(item.ID, "virgo", "implement")
 	c.Close()
@@ -497,7 +497,7 @@ func TestPeekHTTP_ActiveWithMockCapturer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, _ := c.Add("myrepo", "Peek work", "", 1, 2)
+	item, _ := c.Add("myrepo", "Peek work", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(item.ID, "virgo", "implement")
 	c.Close()
@@ -526,7 +526,7 @@ func TestPeekHTTP_ActiveButSessionGone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, _ := c.Add("myrepo", "Gone session", "", 1, 2)
+	item, _ := c.Add("myrepo", "Gone session", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(item.ID, "virgo", "implement")
 	c.Close()
@@ -739,7 +739,7 @@ func TestWsPeek_SuccessfulStreamActive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, _ := c.Add("myrepo", "Peek work", "", 1, 2)
+	item, _ := c.Add("myrepo", "Peek work", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(item.ID, "virgo", "implement")
 	c.Close()

--- a/cmd/ct/doctor_test.go
+++ b/cmd/ct/doctor_test.go
@@ -947,7 +947,7 @@ func TestCheckStalledDroplets_RecentDroplets_NoCrash(t *testing.T) {
 		t.Fatalf("create db: %v", err)
 	}
 	// Add a droplet and mark it in_progress (recent — should not be flagged).
-	item, err := c.Add("repo", "Test droplet", "desc", 2, 3)
+	item, err := c.Add("repo", "Test droplet", "desc", 2)
 	if err != nil {
 		t.Fatalf("add droplet: %v", err)
 	}

--- a/cmd/ct/droplet_history_test.go
+++ b/cmd/ct/droplet_history_test.go
@@ -33,7 +33,7 @@ func runHistoryCapture(t *testing.T, id string) (string, error) {
 
 func TestDropletHistory_ShowsCreationAndNotes(t *testing.T) {
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "History task", "do something", 1, 2)
+	item, err := c.Add("myrepo", "History task", "do something", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestDropletHistory_ShowsCreationAndNotes(t *testing.T) {
 
 func TestDropletHistory_ShowsPoolEvent(t *testing.T) {
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "Pool history task", "", 1, 2)
+	item, err := c.Add("myrepo", "Pool history task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestDropletHistory_ShowsPoolEvent(t *testing.T) {
 
 func TestDropletHistory_ShowsHeader(t *testing.T) {
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "Header history task", "desc", 1, 2)
+	item, err := c.Add("myrepo", "Header history task", "desc", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestDropletHistory_ShowsHeader(t *testing.T) {
 
 func TestDropletHistory_ChronologicalOrder(t *testing.T) {
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "Order history task", "", 1, 2)
+	item, err := c.Add("myrepo", "Order history task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestDropletHistory_NonexistentDroplet(t *testing.T) {
 
 func TestDropletHistory_EmptyDroplet(t *testing.T) {
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "Empty history task", "", 1, 2)
+	item, err := c.Add("myrepo", "Empty history task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestDropletHistory_JsonFormat(t *testing.T) {
 	t.Cleanup(func() { historyFmt = "text" })
 
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "Json history task", "", 1, 2)
+	item, err := c.Add("myrepo", "Json history task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestDropletHistory_InvalidFormat(t *testing.T) {
 	t.Cleanup(func() { historyFmt = "text" })
 
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "Format history task", "", 1, 2)
+	item, err := c.Add("myrepo", "Format history task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestDropletHistory_InvalidFormat(t *testing.T) {
 
 func TestDropletHistory_NoSyntheticHeartbeat(t *testing.T) {
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "No hb history task", "", 1, 2)
+	item, err := c.Add("myrepo", "Heartbeat history task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +243,7 @@ func TestDropletHistory_NoSyntheticHeartbeat(t *testing.T) {
 
 func TestDropletHistory_ProducesSameOutputAsLog(t *testing.T) {
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "Comparison task", "compare log vs history", 1, 2)
+	item, err := c.Add("myrepo", "Comparison task", "compare log vs history", 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ct/droplet_log_test.go
+++ b/cmd/ct/droplet_log_test.go
@@ -33,7 +33,7 @@ func runLogCapture(t *testing.T, id string) (string, error) {
 
 func TestDropletLog_ShowsCreationAndNotes(t *testing.T) {
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Log task", "do something", 1, 2)
+	item, err := c.Add("myrepo", "Log task", "do something", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestDropletLog_ShowsCreationAndNotes(t *testing.T) {
 
 func TestDropletLog_ShowsPoolEvent(t *testing.T) {
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Pool task", "", 1, 2)
+	item, err := c.Add("myrepo", "Pool task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestDropletLog_ShowsPoolEvent(t *testing.T) {
 
 func TestDropletLog_ShowsStageAssignment(t *testing.T) {
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Stage task", "", 1, 2)
+	item, err := c.Add("myrepo", "Stage task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestDropletLog_ShowsStageAssignment(t *testing.T) {
 
 func TestDropletLog_ShowsHeader(t *testing.T) {
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Header task", "desc", 1, 2)
+	item, err := c.Add("myrepo", "Header task", "desc", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestDropletLog_ShowsHeader(t *testing.T) {
 
 func TestDropletLog_ChronologicalOrder(t *testing.T) {
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Order task", "", 1, 2)
+	item, err := c.Add("myrepo", "Order task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestDropletLog_NonexistentDroplet(t *testing.T) {
 
 func TestDropletLog_EmptyDroplet(t *testing.T) {
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Empty task", "", 1, 2)
+	item, err := c.Add("myrepo", "Empty task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestDropletLog_JsonFormat(t *testing.T) {
 	t.Cleanup(func() { logFmt = "text" })
 
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Json log task", "", 1, 2)
+	item, err := c.Add("myrepo", "Json log task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +229,7 @@ func TestDropletLog_InvalidFormat(t *testing.T) {
 	t.Cleanup(func() { logFmt = "text" })
 
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Format task", "", 1, 2)
+	item, err := c.Add("myrepo", "Format task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestDropletLog_InvalidFormat(t *testing.T) {
 
 func TestDropletLog_NoSyntheticHeartbeat(t *testing.T) {
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "No hb task", "", 1, 2)
+	item, err := c.Add("myrepo", "Heartbeat task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,11 +268,44 @@ func TestDropletLog_NoSyntheticHeartbeat(t *testing.T) {
 	}
 }
 
+func TestDropletLog_HeartbeatInChronologicalOrder(t *testing.T) {
+	c := setupLogTestDB(t)
+	item, err := c.Add("myrepo", "Heartbeat order task", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.GetReadyForAqueduct("myrepo", "default")
+	c.Assign(item.ID, "worker-1", "implement")
+	c.AddNote(item.ID, "implement", "early note")
+	err = c.Heartbeat(item.ID)
+	if err != nil {
+		t.Fatalf("heartbeat failed: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	c.AddNote(item.ID, "implement", "late note")
+
+	out, err := runLogCapture(t, item.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	heartbeatIdx := strings.Index(out, "heartbeat")
+	lateNoteIdx := strings.Index(out, "late note")
+	if heartbeatIdx == -1 || lateNoteIdx == -1 {
+		t.Fatalf("log output missing expected entries: %s", out)
+	}
+	if heartbeatIdx > lateNoteIdx {
+		t.Errorf("heartbeat should appear before late note in chronological order: heartbeat at %d, late note at %d", heartbeatIdx, lateNoteIdx)
+	}
+}
+
 func TestBuildLogEntries_DisplaysEventsFromTimeline(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 
 	timeline := []cistern.TimelineEntry{
-		{Time: now, EventType: "create", Payload: `{"repo":"myrepo","title":"Test task","priority":1,"complexity":2}`},
+		{Time: now, EventType: "create", Payload: `{"repo":"myrepo","title":"Test task","priority":1}`},
 		{Time: now.Add(time.Minute), EventType: "dispatch", Payload: `{"aqueduct":"default","cataractae":"implement","assignee":"worker-1"}`},
 		{Time: now.Add(2 * time.Minute), EventType: "pass", Payload: `{"cataractae":"implement","notes":"all good"}`},
 	}
@@ -360,7 +393,7 @@ func TestBuildLogEntries_NoDuplicateCreatedEvent(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 
 	timeline := []cistern.TimelineEntry{
-		{Time: now, EventType: "create", Payload: `{"repo":"myrepo","title":"New task","priority":1,"complexity":2}`},
+		{Time: now, EventType: "create", Payload: `{"repo":"myrepo","title":"New task","priority":1}`},
 		{Time: now.Add(time.Minute), EventType: "dispatch", Payload: `{}`},
 	}
 
@@ -389,11 +422,11 @@ func TestDisplayInfo_DisplaysHumanReadableDetails(t *testing.T) {
 		wantOmit string
 	}{
 		{
-			name:     "create event shows repo, title, priority, complexity",
+			name:     "create event shows repo, title, priority",
 			evt:      "create",
-			detail:   `{"repo":"myrepo","title":"My task","priority":1,"complexity":2}`,
+			detail:   `{"repo":"myrepo","title":"My task","priority":1}`,
 			wantEvt:  "created",
-			wantSub:  "repo: myrepo, title: My task, priority: 1, complexity: 2",
+			wantSub:  "repo: myrepo, title: My task, priority: 1",
 			wantOmit: `"repo"`,
 		},
 		{

--- a/cmd/ct/droplet_restart_test.go
+++ b/cmd/ct/droplet_restart_test.go
@@ -27,7 +27,7 @@ func setupRestartTestDB(t *testing.T) (*cistern.Client, string) {
 
 func TestDropletRestart_WithCataractae(t *testing.T) {
 	c, _ := setupRestartTestDB(t)
-	item, err := c.Add("myrepo", "Stuck feature", "", 1, 3)
+	item, err := c.Add("myrepo", "Stuck feature", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestDropletRestart_WithCataractae(t *testing.T) {
 
 func TestDropletRestart_WithoutCataractae_UsesCurrentCataractae(t *testing.T) {
 	c, _ := setupRestartTestDB(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestDropletRestart_WithoutCataractae_UsesCurrentCataractae(t *testing.T) {
 
 func TestDropletRestart_NoCataractaeFlag_NoCurrentStage(t *testing.T) {
 	c, _ := setupRestartTestDB(t)
-	item, err := c.Add("myrepo", "New task", "", 1, 3)
+	item, err := c.Add("myrepo", "New task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestDropletRestart_NoCataractaeFlag_NoCurrentStage(t *testing.T) {
 
 func TestDropletRestart_WithNotes(t *testing.T) {
 	c, _ := setupRestartTestDB(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestDropletRestart_WithNotes(t *testing.T) {
 
 func TestDropletRestart_WritesRestartEvent(t *testing.T) {
 	c, _ := setupRestartTestDB(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestDropletRestart_WritesRestartEvent(t *testing.T) {
 
 func TestDropletRestart_ClearsOutcomeAndAssignee(t *testing.T) {
 	c, _ := setupRestartTestDB(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +231,7 @@ func TestDropletRestart_NotFound(t *testing.T) {
 
 func TestDropletRestart_UpdatesTimestamp(t *testing.T) {
 	c, _ := setupRestartTestDB(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ct/droplet_tail_test.go
+++ b/cmd/ct/droplet_tail_test.go
@@ -33,7 +33,7 @@ func runTailCapture(t *testing.T, id string) (string, error) {
 
 func TestDropletTail_TextFormat_ShowsEvents(t *testing.T) {
 	c, _ := setupTailTestDB(t)
-	item, err := c.Add("myrepo", "Tail task", "", 1, 2)
+	item, err := c.Add("myrepo", "Tail task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestDropletTail_TextFormat_ShowsEvents(t *testing.T) {
 
 func TestDropletTail_JsonFormat_OutputsNDJson(t *testing.T) {
 	c, _ := setupTailTestDB(t)
-	item, err := c.Add("myrepo", "Json task", "", 1, 2)
+	item, err := c.Add("myrepo", "Json task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestDropletTail_JsonFormat_OutputsNDJson(t *testing.T) {
 
 func TestDropletTail_LinesFlag_LimitsOutput(t *testing.T) {
 	c, _ := setupTailTestDB(t)
-	item, err := c.Add("myrepo", "Limited task", "", 1, 2)
+	item, err := c.Add("myrepo", "Limited task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestDropletTail_LinesFlag_LimitsOutput(t *testing.T) {
 
 func TestDropletTail_PoolEvent(t *testing.T) {
 	c, _ := setupTailTestDB(t)
-	item, err := c.Add("myrepo", "Pooled task", "", 1, 2)
+	item, err := c.Add("myrepo", "Pooled task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ct/flow_inspect_test.go
+++ b/cmd/ct/flow_inspect_test.go
@@ -61,12 +61,12 @@ func TestFlowInspectCisternCounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	// open item
-	_, err = c.Add("repo", "open item", "", 2, 2)
+	_, err = c.Add("repo", "open item", "", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// in_progress item
-	item2, err := c.Add("repo", "flowing item", "", 2, 2)
+	item2, err := c.Add("repo", "flowing item", "", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestFlowInspectCisternCounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	// pooled item
-	item3, err := c.Add("repo", "pooled item", "", 2, 2)
+	item3, err := c.Add("repo", "pooled item", "", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestFlowInspectCisternCounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	// closed item
-	item4, err := c.Add("repo", "closed item", "", 2, 2)
+	item4, err := c.Add("repo", "closed item", "", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestFlowInspectElapsedSeconds(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("repo", "in_progress item", "", 2, 2)
+	item, err := c.Add("repo", "in_progress item", "", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestBuildInspectOutput_UsesProvidedPathsAndIncludesPooled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("myrepo", "pooled item", "", 2, 2)
+	item, err := c.Add("myrepo", "pooled item", "", 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ct/import.go
+++ b/cmd/ct/import.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
+	importProvider    string
 	importRepo       string
 	importPriority   int
-	importComplexity string
 )
 
 var importCmd = &cobra.Command{
@@ -32,7 +32,7 @@ ct droplet add.
 
 Examples:
   ct import jira PROJ-123 --repo myrepo
-  ct import jira PROJ-456 --repo myrepo --priority 1 --complexity full`,
+  ct import jira PROJ-456 --repo myrepo --priority 1`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		providerName := args[0]
@@ -70,11 +70,6 @@ Examples:
 			priority = importPriority
 		}
 
-		cx, err := parseComplexity(importComplexity)
-		if err != nil {
-			return err
-		}
-
 		externalRef := providerName + ":" + issueKey
 
 		c, err := cistern.New(resolveDBPath(), inferPrefix(repo))
@@ -83,7 +78,7 @@ Examples:
 		}
 		defer c.Close()
 
-		item, err := c.AddDroplet(repo, issue.Title, issue.Description, externalRef, priority, cx)
+		item, err := c.AddDroplet(repo, issue.Title, issue.Description, externalRef, priority)
 		if err != nil {
 			return fmt.Errorf("add droplet: %w", err)
 		}
@@ -120,7 +115,6 @@ func loadTrackerConfig(providerName string) (tracker.TrackerConfig, error) {
 func init() {
 	importCmd.Flags().StringVar(&importRepo, "repo", "", "target repository (required)")
 	importCmd.Flags().IntVar(&importPriority, "priority", 2, "override the priority mapped from the tracker")
-	importCmd.Flags().StringVarP(&importComplexity, "complexity", "x", "1", "droplet complexity: 1/standard (default), 2/full, 3/critical")
 	_ = importCmd.MarkFlagRequired("repo")
 	rootCmd.AddCommand(importCmd)
 }

--- a/cmd/ct/import_test.go
+++ b/cmd/ct/import_test.go
@@ -54,7 +54,6 @@ func TestImportCmd_AddsDropletDirectly(t *testing.T) {
 	out := captureStdout(t, func() {
 		importRepo = "cistern"
 		importPriority = 2
-		importComplexity = "1"
 		err = importCmd.RunE(importCmd, []string{"fake-tracker", "FAKE-42"})
 	})
 	if err != nil {
@@ -86,9 +85,6 @@ func TestImportCmd_AddsDropletDirectly(t *testing.T) {
 	if droplet.ExternalRef != "fake-tracker:FAKE-42" {
 		t.Errorf("ExternalRef = %q, want %q", droplet.ExternalRef, "fake-tracker:FAKE-42")
 	}
-	if droplet.Complexity != 1 {
-		t.Errorf("Complexity = %d, want 1 (standard)", droplet.Complexity)
-	}
 }
 
 func TestImportCmd_OverridesPriorityWhenFlagSet(t *testing.T) {
@@ -111,7 +107,6 @@ func TestImportCmd_OverridesPriorityWhenFlagSet(t *testing.T) {
 	out := captureStdout(t, func() {
 		importRepo = "cistern"
 		importPriority = 1
-		importComplexity = "1"
 		// Mark the priority flag as changed.
 		_ = importCmd.Flags().Set("priority", "1")
 		err = importCmd.RunE(importCmd, []string{"fake-tracker", "FAKE-99"})
@@ -137,7 +132,6 @@ func TestImportCmd_OverridesPriorityWhenFlagSet(t *testing.T) {
 
 func TestImportCmd_ErrorsOnUnknownProvider(t *testing.T) {
 	importRepo = "cistern"
-	importComplexity = "1"
 	err := importCmd.RunE(importCmd, []string{"no-such-provider-zzz", "ISSUE-1"})
 	if err == nil {
 		t.Fatal("expected error for unknown provider, got nil")
@@ -159,7 +153,6 @@ func TestImportCmd_ErrorsOnFetchFailure(t *testing.T) {
 	c.Close()
 
 	importRepo = "cistern"
-	importComplexity = "1"
 	err = importCmd.RunE(importCmd, []string{"fake-tracker", "FAIL-1"})
 	if err == nil {
 		t.Fatal("expected error when FetchIssue fails, got nil")
@@ -324,7 +317,6 @@ trackers:
 	out := captureStdout(t, func() {
 		importRepo = "myproject"
 		importPriority = 2
-		importComplexity = "1"
 		err = importCmd.RunE(importCmd, []string{"jira", "PROJ-1"})
 	})
 	if err != nil {

--- a/cmd/ct/inspect.go
+++ b/cmd/ct/inspect.go
@@ -43,8 +43,6 @@ type cisternInfo struct {
 type dropletInfo struct {
 	ID             string    `json:"id"`
 	Title          string    `json:"title"`
-	Complexity     int       `json:"complexity"`
-	ComplexityName string    `json:"complexity_name"`
 	Status         string    `json:"status"`
 	Stage          string    `json:"stage"`
 	Operator       string    `json:"operator"`
@@ -184,14 +182,12 @@ func buildInspectOutput(cfgPath, dbPath string) (inspectOutput, error) {
 			continue
 		}
 		di := dropletInfo{
-			ID:             item.ID,
-			Title:          item.Title,
-			Complexity:     item.Complexity,
-			ComplexityName: complexityName(item.Complexity),
-			Status:         item.Status,
-			Stage:          item.CurrentCataractae,
-			Operator:       item.Assignee,
-			UpdatedAt:      item.UpdatedAt,
+			ID:        item.ID,
+			Title:     item.Title,
+			Status:    item.Status,
+			Stage:     item.CurrentCataractae,
+			Operator:  item.Assignee,
+			UpdatedAt: item.UpdatedAt,
 		}
 		if item.Status == "open" {
 			if blockedBy, err := c.GetBlockedBy(item.ID); err == nil && len(blockedBy) > 0 {

--- a/cmd/ct/issue_test.go
+++ b/cmd/ct/issue_test.go
@@ -24,7 +24,7 @@ func TestDropletIssueAdd_CreatesIssue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.Close()
 
 	if err := execCmd(t, "droplet", "issue", "add", item.ID, "missing error handling"); err != nil {
@@ -54,7 +54,7 @@ func TestDropletIssueResolve_UpdatesStatus(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "some issue")
 	c.Close()
 
@@ -76,7 +76,7 @@ func TestDropletIssueResolve_ImplementerForbidden(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "implementer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "some issue")
 	c.Close()
 
@@ -103,7 +103,7 @@ func TestDropletIssueResolve_ImplementShortName(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "implement")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "some issue")
 	c.Close()
 
@@ -119,7 +119,7 @@ func TestDropletIssueReject_UpdatesStatus(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "unfixed issue")
 	c.Close()
 
@@ -144,7 +144,7 @@ func TestDropletIssueReject_ImplementerForbidden(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "implementer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "some issue")
 	c.Close()
 
@@ -171,7 +171,7 @@ func TestDropletIssueReject_ImplementShortName(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "implement")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "some issue")
 	c.Close()
 
@@ -186,7 +186,7 @@ func TestDropletPass_SucceedsWithOpenIssues(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.AddIssue(item.ID, "reviewer", "open issue present")
 	c.Close()
 
@@ -209,7 +209,7 @@ func TestDropletPass_AllowedWhenIssuesResolved(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "a finding")
 	c.ResolveIssue(iss.ID, "fixed")
 	c.Close()
@@ -235,7 +235,7 @@ func TestDropletPass_NoIssues(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.Close()
 
 	if err := execCmd(t, "droplet", "pass", item.ID); err != nil {
@@ -262,7 +262,7 @@ func TestDropletPass_WhenPooled_SetsOutcome(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.Pool(item.ID, "timed out")
 	c.Close()
 
@@ -291,7 +291,7 @@ func TestDropletPass_WhenInProgress_BehaviorUnchanged(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 	c.Close()
 
@@ -317,7 +317,7 @@ func TestDropletPass_WhenDelivered_ReturnsError(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.CloseItem(item.ID)
 	c.Close()
 
@@ -337,7 +337,7 @@ func TestDropletPass_WhenCancelled_ReturnsError(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.Cancel(item.ID, "no longer needed")
 	c.Close()
 
@@ -363,7 +363,7 @@ func TestDropletPool_WhenPooled_SetsOutcomeAndKeepsPooled(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.Pool(item.ID, "timed out")
 	c.Close()
 
@@ -393,7 +393,7 @@ func TestDropletPool_WhenPooled_ForwardsPoolNotes(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.Pool(item.ID, "timed out")
 	c.Close()
 
@@ -427,7 +427,7 @@ func TestDropletPool_WhenDelivered_ReturnsError(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.CloseItem(item.ID)
 	c.Close()
 
@@ -447,7 +447,7 @@ func TestDropletPool_WhenCancelled_ReturnsError(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.Cancel(item.ID, "no longer needed")
 	c.Close()
 
@@ -474,7 +474,7 @@ func TestDropletRecirculate_WhenPooled_SetsStatusOpen(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.SetCataractae(item.ID, "implement")
 	c.Pool(item.ID, "timed out")
 	c.Close()
@@ -506,7 +506,7 @@ func TestDropletRecirculate_WhenPooled_DefaultsToCurrentCataractae(t *testing.T)
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.SetCataractae(item.ID, "implement")
 	c.Pool(item.ID, "timed out")
 	c.Close()
@@ -538,7 +538,7 @@ func TestDropletRecirculate_WhenPooled_WithTo_SetsCurrentCataractae(t *testing.T
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.SetCataractae(item.ID, "review")
 	c.Pool(item.ID, "timed out")
 	c.Close()
@@ -570,7 +570,7 @@ func TestDropletRecirculate_WhenDelivered_ReturnsError(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.CloseItem(item.ID)
 	c.Close()
 
@@ -592,7 +592,7 @@ func TestDropletRecirculate_WhenCancelled_ReturnsError(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.Cancel(item.ID, "no longer needed")
 	c.Close()
 
@@ -617,7 +617,7 @@ func TestRecirculate_RejectedFromImplementer(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "implementer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 	c.Close()
 
@@ -642,7 +642,7 @@ func TestRecirculate_AllowedFromReviewer(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.SetCataractae(item.ID, "implement")
 	c.Pool(item.ID, "timed out")
 	c.Close()
@@ -664,7 +664,7 @@ func TestRecirculate_RejectedFromImplementShortName(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "implement")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 	c.Close()
 
@@ -682,7 +682,7 @@ func TestDropletIssueList_NoIssues(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.Close()
 
 	out := captureStdout(t, func() {
@@ -700,7 +700,7 @@ func TestDropletIssueList_WithIssues(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.AddIssue(item.ID, "reviewer", "first issue description")
 	c.AddIssue(item.ID, "reviewer", "second issue description")
 	c.Close()
@@ -724,7 +724,7 @@ func TestDropletIssueList_OpenFilter(t *testing.T) {
 	t.Setenv("CT_DB", db)
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.AddIssue(item.ID, "reviewer", "open issue stays")
 	iss2, _ := c.AddIssue(item.ID, "reviewer", "resolved issue hidden")
 	c.ResolveIssue(iss2.ID, "fixed it")
@@ -749,7 +749,7 @@ func TestDropletIssueResolve_EmptyEvidence(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "some issue")
 	c.Close()
 
@@ -765,7 +765,7 @@ func TestDropletIssueReject_EmptyEvidence(t *testing.T) {
 	t.Setenv("CT_CATARACTA_NAME", "reviewer")
 
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "some issue")
 	c.Close()
 
@@ -782,7 +782,7 @@ func TestDropletIssueList_FlaggedByFilter(t *testing.T) {
 
 	// Given: issues filed by two different cataractae.
 	c, _ := cistern.New(db, "ct")
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.AddIssue(item.ID, "reviewer", "reviewer filed this")
 	c.AddIssue(item.ID, "qa", "qa filed this")
 	c.Close()

--- a/cmd/ct/peek_test.go
+++ b/cmd/ct/peek_test.go
@@ -40,7 +40,7 @@ func TestDropletPeekNotFlowing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	item, err := c.Add("myrepo", "Test item", "", 1, 3)
+	item, err := c.Add("myrepo", "Test item", "", 1)
 	c.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -89,7 +89,7 @@ func TestDropletPeekLiveSession_AttachesReadOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Add("myrepo", "Test item", "", 1, 3); err != nil {
+	if _, err := c.Add("myrepo", "Test item", "", 1); err != nil {
 		t.Fatal(err)
 	}
 	item, err := c.GetReady("myrepo")
@@ -152,7 +152,7 @@ func TestDropletPeekNoSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Add("myrepo", "Test item", "", 1, 3); err != nil {
+	if _, err := c.Add("myrepo", "Test item", "", 1); err != nil {
 		t.Fatal(err)
 	}
 	// Advance to in_progress, then assign a non-existent worker so tmux lookup fails.
@@ -211,7 +211,7 @@ func makeInProgressItem(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Add("myrepo", "Test item", "", 1, 3); err != nil {
+	if _, err := c.Add("myrepo", "Test item", "", 1); err != nil {
 		t.Fatal(err)
 	}
 	item, err := c.GetReady("myrepo")
@@ -379,7 +379,7 @@ func TestDropletPeek_FollowWithoutSnapshot_ReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Add("myrepo", "Test item", "", 1, 3); err != nil {
+	if _, err := c.Add("myrepo", "Test item", "", 1); err != nil {
 		t.Fatal(err)
 	}
 	item, err := c.GetReady("myrepo")
@@ -422,7 +422,7 @@ func TestDropletPeek_StageElapsedNonZero_ShowsStageAge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dr, err := c.Add("myrepo", "Stage peek test", "", 1, 3)
+	dr, err := c.Add("myrepo", "Stage peek test", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -499,7 +499,7 @@ func TestDropletPeek_StageElapsedZero_OmitsStageAge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dr, err := c.Add("myrepo", "Zero dispatch test", "", 1, 3)
+	dr, err := c.Add("myrepo", "Zero dispatch test", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ct/status_panel_tui.go
+++ b/cmd/ct/status_panel_tui.go
@@ -130,24 +130,6 @@ func (p statusPanel) View() string {
 		tuiStyleDim.Render(fmt.Sprintf("%d", p.data.DoneCount)))
 	lines = append(lines, summary, "")
 
-	// ── Human-gated notice ───────────────────────────────────────────────────
-	var humanGated []*cistern.Droplet
-	for _, d := range p.data.PooledItems {
-		if d.CurrentCataractae == "human" {
-			humanGated = append(humanGated, d)
-		}
-	}
-	if len(humanGated) > 0 {
-		ids := make([]string, len(humanGated))
-		for i, d := range humanGated {
-			ids[i] = d.ID
-		}
-		lines = append(lines,
-			tuiStyleYellow.Render(fmt.Sprintf("  ⏸  %d droplet(s) awaiting human approval: %s",
-				len(humanGated), strings.Join(ids, ", "))),
-			"")
-	}
-
 	// ── Castellarius health ──────────────────────────────────────────────────
 	castellariusStatus := tuiStyleRed.Render("stopped")
 	if p.data.CastellariusRunning {

--- a/cmd/ct/status_panel_tui_test.go
+++ b/cmd/ct/status_panel_tui_test.go
@@ -181,48 +181,6 @@ func TestStatusPanel_View_IdleAqueduct_ShowsIdleLabel(t *testing.T) {
 	}
 }
 
-// TestStatusPanel_View_HumanGated_ShowsApprovalNotice verifies that pooled droplets
-// awaiting human approval are surfaced in the view.
-//
-// Given: a statusPanel with one pooled droplet at CurrentCataractae="human"
-// When:  View() is called
-// Then:  output contains "human approval" and the droplet ID
-func TestStatusPanel_View_HumanGated_ShowsApprovalNotice(t *testing.T) {
-	p := newStatusPanel("", "")
-	p.data = &DashboardData{
-		PooledItems: []*cistern.Droplet{
-			{ID: "ci-human01", CurrentCataractae: "human"},
-		},
-		FetchedAt: time.Now(),
-	}
-	v := p.View()
-	for _, want := range []string{"human approval", "ci-human01"} {
-		if !strings.Contains(v, want) {
-			t.Errorf("View() does not contain %q; output:\n%s", want, v)
-		}
-	}
-}
-
-// TestStatusPanel_View_NonHumanGated_HidesApprovalNotice verifies that pooled droplets
-// waiting on a non-human cataractae do not trigger the human approval notice.
-//
-// Given: a statusPanel with one pooled droplet at CurrentCataractae="qa" (not "human")
-// When:  View() is called
-// Then:  output does NOT contain "human approval"
-func TestStatusPanel_View_NonHumanGated_HidesApprovalNotice(t *testing.T) {
-	p := newStatusPanel("", "")
-	p.data = &DashboardData{
-		PooledItems: []*cistern.Droplet{
-			{ID: "ci-qa01", CurrentCataractae: "qa"},
-		},
-		FetchedAt: time.Now(),
-	}
-	v := p.View()
-	if strings.Contains(v, "human approval") {
-		t.Errorf("View() contains %q for a non-human-gated droplet; output:\n%s", "human approval", v)
-	}
-}
-
 // TestStatusPanel_View_ProgressFraction_Shown verifies that cataractae progress
 // indices are shown when available.
 //

--- a/cmd/ct/tui.go
+++ b/cmd/ct/tui.go
@@ -38,8 +38,8 @@ const (
 	actionClose         = "close"
 	actionReopen        = "reopen"
 	actionApprove       = "approve"
-	actionEditMeta      = "editmeta"     // multi-field: title, priority, complexity, description
-	actionCreateDroplet = "create"       // multi-field: repo, title, description, complexity
+	actionEditMeta      = "editmeta"     // multi-field: title, priority, description
+	actionCreateDroplet = "create"       // multi-field: repo, title, description
 	actionAddDep        = "adddep"       // text: depends-on droplet ID
 	actionRemoveDep     = "removedep"    // text: dependency ID to remove
 	actionFileIssue     = "fileissue"    // text: issue description
@@ -254,31 +254,24 @@ func (m tabAppModel) execMultiActionCmd(action string, values []string) tea.Cmd 
 		var execErr error
 		switch action {
 		case actionCreateDroplet:
-			// values: [repo, title, description, complexity]
+			// values: [repo, title, description]
 			repo := strings.TrimSpace(valAt(values, 0))
 			title := strings.TrimSpace(valAt(values, 1))
 			description := strings.TrimSpace(valAt(values, 2))
-			complexity := 1
-			if n, err := strconv.Atoi(strings.TrimSpace(valAt(values, 3))); err == nil && n >= 1 && n <= 3 {
-				complexity = n
-			}
 			if repo == "" || title == "" {
 				execErr = fmt.Errorf("repo and title are required to create a droplet")
 				break
 			}
-			_, execErr = c.Add(repo, title, description, 1, complexity)
+			_, execErr = c.Add(repo, title, description, 1)
 		case actionEditMeta:
-			// values: [title, priority, complexity, description]
+			// values: [title, priority, description]
 			// Each field is optional — skip empty/invalid values.
 			title := strings.TrimSpace(valAt(values, 0))
 			fields := cistern.EditDropletFields{}
 			if p, err := strconv.Atoi(strings.TrimSpace(valAt(values, 1))); err == nil && p > 0 {
 				fields.Priority = &p
 			}
-			if cx, err := strconv.Atoi(strings.TrimSpace(valAt(values, 2))); err == nil && cx >= 1 && cx <= 3 {
-				fields.Complexity = &cx
-			}
-			if desc := strings.TrimSpace(valAt(values, 3)); desc != "" {
+			if desc := strings.TrimSpace(valAt(values, 2)); desc != "" {
 				fields.Description = &desc
 			}
 			if title != "" {
@@ -340,7 +333,7 @@ func openMultiOverlay(m tabAppModel, fields []string) tabAppModel {
 // creation form. Callers set m.tab as needed before calling.
 func openCreateDropletOverlay(m tabAppModel) tabAppModel {
 	m.overlayAction = actionCreateDroplet
-	return openMultiOverlay(m, []string{"repo", "title", "description", "complexity (1-3)"})
+	return openMultiOverlay(m, []string{"repo", "title", "description"})
 }
 
 // overlayMultiFooter renders the progress footer shown during a multi-field form.
@@ -635,7 +628,7 @@ func (m tabAppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				actionAddDep, actionRemoveDep, actionFileIssue:
 				updated.overlayMode = overlayText
 			case actionEditMeta:
-				updated = openMultiOverlay(updated, []string{"title", "priority (1-5)", "complexity (1-3)", "description"})
+				updated = openMultiOverlay(updated, []string{"title", "priority (1-5)", "description"})
 			case actionResolveIssue, actionRejectIssue:
 				updated = openMultiOverlay(updated, []string{"issue ID", "evidence"})
 			}

--- a/cmd/ct/tui_test.go
+++ b/cmd/ct/tui_test.go
@@ -1471,7 +1471,7 @@ func newTestDBWithDroplet(t *testing.T) (dbPath, dropletID string) {
 		t.Fatal(err)
 	}
 	defer c.Close()
-	d, err := c.Add("test-repo", "test droplet", "", 2, 2)
+	d, err := c.Add("test-repo", "test droplet", "", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2744,9 +2744,9 @@ func TestTabApp_MultiOverlay_TypeChar_AppendsToInput(t *testing.T) {
 	m := detailModelWithDroplet()
 	m.overlayMode = overlayMulti
 	m.overlayAction = actionEditMeta
-	m.overlayMultiFields = []string{"title", "priority (1-5)", "complexity (1-3)", "description"}
+	m.overlayMultiFields = []string{"title", "priority (1-5)", "description"}
 	m.overlayMultiIdx = 0
-	m.overlayMultiValues = make([]string, 4)
+	m.overlayMultiValues = make([]string, 3)
 	m.overlayInput = ""
 
 	for _, ch := range []rune{'a', 'b', 'c'} {
@@ -2799,9 +2799,9 @@ func TestTabApp_MultiOverlay_Enter_AdvancesToNextField(t *testing.T) {
 	m.height = 30
 	m.overlayMode = overlayMulti
 	m.overlayAction = actionCreateDroplet
-	m.overlayMultiFields = []string{"repo", "title", "description", "complexity (1-3)"}
+	m.overlayMultiFields = []string{"repo", "title", "description"}
 	m.overlayMultiIdx = 0
-	m.overlayMultiValues = make([]string, 4)
+	m.overlayMultiValues = make([]string, 3)
 	m.overlayInput = "myrepo"
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -2835,9 +2835,9 @@ func TestTabApp_MultiOverlay_Enter_OnLastField_ClosesAndDispatches(t *testing.T)
 	m.height = 30
 	m.overlayMode = overlayMulti
 	m.overlayAction = actionCreateDroplet
-	m.overlayMultiFields = []string{"repo", "title", "description", "complexity (1-3)"}
-	m.overlayMultiIdx = 3 // last field
-	m.overlayMultiValues = []string{"myrepo", "mytitle", "desc", ""}
+	m.overlayMultiFields = []string{"repo", "title", "description"}
+	m.overlayMultiIdx = 2 // last field
+	m.overlayMultiValues = []string{"myrepo", "mytitle", "desc"}
 	m.overlayInput = "2"
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -3127,7 +3127,7 @@ func TestExecActionCmd_AddDependency_AddsDep(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dep, err := c.Add("test-repo", "dep droplet", "", 1, 1)
+	dep, err := c.Add("test-repo", "dep droplet", "", 1)
 	c.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -3172,7 +3172,7 @@ func TestExecActionCmd_RemoveDependency_RemovesDep(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dep, err := c.Add("test-repo", "dep droplet", "", 1, 1)
+	dep, err := c.Add("test-repo", "dep droplet", "", 1)
 	if err != nil {
 		c.Close()
 		t.Fatal(err)
@@ -3284,9 +3284,6 @@ func TestExecMultiActionCmd_CreateDroplet_CreatesDroplet(t *testing.T) {
 	}
 	if items[0].Title != "my new task" {
 		t.Errorf("title = %q, want %q", items[0].Title, "my new task")
-	}
-	if items[0].Complexity != 2 {
-		t.Errorf("complexity = %d, want 2", items[0].Complexity)
 	}
 }
 
@@ -3457,8 +3454,8 @@ func TestTabApp_MultiOverlay_EditMeta_MultiFields(t *testing.T) {
 	updated, _ := m.Update(tuiPaletteActionMsg{dropletID: "ci-aaa", action: actionEditMeta})
 	um := updated.(tabAppModel)
 
-	if len(um.overlayMultiFields) != 4 {
-		t.Errorf("overlayMultiFields len = %d, want 4 for editMeta", len(um.overlayMultiFields))
+	if len(um.overlayMultiFields) != 3 {
+		t.Errorf("overlayMultiFields len = %d, want 3 for editMeta", len(um.overlayMultiFields))
 	}
 }
 

--- a/internal/aqueduct/template.go
+++ b/internal/aqueduct/template.go
@@ -34,9 +34,6 @@ type StepTemplateContext struct {
 	// ValidOutcomes lists the ct droplet commands valid for this step.
 	// pass is always included; recirculate is included only when OnRecirculate != "".
 	ValidOutcomes []ValidOutcome
-	// SkippedFor lists complexity levels for which this step is skipped.
-	// Currently always empty — per-step complexity skipping is not yet modelled in aqueduct.yaml.
-	SkippedFor []string
 }
 
 // DropletTemplateContext holds the per-droplet variables available under {{.Droplet}} in templates.
@@ -44,7 +41,6 @@ type DropletTemplateContext struct {
 	ID          string
 	Title       string
 	Description string
-	Complexity  int
 }
 
 // TemplateContext is the top-level data passed to AGENTS.md template rendering.

--- a/internal/aqueduct/template_test.go
+++ b/internal/aqueduct/template_test.go
@@ -325,13 +325,12 @@ func TestRenderTemplate_DropletFields(t *testing.T) {
 		Name:       "test",
 		Cataractae: []WorkflowCataractae{{Name: "s", Type: CataractaeTypeGate, OnPass: "done"}},
 	}
-	content := `ID={{.Droplet.ID}} Title={{.Droplet.Title}} Complexity={{.Droplet.Complexity}}`
+	content := `ID={{.Droplet.ID}} Title={{.Droplet.Title}}`
 	ctx := TemplateContext{
 		Step: BuildStepTemplateContext(wf, &wf.Cataractae[0]),
 		Droplet: DropletTemplateContext{
-			ID:         "ct-999",
-			Title:      "My Feature",
-			Complexity: 2,
+			ID:    "ct-999",
+			Title: "My Feature",
 		},
 		Pipeline: BuildPipeline(wf),
 	}
@@ -342,8 +341,5 @@ func TestRenderTemplate_DropletFields(t *testing.T) {
 	}
 	if !strings.Contains(result, "Title=My Feature") {
 		t.Errorf("result should contain Title, got %q", result)
-	}
-	if !strings.Contains(result, "Complexity=2") {
-		t.Errorf("result should contain Complexity, got %q", result)
 	}
 }

--- a/internal/aqueduct/types.go
+++ b/internal/aqueduct/types.go
@@ -51,19 +51,6 @@ type WorkflowCataractae struct {
 	OnPool         string     `yaml:"on_pool,omitempty"`
 }
 
-// ComplexityLevel configures a single complexity tier.
-type ComplexityLevel struct {
-	Level        int  `yaml:"level"`
-	RequireHuman bool `yaml:"require_human,omitempty"`
-}
-
-// ComplexityConfig holds the three complexity tiers for a aqueduct.
-type ComplexityConfig struct {
-	Standard ComplexityLevel `yaml:"standard"`
-	Full     ComplexityLevel `yaml:"full"`
-	Critical ComplexityLevel `yaml:"critical"`
-}
-
 // UniqueIdentities returns the deduplicated, sorted list of agent identity
 // strings from the workflow's cataractae steps.
 func (wf *Workflow) UniqueIdentities() []string {
@@ -79,16 +66,10 @@ func (wf *Workflow) UniqueIdentities() []string {
 	return ids
 }
 
-// RequireHumanForLevel returns whether a human gate is required for a given complexity level.
-func (cc ComplexityConfig) RequireHumanForLevel(level int) bool {
-	return level == 3 && cc.Critical.RequireHuman
-}
-
 // Workflow is a named sequence of cataractae parsed from a YAML file.
 type Workflow struct {
 	Name       string               `yaml:"name"`
 	Cataractae []WorkflowCataractae `yaml:"cataractae"`
-	Complexity ComplexityConfig     `yaml:"complexity"`
 }
 
 // ProviderConfig holds the provider block that can appear at the top level of

--- a/internal/castellarius/integration_test.go
+++ b/internal/castellarius/integration_test.go
@@ -363,7 +363,7 @@ func TestIntegration_HappyPath_FakeAgentDeliversDroplet(t *testing.T) {
 
 	sched := newIntScheduler(client, runner, prefix)
 
-	droplet, err := client.Add(prefix+"-myrepo", "integration happy path", "desc", 1, 3)
+	droplet, err := client.Add(prefix+"-myrepo", "integration happy path", "desc", 1)
 	if err != nil {
 		t.Fatalf("client.Add: %v", err)
 	}
@@ -414,7 +414,7 @@ func TestIntegration_StartupRecovery_OrphanedDroplet_RedeliversDroplet(t *testin
 
 	// Add a droplet and put it into in_progress/no-outcome state — simulating a
 	// prior Castellarius run where the agent session died before signaling.
-	droplet, err := client.Add(prefix+"-myrepo", "recovery test", "desc", 1, 3)
+	droplet, err := client.Add(prefix+"-myrepo", "recovery test", "desc", 1)
 	if err != nil {
 		t.Fatalf("client.Add: %v", err)
 	}
@@ -492,7 +492,7 @@ func TestIntegration_HeartbeatRecovery_DeadSession_RedeliversDroplet(t *testing.
 
 	sched := newIntScheduler(client, runner, prefix)
 
-	droplet, err := client.Add(prefix+"-myrepo", "heartbeat recovery test", "desc", 1, 3)
+	droplet, err := client.Add(prefix+"-myrepo", "heartbeat recovery test", "desc", 1)
 	if err != nil {
 		t.Fatalf("client.Add: %v", err)
 	}
@@ -556,7 +556,7 @@ func TestIntegration_EnvHygiene_LeakedKeyNotForwardedToSession(t *testing.T) {
 
 	sched := newIntScheduler(client, runner, prefix)
 
-	droplet, err := client.Add(prefix+"-myrepo", "env hygiene test", "desc", 1, 3)
+	droplet, err := client.Add(prefix+"-myrepo", "env hygiene test", "desc", 1)
 	if err != nil {
 		t.Fatalf("client.Add: %v", err)
 	}

--- a/internal/castellarius/production_gaps_test.go
+++ b/internal/castellarius/production_gaps_test.go
@@ -302,7 +302,7 @@ func TestHeartbeat_DB_NotStalled_WhenRecentHeartbeat(t *testing.T) {
 	}
 	t.Cleanup(func() { c.Close() })
 
-	item, err := c.Add("test-repo", "DB integration task", "", 1, 2)
+	item, err := c.Add("test-repo", "DB integration task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +361,7 @@ func TestHeartbeat_DB_Stalled_WhenNoHeartbeat(t *testing.T) {
 	}
 	t.Cleanup(func() { c.Close() })
 
-	item, err := c.Add("test-repo", "DB stall task", "", 1, 2)
+	item, err := c.Add("test-repo", "DB stall task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -51,9 +51,9 @@ type CisternClient interface {
 	// Cancel marks a droplet as cancelled. Used by the Architecti for
 	// irrecoverable droplets.
 	Cancel(id, reason string) error
-	// FileDroplet creates a new droplet in the given repo. Used by the Architecti
-	// to file structural/code fix work items.
-	FileDroplet(repo, title, description string, priority, complexity int) (*cistern.Droplet, error)
+	// FileDroplet creates a new droplet in the given repo. Used by the Architect
+	// to file structural fix work items.
+	FileDroplet(repo, title, description string, priority int) (*cistern.Droplet, error)
 	// Heartbeat records the current time as the agent's most recent activity
 	// timestamp. Called by agents via `ct droplet heartbeat <id>` every 60 seconds.
 	Heartbeat(id string) error
@@ -883,11 +883,6 @@ func (s *Castellarius) observeRepo(_ context.Context, repo aqueduct.RepoConfig) 
 			continue
 		}
 
-		// For critical droplets, insert a human gate before delivery.
-		if wf.Complexity.RequireHumanForLevel(item.Complexity) && next == "delivery" {
-			next = "human"
-		}
-
 		if isTerminal(next) {
 			keepBranch := strings.ToLower(next) != "done"
 			cleanupBranch(keepBranch)
@@ -1164,7 +1159,7 @@ func route(step aqueduct.WorkflowCataractae, result Result) string {
 // isTerminal returns true if the target is a terminal state.
 func isTerminal(name string) bool {
 	switch strings.ToLower(name) {
-	case "done", "pooled", "human", "pool":
+	case "done", "pooled", "pool":
 		return true
 	}
 	return false
@@ -1177,16 +1172,11 @@ func (s *Castellarius) handleTerminal(client CisternClient, itemID, terminal, fr
 		if err := client.CloseItem(itemID); err != nil {
 			s.logger.Error("close failed", "droplet", itemID, "error", err)
 		}
-	case "pooled", "human", "pool":
+	case "pooled", "pool":
 		s.logger.Info("Droplet pooled at terminal", "droplet", itemID, "terminal", terminal, "from_cataractae", fromStep)
 		reason := fmt.Sprintf("reached terminal %q from cataractae %q", terminal, fromStep)
 		if err := client.Pool(itemID, reason); err != nil {
 			s.logger.Error("pool at terminal failed", "droplet", itemID, "error", err)
-		}
-		if strings.ToLower(terminal) == "human" {
-			if err := client.SetCataractae(itemID, "human"); err != nil {
-				s.logger.Error("set cataractae human failed", "droplet", itemID, "error", err)
-			}
 		}
 	}
 }
@@ -1537,6 +1527,8 @@ func prepareBranchInSandbox(dir, itemID string) error {
 	for _, args := range [][]string{
 		{"git", "config", "user.name", "Cistern Agent"},
 		{"git", "config", "user.email", "agent@cistern.local"},
+		{"git", "config", "core.editor", "true"},
+		{"git", "config", "sequence.editor", "true"},
 	} {
 		c := exec.Command(args[0], args[1:]...)
 		c.Dir = dir

--- a/internal/castellarius/scheduler_test.go
+++ b/internal/castellarius/scheduler_test.go
@@ -28,7 +28,7 @@ func newTestLogger(buf *bytes.Buffer) *slog.Logger {
 
 type filedDroplet struct {
 	Repo, Title, Description string
-	Priority, Complexity     int
+	Priority                 int
 }
 
 type mockClient struct {
@@ -217,7 +217,7 @@ func (m *mockClient) Cancel(id, reason string) error {
 	return nil
 }
 
-func (m *mockClient) FileDroplet(repo, title, description string, priority, complexity int) (*cistern.Droplet, error) {
+func (m *mockClient) FileDroplet(repo, title, description string, priority int) (*cistern.Droplet, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	d := &cistern.Droplet{
@@ -225,7 +225,7 @@ func (m *mockClient) FileDroplet(repo, title, description string, priority, comp
 		Repo:  repo,
 		Title: title,
 	}
-	m.filed = append(m.filed, filedDroplet{repo, title, description, priority, complexity})
+	m.filed = append(m.filed, filedDroplet{repo, title, description, priority})
 	return d, nil
 }
 
@@ -438,7 +438,7 @@ func TestRoute(t *testing.T) {
 		OnPass:        "review",
 		OnFail:        "pooled",
 		OnRecirculate: "implement",
-		OnPool:        "human",
+		OnPool:        "pooled",
 	}
 
 	tests := []struct {
@@ -448,7 +448,7 @@ func TestRoute(t *testing.T) {
 		{ResultPass, "review"},
 		{ResultFail, "pooled"},
 		{ResultRecirculate, "implement"},
-		{ResultPool, "human"},
+		{ResultPool, "pooled"},
 		{Result("unknown"), "pooled"},
 	}
 
@@ -461,7 +461,7 @@ func TestRoute(t *testing.T) {
 }
 
 func TestIsTerminal(t *testing.T) {
-	for _, name := range []string{"done", "pooled", "human", "pool", "Done", "POOLED"} {
+	for _, name := range []string{"done", "pooled", "pool", "Done", "POOLED"} {
 		if !isTerminal(name) {
 			t.Errorf("isTerminal(%q) = false, want true", name)
 		}
@@ -1606,133 +1606,6 @@ func TestLookupStep(t *testing.T) {
 	}
 	if s := lookupCataracta(wf, "nonexistent"); s != nil {
 		t.Error("expected nil for unknown step")
-	}
-}
-
-// --- complexity / human-gate tests ---
-
-// criticalWorkflow returns a workflow with RequireHuman for critical (level 3)
-// droplets and no skip rules on any step.
-func criticalWorkflow() *aqueduct.Workflow {
-	return &aqueduct.Workflow{
-		Name: "feature",
-		Cataractae: []aqueduct.WorkflowCataractae{
-			{Name: "implement", Type: aqueduct.CataractaeTypeAgent, OnPass: "adversarial-review", OnFail: "pooled"},
-			{Name: "adversarial-review", Type: aqueduct.CataractaeTypeAgent, OnPass: "qa", OnFail: "implement", OnRecirculate: "implement"},
-			{Name: "qa", Type: aqueduct.CataractaeTypeAgent, OnPass: "docs", OnFail: "implement"},
-			{Name: "docs", Type: aqueduct.CataractaeTypeAgent, OnPass: "delivery", OnFail: "implement", OnRecirculate: "implement", OnPool: "human"},
-			{Name: "delivery", Type: aqueduct.CataractaeTypeAgent, OnPass: "done", OnRecirculate: "implement", OnPool: "human"},
-		},
-		Complexity: aqueduct.ComplexityConfig{
-			Standard: aqueduct.ComplexityLevel{Level: 1},
-			Full:     aqueduct.ComplexityLevel{Level: 2},
-			Critical: aqueduct.ComplexityLevel{Level: 3, RequireHuman: true},
-		},
-	}
-}
-
-func TestComplexity_CriticalHumanGateBeforeMerge(t *testing.T) {
-	wf := criticalWorkflow()
-	client := newMockClient()
-	client.readyItems = []*cistern.Droplet{
-		{ID: "crit-1", CurrentCataractae: "docs", Complexity: 3},
-	}
-
-	runner := newMockRunner(client)
-	// default outcome "pass"; docs.OnPass = "delivery" → critical → "human" → pool
-
-	config := aqueduct.AqueductConfig{
-		Repos: []aqueduct.RepoConfig{
-			{Name: "test-repo", Cataractae: 1, Names: []string{"alpha"}, Prefix: "test"},
-		},
-		MaxCataractae: 4,
-	}
-	workflows := map[string]*aqueduct.Workflow{"test-repo": wf}
-	clients := map[string]CisternClient{"test-repo": client}
-	sched := NewFromParts(config, workflows, clients, runner)
-	sched.Tick(context.Background())
-
-	if !runner.waitCalls(1, time.Second) {
-		t.Fatal("timed out")
-	}
-	sched.Tick(context.Background())
-	time.Sleep(10 * time.Millisecond)
-
-	client.mu.Lock()
-	defer client.mu.Unlock()
-	// docs passes → next is delivery → critical requires human gate → should pool.
-	if _, ok := client.pooled["crit-1"]; !ok {
-		t.Errorf("expected critical droplet pooled to human before delivery, got step %q", client.steps["crit-1"])
-	}
-}
-
-func TestTick_StandardDrop_AdvancesToAdversarialReview(t *testing.T) {
-	wf := criticalWorkflow()
-	client := newMockClient()
-	client.readyItems = []*cistern.Droplet{
-		{ID: "std-1", Complexity: 1},
-	}
-
-	runner := newMockRunner(client)
-
-	config := aqueduct.AqueductConfig{
-		Repos: []aqueduct.RepoConfig{
-			{Name: "test-repo", Cataractae: 1, Names: []string{"alpha"}, Prefix: "test"},
-		},
-		MaxCataractae: 4,
-	}
-	workflows := map[string]*aqueduct.Workflow{"test-repo": wf}
-	clients := map[string]CisternClient{"test-repo": client}
-	sched := NewFromParts(config, workflows, clients, runner)
-	sched.Tick(context.Background())
-
-	if !runner.waitCalls(1, time.Second) {
-		t.Fatal("timed out")
-	}
-	// implement passed → advance to adversarial-review.
-	sched.Tick(context.Background())
-	time.Sleep(10 * time.Millisecond)
-
-	client.mu.Lock()
-	defer client.mu.Unlock()
-	if client.steps["std-1"] != "adversarial-review" {
-		t.Errorf("expected droplet at adversarial-review, got %q", client.steps["std-1"])
-	}
-}
-
-func TestComplexity_HumanGateSetsCurrentCataractae(t *testing.T) {
-	wf := criticalWorkflow()
-	client := newMockClient()
-	client.readyItems = []*cistern.Droplet{
-		{ID: "crit-2", CurrentCataractae: "docs", Complexity: 3},
-	}
-
-	runner := newMockRunner(client)
-	config := aqueduct.AqueductConfig{
-		Repos: []aqueduct.RepoConfig{
-			{Name: "test-repo", Cataractae: 1, Names: []string{"alpha"}, Prefix: "test"},
-		},
-		MaxCataractae: 4,
-	}
-	workflows := map[string]*aqueduct.Workflow{"test-repo": wf}
-	clients := map[string]CisternClient{"test-repo": client}
-	sched := NewFromParts(config, workflows, clients, runner)
-	sched.Tick(context.Background())
-
-	if !runner.waitCalls(1, time.Second) {
-		t.Fatal("timed out waiting for runner")
-	}
-	sched.Tick(context.Background())
-	time.Sleep(10 * time.Millisecond)
-
-	client.mu.Lock()
-	defer client.mu.Unlock()
-	// Human gate: pooled and current_cataractae must be set to "human".
-	if _, ok := client.pooled["crit-2"]; !ok {
-		t.Errorf("expected critical droplet pooled, not found in pooled map")
-	}
-	if client.steps["crit-2"] != "human" {
-		t.Errorf("expected current_cataractae='human', got %q", client.steps["crit-2"])
 	}
 }
 

--- a/internal/castellarius/smoke_test.go
+++ b/internal/castellarius/smoke_test.go
@@ -215,7 +215,7 @@ func (c *pipelineClient) Cancel(id, reason string) error {
 	return nil
 }
 
-func (c *pipelineClient) FileDroplet(repo, title, description string, priority, complexity int) (*cistern.Droplet, error) {
+func (c *pipelineClient) FileDroplet(repo, title, description string, priority int) (*cistern.Droplet, error) {
 	return &cistern.Droplet{ID: "smoke-filed", Repo: repo}, nil
 }
 

--- a/internal/cataractae/adapter_test.go
+++ b/internal/cataractae/adapter_test.go
@@ -98,7 +98,7 @@ func TestSpawnAutomated_SetsOutcome(t *testing.T) {
 	client := testQueueClient(t)
 	a := newTestAdapter(t, "testrepo", client)
 
-	item, err := client.Add("testrepo", "Automated test", "", 1, 1)
+	item, err := client.Add("testrepo", "Automated test", "", 1)
 	if err != nil {
 		t.Fatalf("Create droplet: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestSpawnAutomated_SandboxDirFallback(t *testing.T) {
 	client := testQueueClient(t)
 	a := newTestAdapter(t, "testrepo", client)
 
-	item, err := client.Add("testrepo", "Fallback test", "", 1, 1)
+	item, err := client.Add("testrepo", "Fallback test", "", 1)
 	if err != nil {
 		t.Fatalf("Create droplet: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestSpawnAutomated_WithMetaNotes(t *testing.T) {
 	client := testQueueClient(t)
 	a := newTestAdapter(t, "testrepo", client)
 
-	item, err := client.Add("testrepo", "Meta test", "", 1, 1)
+	item, err := client.Add("testrepo", "Meta test", "", 1)
 	if err != nil {
 		t.Fatalf("Create droplet: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestAdapterSpawn_DispatchesToSpawnAutomated(t *testing.T) {
 	client := testQueueClient(t)
 	a := newTestAdapter(t, "testrepo", client)
 
-	item, err := client.Add("testrepo", "Dispatch test", "", 1, 1)
+	item, err := client.Add("testrepo", "Dispatch test", "", 1)
 	if err != nil {
 		t.Fatalf("Create droplet: %v", err)
 	}

--- a/internal/cataractae/runner.go
+++ b/internal/cataractae/runner.go
@@ -267,7 +267,6 @@ func (r *Runner) SpawnStep(w *Worker, item *cistern.Droplet, step *aqueduct.Work
 				ID:          item.ID,
 				Title:       item.Title,
 				Description: item.Description,
-				Complexity:  item.Complexity,
 			},
 			Pipeline: aqueduct.BuildPipeline(r.workflow),
 		},

--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -196,11 +196,17 @@ func (s *Session) collectEnvArgs() []string {
 	// OPENCODE_SERVER_* causes "session not found" errors when opencode run
 	// tries to connect to an authenticated server instead of starting fresh.
 	// See: https://github.com/anomalyco/opencode/issues/8502
+	//
+	// GIT_EDITOR / GIT_SEQUENCE_EDITOR set to "true" so git never opens an
+	// interactive editor (Vim) inside agent sessions. Without these, git rebase
+	// --continue and similar commands hang forever waiting for terminal input.
 	args = append(args,
 		"-e", "OPENCODE_SERVER_USERNAME=",
 		"-e", "OPENCODE_SERVER_PASSWORD=",
 		"-e", "OPENCODE_PID=",
 		"-e", "OPENCODE=",
+		"-e", "GIT_EDITOR=true",
+		"-e", "GIT_SEQUENCE_EDITOR=true",
 	)
 
 	// Provider-specific context isolation: when AgentFlag is set (opencode),

--- a/internal/cataractae/session_test.go
+++ b/internal/cataractae/session_test.go
@@ -170,7 +170,7 @@ func TestFakeagent_SpawnOutcomeCycle(t *testing.T) {
 	}
 	defer c.Close()
 
-	droplet, err := c.Add("testrepo", "fakeagent test", "desc", 1, 2)
+	droplet, err := c.Add("testrepo", "fakeagent test", "desc", 1)
 	if err != nil {
 		t.Fatalf("cistern.Add: %v", err)
 	}
@@ -496,6 +496,20 @@ func TestCollectEnvArgs_GHToken_AbsentWhenNotSet(t *testing.T) {
 		if strings.Contains(a, "GH_TOKEN") {
 			t.Errorf("collectEnvArgs contains GH_TOKEN when unset; args: %v", args)
 		}
+	}
+}
+
+// TestCollectEnvArgs_GitEditorAlwaysSet verifies that GIT_EDITOR and
+// GIT_SEQUENCE_EDITOR are always set to "true" so git never opens an
+// interactive editor inside agent sessions.
+func TestCollectEnvArgs_GitEditorAlwaysSet(t *testing.T) {
+	s := &Session{ID: "test", Preset: provider.ProviderPreset{Name: "opencode"}}
+	args := s.collectEnvArgs()
+	if !containsEnvPair(args, "GIT_EDITOR", "true") {
+		t.Errorf("collectEnvArgs missing GIT_EDITOR=true; args: %v", args)
+	}
+	if !containsEnvPair(args, "GIT_SEQUENCE_EDITOR", "true") {
+		t.Errorf("collectEnvArgs missing GIT_SEQUENCE_EDITOR=true; args: %v", args)
 	}
 }
 

--- a/internal/cistern/client.go
+++ b/internal/cistern/client.go
@@ -40,7 +40,6 @@ type Droplet struct {
 	Title             string `json:"title"`
 	Description       string `json:"description"`
 	Priority          int    `json:"priority"`
-	Complexity        int    `json:"complexity"`
 	Status            string `json:"status"`
 	Assignee          string `json:"assignee"` // empty string when unassigned
 	CurrentCataractae string `json:"current_cataractae"`
@@ -139,10 +138,7 @@ func (c *Client) generateID() (string, error) {
 
 // Add creates a new droplet and returns it. Optional deps are dependency IDs
 // that must be delivered before this droplet can be dispatched.
-func (c *Client) Add(repo, title, description string, priority, complexity int, deps ...string) (*Droplet, error) {
-	if complexity < 1 || complexity > 3 {
-		complexity = 2
-	}
+func (c *Client) Add(repo, title, description string, priority int, deps ...string) (*Droplet, error) {
 	id, err := c.generateID()
 	if err != nil {
 		return nil, fmt.Errorf("cistern: generate id: %w", err)
@@ -167,9 +163,9 @@ func (c *Client) Add(repo, title, description string, priority, complexity int, 
 
 	now := time.Now().UTC()
 	if _, err = tx.Exec(
-		`INSERT INTO droplets (id, repo, title, description, priority, complexity, status, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, 'open', ?, ?)`,
-		id, repo, title, description, priority, complexity, now, now,
+		`INSERT INTO droplets (id, repo, title, description, priority, status, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, 'open', ?, ?)`,
+		id, repo, title, description, priority, now, now,
 	); err != nil {
 		return nil, fmt.Errorf("cistern: add: %w", err)
 	}
@@ -184,10 +180,9 @@ func (c *Client) Add(repo, title, description string, priority, complexity int, 
 	}
 
 	createPayload, _ := json.Marshal(map[string]any{
-		"repo":       repo,
-		"title":      title,
-		"priority":   priority,
-		"complexity": complexity,
+		"repo":     repo,
+		"title":    title,
+		"priority": priority,
 	})
 	if err := c.recordEvent(tx, id, EventCreate, string(createPayload)); err != nil {
 		return nil, err
@@ -203,7 +198,6 @@ func (c *Client) Add(repo, title, description string, priority, complexity int, 
 		Title:       title,
 		Description: description,
 		Priority:    priority,
-		Complexity:  complexity,
 		Status:      "open",
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -211,8 +205,8 @@ func (c *Client) Add(repo, title, description string, priority, complexity int, 
 }
 
 // AddDroplet is a convenience method that adds a droplet and sets its external reference.
-func (c *Client) AddDroplet(repo, title, description, externalRef string, priority, complexity int) (*Droplet, error) {
-	droplet, err := c.Add(repo, title, description, priority, complexity)
+func (c *Client) AddDroplet(repo, title, description, externalRef string, priority int) (*Droplet, error) {
+	droplet, err := c.Add(repo, title, description, priority)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +229,7 @@ func (c *Client) GetReady(repo string) (*Droplet, error) {
 	defer tx.Rollback()
 
 	row := tx.QueryRow(
-		`SELECT id, repo, title, description, priority, complexity, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+		`SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
 		 FROM droplets d
 		 WHERE d.repo = ? COLLATE NOCASE AND d.status = 'open'
 		   AND NOT EXISTS (
@@ -253,7 +247,7 @@ func (c *Client) GetReady(repo string) (*Droplet, error) {
 	var lastHeartbeatAt, stageDispatchedAt sql.NullTime
 	err = row.Scan(
 		&droplet.ID, &droplet.Repo, &droplet.Title, &droplet.Description,
-		&droplet.Priority, &droplet.Complexity, &droplet.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
+		&droplet.Priority, &droplet.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
 		&lastHeartbeatAt, &droplet.CreatedAt, &droplet.UpdatedAt, &stageDispatchedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -301,7 +295,7 @@ func (c *Client) GetReadyForAqueduct(repo, aqueductName string) (*Droplet, error
 	defer tx.Rollback()
 
 	row := tx.QueryRow(
-		`SELECT id, repo, title, description, priority, complexity, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+		`SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
 		 FROM droplets d
 		 WHERE d.repo = ? COLLATE NOCASE AND d.status = 'open'
 		   AND (d.assigned_aqueduct = '' OR d.assigned_aqueduct IS NULL OR d.assigned_aqueduct = ?)
@@ -321,7 +315,7 @@ func (c *Client) GetReadyForAqueduct(repo, aqueductName string) (*Droplet, error
 	now := time.Now().UTC()
 	err = row.Scan(
 		&droplet.ID, &droplet.Repo, &droplet.Title, &droplet.Description,
-		&droplet.Priority, &droplet.Complexity, &droplet.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
+		&droplet.Priority, &droplet.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
 		&lastHeartbeatAt, &droplet.CreatedAt, &droplet.UpdatedAt, &stageDispatchedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -464,7 +458,11 @@ func (c *Client) Heartbeat(id string) error {
 	if err != nil {
 		return fmt.Errorf("cistern: heartbeat %s: %w", id, err)
 	}
-	return checkRowsAffected(res, id)
+	if err := checkRowsAffected(res, id); err != nil {
+		return err
+	}
+	payload, _ := json.Marshal(map[string]any{"at": now.Format(time.RFC3339)})
+	return c.RecordEvent(id, EventHeartbeat, string(payload))
 }
 
 // EditDropletFields holds the optional fields for EditDroplet.
@@ -472,12 +470,11 @@ func (c *Client) Heartbeat(id string) error {
 type EditDropletFields struct {
 	Title       *string
 	Description *string
-	Complexity  *int
 	Priority    *int
 }
 
 func (f EditDropletFields) Empty() bool {
-	return f.Title == nil && f.Description == nil && f.Complexity == nil && f.Priority == nil
+	return f.Title == nil && f.Description == nil && f.Priority == nil
 }
 
 // EditDroplet updates mutable fields on a droplet that has not yet been picked
@@ -492,10 +489,6 @@ func (c *Client) EditDroplet(id string, fields EditDropletFields) error {
 		return fmt.Errorf("cistern: title must not be empty")
 	}
 
-	if fields.Complexity != nil && (*fields.Complexity < 1 || *fields.Complexity > 3) {
-		return fmt.Errorf("cistern: complexity must be between 1 and 3, got %d", *fields.Complexity)
-	}
-
 	if fields.Priority != nil && *fields.Priority < 1 {
 		return fmt.Errorf("cistern: priority must be a positive integer, got %d", *fields.Priority)
 	}
@@ -506,9 +499,6 @@ func (c *Client) EditDroplet(id string, fields EditDropletFields) error {
 	}
 	if fields.Description != nil {
 		changedFields = append(changedFields, "description")
-	}
-	if fields.Complexity != nil {
-		changedFields = append(changedFields, "complexity")
 	}
 	if fields.Priority != nil {
 		changedFields = append(changedFields, "priority")
@@ -529,10 +519,6 @@ func (c *Client) EditDroplet(id string, fields EditDropletFields) error {
 	if fields.Description != nil {
 		setClauses = append(setClauses, "description = ?")
 		args = append(args, *fields.Description)
-	}
-	if fields.Complexity != nil {
-		setClauses = append(setClauses, "complexity = ?")
-		args = append(args, *fields.Complexity)
 	}
 	if fields.Priority != nil {
 		setClauses = append(setClauses, "priority = ?")
@@ -881,9 +867,9 @@ func (c *Client) Cancel(id, reason string) error {
 }
 
 // FileDroplet creates a new droplet in the given repo. It is a convenience
-// wrapper around Add used by the Architecti to file structural fix work items.
-func (c *Client) FileDroplet(repo, title, description string, priority, complexity int) (*Droplet, error) {
-	return c.Add(repo, title, description, priority, complexity)
+// wrapper around Add used by the Architect to file structural fix work items.
+func (c *Client) FileDroplet(repo, title, description string, priority int) (*Droplet, error) {
+	return c.Add(repo, title, description, priority)
 }
 
 // CloseItem marks a droplet as delivered.
@@ -963,7 +949,7 @@ func (c *Client) SetCataractae(id, cataractaeName string) error {
 // Get retrieves a single droplet by ID. Returns an error if not found.
 func (c *Client) Get(id string) (*Droplet, error) {
 	row := c.db.QueryRow(
-		`SELECT id, repo, title, description, priority, complexity, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+		`SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
 		 FROM droplets WHERE id = ?`,
 		id,
 	)
@@ -980,7 +966,7 @@ func (c *Client) Get(id string) (*Droplet, error) {
 // List returns droplets filtered by repo and/or status. Empty strings mean no filter.
 // Cancelled droplets are always excluded unless status is explicitly "cancelled".
 func (c *Client) List(repo, status string) ([]*Droplet, error) {
-	query := `SELECT id, repo, title, description, priority, complexity, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+	query := `SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
 		 FROM droplets WHERE 1=1`
 	var args []any
 	if repo != "" {
@@ -1019,7 +1005,7 @@ func (c *Client) List(repo, status string) ([]*Droplet, error) {
 // (empty means all). priority is an exact match on priority (0 means all).
 // Results are ordered by priority ASC, created_at ASC.
 func (c *Client) Search(query, status string, priority int) ([]*Droplet, error) {
-	qry := `SELECT id, repo, title, description, priority, complexity, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+	qry := `SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
 		 FROM droplets WHERE 1=1`
 	var args []any
 	if query != "" {
@@ -1064,7 +1050,7 @@ func scanDroplet(row *sql.Row) (*Droplet, error) {
 	var lastHeartbeatAt, stageDispatchedAt sql.NullTime
 	err := row.Scan(
 		&d.ID, &d.Repo, &d.Title, &d.Description,
-		&d.Priority, &d.Complexity, &d.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
+		&d.Priority, &d.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
 		&lastHeartbeatAt, &d.CreatedAt, &d.UpdatedAt, &stageDispatchedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -1084,7 +1070,7 @@ func scanDropletFromRows(rows *sql.Rows) (*Droplet, error) {
 	var lastHeartbeatAt, stageDispatchedAt sql.NullTime
 	if err := rows.Scan(
 		&d.ID, &d.Repo, &d.Title, &d.Description,
-		&d.Priority, &d.Complexity, &d.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
+		&d.Priority, &d.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
 		&lastHeartbeatAt, &d.CreatedAt, &d.UpdatedAt, &stageDispatchedAt,
 	); err != nil {
 		return nil, err

--- a/internal/cistern/client_test.go
+++ b/internal/cistern/client_test.go
@@ -30,105 +30,6 @@ func TestNew_CreatesDB(t *testing.T) {
 	}
 }
 
-// TestNew_FreshDB_DefaultComplexityIsTwo verifies that a fresh database created
-// from schema.sql defaults the complexity column to 2 (full), not 3 (critical).
-func TestNew_FreshDB_DefaultComplexityIsTwo(t *testing.T) {
-	c := testClient(t)
-	// Add a droplet, then fetch it back directly to check the schema-level default
-	// is not involved (Add validates and stores explicitly). Instead, verify the
-	// schema default by inserting a row without specifying complexity.
-	_, err := c.db.Exec(`INSERT INTO droplets (id, repo, title) VALUES ('bf-test1', 'repo', 'title')`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var got int
-	if err := c.db.QueryRow(`SELECT complexity FROM droplets WHERE id = 'bf-test1'`).Scan(&got); err != nil {
-		t.Fatal(err)
-	}
-	if got != 2 {
-		t.Errorf("schema DEFAULT complexity = %d, want 2 (full)", got)
-	}
-}
-
-// TestNew_ComplexityMigration_RemapsOldSchemeValues verifies that when New() is
-// called on a DB containing old-scheme complexity values (1=trivial, 2=standard,
-// 3=full, 4=critical), they are remapped to the new scheme (1=standard, 2=full,
-// 3=critical).
-func TestNew_ComplexityMigration_RemapsOldSchemeValues(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "migrate.db")
-
-	// Seed the DB with old-scheme complexity values using the raw driver,
-	// bypassing New() so the migration has not yet run.
-	seedDB, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = seedDB.Exec(`CREATE TABLE IF NOT EXISTS droplets (
-		id TEXT PRIMARY KEY,
-		repo TEXT NOT NULL,
-		title TEXT NOT NULL,
-		description TEXT DEFAULT '',
-		priority INTEGER DEFAULT 2,
-		complexity INTEGER DEFAULT 3,
-		status TEXT DEFAULT 'open',
-		assignee TEXT DEFAULT '',
-		current_cataractae TEXT DEFAULT '',
-		outcome TEXT DEFAULT NULL,
-		assigned_aqueduct TEXT DEFAULT '',
-		last_reviewed_commit TEXT DEFAULT NULL,
-		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-	)`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Insert rows with old-scheme values: trivial=1, standard=2, full=3, critical=4.
-	for _, row := range []struct {
-		id         string
-		complexity int
-	}{
-		{"old-trivial", 1},
-		{"old-standard", 2},
-		{"old-full", 3},
-		{"old-critical", 4},
-	} {
-		if _, err := seedDB.Exec(`INSERT INTO droplets (id, repo, title, complexity) VALUES (?, 'r', 't', ?)`, row.id, row.complexity); err != nil {
-			t.Fatal(err)
-		}
-	}
-	seedDB.Close()
-
-	// Open with New() to trigger the migration.
-	c, err := New(dbPath, "bf")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer c.Close()
-
-	// Given: old scheme 1=trivial → new scheme 1=standard (unchanged, trivial removed)
-	// Given: old scheme 2=standard → new scheme 1=standard
-	// Given: old scheme 3=full    → new scheme 2=full
-	// Given: old scheme 4=critical → new scheme 3=critical
-	cases := []struct {
-		id      string
-		wantNew int
-	}{
-		{"old-trivial", 1},
-		{"old-standard", 1},
-		{"old-full", 2},
-		{"old-critical", 3},
-	}
-	for _, tc := range cases {
-		var got int
-		if err := c.db.QueryRow(`SELECT complexity FROM droplets WHERE id = ?`, tc.id).Scan(&got); err != nil {
-			t.Fatalf("id=%s: %v", tc.id, err)
-		}
-		if got != tc.wantNew {
-			t.Errorf("id=%s: complexity after migration = %d, want %d", tc.id, got, tc.wantNew)
-		}
-	}
-}
-
 func TestGenerateID(t *testing.T) {
 	c := testClient(t)
 	id, err := c.generateID()
@@ -158,7 +59,7 @@ func TestGenerateID(t *testing.T) {
 
 func TestAdd_And_Get(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("github.com/org/repo", "Fix bug", "Details here", 1, 3)
+	item, err := c.Add("github.com/org/repo", "Fix bug", "Details here", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,9 +87,9 @@ func TestAdd_And_Get(t *testing.T) {
 
 func TestGetReady_PriorityOrdering(t *testing.T) {
 	c := testClient(t)
-	c.Add("myrepo", "Low priority", "", 3, 3)
-	c.Add("myrepo", "High priority", "", 1, 3)
-	c.Add("myrepo", "Medium priority", "", 2, 3)
+	c.Add("myrepo", "Low priority", "", 3)
+	c.Add("myrepo", "High priority", "", 1)
+	c.Add("myrepo", "Medium priority", "", 2)
 
 	item, err := c.GetReady("myrepo")
 	if err != nil {
@@ -204,8 +105,8 @@ func TestGetReady_PriorityOrdering(t *testing.T) {
 
 func TestGetReady_RepoFilter(t *testing.T) {
 	c := testClient(t)
-	c.Add("repo-a", "A task", "", 1, 3)
-	c.Add("repo-b", "B task", "", 1, 3)
+	c.Add("repo-a", "A task", "", 1)
+	c.Add("repo-b", "B task", "", 1)
 
 	item, err := c.GetReady("repo-a")
 	if err != nil {
@@ -226,7 +127,7 @@ func TestGetReady_RepoFilter(t *testing.T) {
 
 func TestGetReady_OnlyOpen(t *testing.T) {
 	c := testClient(t)
-	c.Add("myrepo", "Task", "", 1, 3)
+	c.Add("myrepo", "Task", "", 1)
 
 	// First GetReady atomically claims the item.
 	got, err := c.GetReady("myrepo")
@@ -260,7 +161,7 @@ func TestGetReady_NoWork(t *testing.T) {
 
 func TestAssign(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	// Claim the item via GetReady (atomically sets in_progress).
 	c.GetReady("myrepo")
@@ -283,7 +184,7 @@ func TestAssign(t *testing.T) {
 
 func TestAssign_EmptyWorker_SetsOpen(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.GetReady("myrepo") // claim item (sets in_progress)
 	c.Assign(item.ID, "alice", "implement")
 
@@ -309,7 +210,7 @@ func TestAssign_EmptyWorker_SetsOpen(t *testing.T) {
 // droplet is not locked to a stale aqueduct operator.
 func TestAssign_EmptyWorker_ClearsAssignedAqueduct(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(item.ID, "alice", "implement")
 	c.SetAssignedAqueduct(item.ID, "cistern-alice")
@@ -331,7 +232,7 @@ func TestAssign_EmptyWorker_ClearsAssignedAqueduct(t *testing.T) {
 
 func TestUpdateStatus(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	if err := c.UpdateStatus(item.ID, "in_progress"); err != nil {
 		t.Fatal(err)
@@ -345,7 +246,7 @@ func TestUpdateStatus(t *testing.T) {
 
 func TestAddNote_And_GetNotes(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	if err := c.AddNote(item.ID, "implement", "wrote the code"); err != nil {
 		t.Fatal(err)
@@ -383,7 +284,7 @@ func TestGetNotes_Empty(t *testing.T) {
 
 func TestPool(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	if err := c.Pool(item.ID, "stuck on flaky test"); err != nil {
 		t.Fatal(err)
@@ -413,7 +314,7 @@ func TestPool(t *testing.T) {
 
 func TestCloseItem(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	if err := c.CloseItem(item.ID); err != nil {
 		t.Fatal(err)
@@ -427,9 +328,9 @@ func TestCloseItem(t *testing.T) {
 
 func TestList_All(t *testing.T) {
 	c := testClient(t)
-	c.Add("myrepo", "Task 1", "", 1, 3)
-	c.Add("myrepo", "Task 2", "", 2, 3)
-	c.Add("other", "Task 3", "", 1, 3)
+	c.Add("myrepo", "Task 1", "", 1)
+	c.Add("myrepo", "Task 2", "", 2)
+	c.Add("other", "Task 3", "", 1)
 
 	items, err := c.List("", "")
 	if err != nil {
@@ -442,8 +343,8 @@ func TestList_All(t *testing.T) {
 
 func TestList_ByRepo(t *testing.T) {
 	c := testClient(t)
-	c.Add("myrepo", "Task 1", "", 1, 3)
-	c.Add("other", "Task 2", "", 1, 3)
+	c.Add("myrepo", "Task 1", "", 1)
+	c.Add("other", "Task 2", "", 1)
 
 	items, err := c.List("myrepo", "")
 	if err != nil {
@@ -459,8 +360,8 @@ func TestList_ByRepo(t *testing.T) {
 
 func TestList_ByStatus(t *testing.T) {
 	c := testClient(t)
-	item1, _ := c.Add("myrepo", "Open task", "", 1, 3)
-	item2, _ := c.Add("myrepo", "Closed task", "", 1, 3)
+	item1, _ := c.Add("myrepo", "Open task", "", 1)
+	item2, _ := c.Add("myrepo", "Closed task", "", 1)
 	_ = item1
 	c.CloseItem(item2.ID)
 
@@ -500,7 +401,7 @@ func TestAssign_NotFound(t *testing.T) {
 // (the field is preserved as-is when resetting to open).
 func TestAssign_SetsStageDispatchedAt(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 2)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.GetReady("myrepo")
 
 	before := time.Now()
@@ -527,85 +428,10 @@ func TestAssign_SetsStageDispatchedAt(t *testing.T) {
 	}
 }
 
-func TestAdd_WithComplexity(t *testing.T) {
-	c := testClient(t)
-	item, err := c.Add("myrepo", "Trivial fix", "", 2, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if item.Complexity != 1 {
-		t.Errorf("complexity = %d, want 1", item.Complexity)
-	}
-
-	got, err := c.Get(item.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Complexity != 1 {
-		t.Errorf("stored complexity = %d, want 1", got.Complexity)
-	}
-}
-
-func TestAdd_ComplexityDefault(t *testing.T) {
-	c := testClient(t)
-	// Out-of-range complexity should default to 2 (full).
-	item, err := c.Add("myrepo", "Bad cx", "", 2, 99)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if item.Complexity != 2 {
-		t.Errorf("complexity = %d, want 2 (default)", item.Complexity)
-	}
-}
-
-func TestGetReady_ReturnsComplexity(t *testing.T) {
-	c := testClient(t)
-	c.Add("myrepo", "Critical task", "", 1, 3)
-
-	item, err := c.GetReady("myrepo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if item.Complexity != 3 {
-		t.Errorf("complexity = %d, want 3", item.Complexity)
-	}
-}
-
-func TestList_ReturnsComplexity(t *testing.T) {
-	c := testClient(t)
-	c.Add("myrepo", "Standard", "", 1, 1)
-	c.Add("myrepo", "Critical", "", 1, 3)
-
-	items, err := c.List("myrepo", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(items) != 2 {
-		t.Fatalf("got %d items, want 2", len(items))
-	}
-	if items[0].Complexity != 1 {
-		t.Errorf("items[0].Complexity = %d, want 1", items[0].Complexity)
-	}
-	if items[1].Complexity != 3 {
-		t.Errorf("items[1].Complexity = %d, want 3", items[1].Complexity)
-	}
-}
-
-func TestStats_EmptyDB(t *testing.T) {
-	c := testClient(t)
-	s, err := c.Stats()
-	if err != nil {
-		t.Fatalf("Stats on empty DB: %v", err)
-	}
-	if s.Flowing != 0 || s.Queued != 0 || s.Delivered != 0 || s.Pooled != 0 {
-		t.Errorf("expected all zeros on empty DB, got %+v", s)
-	}
-}
-
 func TestAdd_WithDeps(t *testing.T) {
 	c := testClient(t)
-	parent, _ := c.Add("myrepo", "Parent", "", 1, 3)
-	child, err := c.Add("myrepo", "Child", "", 1, 3, parent.ID)
+	parent, _ := c.Add("myrepo", "Parent", "", 1)
+	child, err := c.Add("myrepo", "Child", "", 1, parent.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -620,7 +446,7 @@ func TestAdd_WithDeps(t *testing.T) {
 
 func TestAdd_UnknownDep(t *testing.T) {
 	c := testClient(t)
-	_, err := c.Add("myrepo", "Child", "", 1, 3, "nonexistent")
+	_, err := c.Add("myrepo", "Child", "", 1, "nonexistent")
 	if err == nil {
 		t.Error("expected error for unknown dep ID")
 	}
@@ -628,8 +454,8 @@ func TestAdd_UnknownDep(t *testing.T) {
 
 func TestAddDependency_And_RemoveDependency(t *testing.T) {
 	c := testClient(t)
-	a, _ := c.Add("myrepo", "A", "", 1, 3)
-	b, _ := c.Add("myrepo", "B", "", 1, 3)
+	a, _ := c.Add("myrepo", "A", "", 1)
+	b, _ := c.Add("myrepo", "B", "", 1)
 
 	if err := c.AddDependency(b.ID, a.ID); err != nil {
 		t.Fatal(err)
@@ -650,7 +476,7 @@ func TestAddDependency_And_RemoveDependency(t *testing.T) {
 
 func TestAddDependency_UnknownDroplet(t *testing.T) {
 	c := testClient(t)
-	a, _ := c.Add("myrepo", "A", "", 1, 3)
+	a, _ := c.Add("myrepo", "A", "", 1)
 	if err := c.AddDependency("nonexistent", a.ID); err == nil {
 		t.Error("expected error for unknown droplet")
 	}
@@ -661,8 +487,8 @@ func TestAddDependency_UnknownDroplet(t *testing.T) {
 
 func TestGetBlockedBy(t *testing.T) {
 	c := testClient(t)
-	parent, _ := c.Add("myrepo", "Parent", "", 1, 3)
-	child, _ := c.Add("myrepo", "Child", "", 1, 3, parent.ID)
+	parent, _ := c.Add("myrepo", "Parent", "", 1)
+	child, _ := c.Add("myrepo", "Child", "", 1, parent.ID)
 
 	// Parent not delivered — child is blocked.
 	blocked, err := c.GetBlockedBy(child.ID)
@@ -686,8 +512,8 @@ func TestGetBlockedBy(t *testing.T) {
 
 func TestGetDependents(t *testing.T) {
 	c := testClient(t)
-	parent, _ := c.Add("myrepo", "Parent", "", 1, 3)
-	child, _ := c.Add("myrepo", "Child", "", 1, 3, parent.ID)
+	parent, _ := c.Add("myrepo", "Parent", "", 1)
+	child, _ := c.Add("myrepo", "Child", "", 1, parent.ID)
 
 	dependents, err := c.GetDependents(parent.ID)
 	if err != nil {
@@ -708,8 +534,8 @@ func TestGetDependents(t *testing.T) {
 
 func TestGetReady_SkipsBlocked(t *testing.T) {
 	c := testClient(t)
-	parent, _ := c.Add("myrepo", "Parent", "", 1, 3)
-	_, _ = c.Add("myrepo", "Child", "", 1, 3, parent.ID)
+	parent, _ := c.Add("myrepo", "Parent", "", 1)
+	_, _ = c.Add("myrepo", "Child", "", 1, parent.ID)
 
 	// GetReady should return parent (child is blocked).
 	got, err := c.GetReady("myrepo")
@@ -738,8 +564,8 @@ func TestGetReady_SkipsBlocked(t *testing.T) {
 
 func TestGetReady_SkipsBlocked_NothingAvailable(t *testing.T) {
 	c := testClient(t)
-	parent, _ := c.Add("myrepo", "Parent", "", 1, 3)
-	_, _ = c.Add("myrepo", "Child", "", 1, 3, parent.ID)
+	parent, _ := c.Add("myrepo", "Parent", "", 1)
+	_, _ = c.Add("myrepo", "Child", "", 1, parent.ID)
 
 	// Claim parent.
 	c.GetReady("myrepo") // claims parent (in_progress)
@@ -755,7 +581,7 @@ func TestGetReady_SkipsBlocked_NothingAvailable(t *testing.T) {
 
 func TestSetAndGetLastReviewedCommit(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	// Initially empty.
 	commit, err := c.GetLastReviewedCommit(item.ID)
@@ -784,7 +610,7 @@ func TestSetAndGetLastReviewedCommit(t *testing.T) {
 
 func TestSetLastReviewedCommit_Overwrite(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	if err := c.SetLastReviewedCommit(item.ID, "hash-old"); err != nil {
 		t.Fatal(err)
@@ -804,7 +630,7 @@ func TestSetLastReviewedCommit_Overwrite(t *testing.T) {
 
 func TestGetLastReviewedCommit_PersistedInGet(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	hash := "deadbeef00"
 	if err := c.SetLastReviewedCommit(item.ID, hash); err != nil {
@@ -824,13 +650,13 @@ func TestStats_WithData(t *testing.T) {
 	c := testClient(t)
 
 	// Add 2 open (queued), 1 in_progress (flowing), 3 delivered, 1 pooled.
-	c.Add("repo", "q1", "", 1, 3)
-	c.Add("repo", "q2", "", 1, 3)
-	item3, _ := c.Add("repo", "ip1", "", 1, 3)
-	item4, _ := c.Add("repo", "d1", "", 1, 3)
-	item5, _ := c.Add("repo", "d2", "", 1, 3)
-	item6, _ := c.Add("repo", "d3", "", 1, 3)
-	item7, _ := c.Add("repo", "s1", "", 1, 3)
+	c.Add("repo", "q1", "", 1)
+	c.Add("repo", "q2", "", 1)
+	item3, _ := c.Add("repo", "ip1", "", 1)
+	item4, _ := c.Add("repo", "d1", "", 1)
+	item5, _ := c.Add("repo", "d2", "", 1)
+	item6, _ := c.Add("repo", "d3", "", 1)
+	item7, _ := c.Add("repo", "s1", "", 1)
 
 	c.UpdateStatus(item3.ID, "in_progress")
 	c.CloseItem(item4.ID)
@@ -858,10 +684,10 @@ func TestStats_WithData(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	c := testClient(t)
-	c.Add("repo", "Fix login bug", "", 1, 3)
-	c.Add("repo", "Add dashboard feature", "", 2, 3)
-	c.Add("repo", "Fix signup flow", "", 1, 2)
-	ip, _ := c.Add("repo", "Refactor auth module", "", 3, 3)
+	c.Add("repo", "Fix login bug", "", 1)
+	c.Add("repo", "Add dashboard feature", "", 2)
+	c.Add("repo", "Fix signup flow", "", 1)
+	ip, _ := c.Add("repo", "Refactor auth module", "", 3)
 	c.UpdateStatus(ip.ID, "in_progress")
 
 	t.Run("empty query returns all", func(t *testing.T) {
@@ -952,7 +778,7 @@ func TestSearch(t *testing.T) {
 
 func TestEditDroplet_Title_GuardInProgress(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Old title", "", 1, 3)
+	item, _ := c.Add("myrepo", "Old title", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Title: ptr("New title")})
@@ -972,7 +798,7 @@ func TestSetOutcome(t *testing.T) {
 	for _, outcome := range []string{"pass", "recirculate", "pool"} {
 		t.Run(outcome, func(t *testing.T) {
 			c := testClient(t)
-			item, _ := c.Add("myrepo", "Task", "", 1, 3)
+			item, _ := c.Add("myrepo", "Task", "", 1)
 			if err := c.SetOutcome(item.ID, outcome); err != nil {
 				t.Fatal(err)
 			}
@@ -986,7 +812,7 @@ func TestSetOutcome(t *testing.T) {
 
 func TestSetOutcome_Clear(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.SetOutcome(item.ID, "pass")
 
 	if err := c.SetOutcome(item.ID, ""); err != nil {
@@ -1008,7 +834,7 @@ func TestSetOutcome_NotFound(t *testing.T) {
 
 func TestSetCataractae(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	if err := c.SetCataractae(item.ID, "review"); err != nil {
 		t.Fatal(err)
@@ -1029,9 +855,9 @@ func TestSetCataractae_NotFound(t *testing.T) {
 
 func TestPurge(t *testing.T) {
 	c := testClient(t)
-	delivered, _ := c.Add("myrepo", "Delivered", "", 1, 3)
-	pooled, _ := c.Add("myrepo", "Pooled", "", 1, 3)
-	inProgress, _ := c.Add("myrepo", "In progress", "", 1, 3)
+	delivered, _ := c.Add("myrepo", "Delivered", "", 1)
+	pooled, _ := c.Add("myrepo", "Pooled", "", 1)
+	inProgress, _ := c.Add("myrepo", "In progress", "", 1)
 
 	c.CloseItem(delivered.ID)  // status = delivered
 	c.Pool(pooled.ID, "stuck") // status = pooled
@@ -1062,7 +888,7 @@ func TestPurge(t *testing.T) {
 
 func TestPurge_DryRun(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.CloseItem(item.ID)
 
 	n, err := c.Purge(-time.Hour, true) // dry run
@@ -1080,7 +906,7 @@ func TestPurge_DryRun(t *testing.T) {
 
 func TestPurge_LeavesInProgress(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 
 	n, err := c.Purge(-time.Hour, false)
@@ -1108,7 +934,7 @@ func TestListRecentEvents_Empty(t *testing.T) {
 
 func TestListRecentEvents_WithEvents(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	c.AddNote(item.ID, "implement", "wrote the code")
 	c.Pool(item.ID, "needs human review")
@@ -1130,7 +956,7 @@ func TestListRecentEvents_WithEvents(t *testing.T) {
 
 func TestListRecentEvents_Limit(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	for i := range 5 {
 		c.RecordEvent(item.ID, "pass", fmt.Sprintf(`{"cataractae":"step-%d"}`, i))
@@ -1150,7 +976,7 @@ func ptr[T any](v T) *T { return &v }
 
 func TestEditDroplet_Description(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "old desc", 2, 3)
+	item, _ := c.Add("repo", "Title", "old desc", 2)
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Description: ptr("new desc")})
 	if err != nil {
@@ -1165,32 +991,11 @@ func TestEditDroplet_Description(t *testing.T) {
 	if got.Priority != 2 {
 		t.Errorf("priority = %d, want 2", got.Priority)
 	}
-	if got.Complexity != 3 {
-		t.Errorf("complexity = %d, want 3", got.Complexity)
-	}
-}
-
-func TestEditDroplet_Complexity(t *testing.T) {
-	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "desc", 2, 3)
-
-	err := c.EditDroplet(item.ID, EditDropletFields{Complexity: ptr(1)})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	got, _ := c.Get(item.ID)
-	if got.Complexity != 1 {
-		t.Errorf("complexity = %d, want 1", got.Complexity)
-	}
-	if got.Description != "desc" {
-		t.Errorf("description changed unexpectedly: %q", got.Description)
-	}
 }
 
 func TestEditDroplet_Priority(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "", 2, 3)
+	item, _ := c.Add("repo", "Title", "", 2)
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Priority: ptr(1)})
 	if err != nil {
@@ -1205,7 +1010,7 @@ func TestEditDroplet_Priority(t *testing.T) {
 
 func TestEditDroplet_Title(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Old Title", "desc", 2, 3)
+	item, _ := c.Add("repo", "Old Title", "desc", 2)
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Title: ptr("New Title")})
 	if err != nil {
@@ -1223,7 +1028,7 @@ func TestEditDroplet_Title(t *testing.T) {
 
 func TestEditDroplet_EmptyTitle(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "desc", 2, 3)
+	item, _ := c.Add("repo", "Title", "desc", 2)
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Title: ptr("")})
 	if err == nil {
@@ -1236,7 +1041,7 @@ func TestEditDroplet_EmptyTitle(t *testing.T) {
 
 func TestEditDroplet_InvalidPriority(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "", 2, 3)
+	item, _ := c.Add("repo", "Title", "", 2)
 
 	for _, bad := range []int{0, -1} {
 		err := c.EditDroplet(item.ID, EditDropletFields{Priority: ptr(bad)})
@@ -1250,12 +1055,11 @@ func TestEditDroplet_InvalidPriority(t *testing.T) {
 
 func TestEditDroplet_AllFields(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "old", 3, 3)
+	item, _ := c.Add("repo", "Title", "old", 3)
 
 	err := c.EditDroplet(item.ID, EditDropletFields{
 		Title:       ptr("New Title"),
 		Description: ptr("updated"),
-		Complexity:  ptr(2),
 		Priority:    ptr(1),
 	})
 	if err != nil {
@@ -1269,9 +1073,6 @@ func TestEditDroplet_AllFields(t *testing.T) {
 	if got.Description != "updated" {
 		t.Errorf("description = %q, want %q", got.Description, "updated")
 	}
-	if got.Complexity != 2 {
-		t.Errorf("complexity = %d, want 2", got.Complexity)
-	}
 	if got.Priority != 1 {
 		t.Errorf("priority = %d, want 1", got.Priority)
 	}
@@ -1279,7 +1080,7 @@ func TestEditDroplet_AllFields(t *testing.T) {
 
 func TestEditDroplet_GuardInProgress(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "", 1, 3)
+	item, _ := c.Add("repo", "Title", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Description: ptr("new")})
@@ -1296,7 +1097,7 @@ func TestEditDroplet_GuardInProgress(t *testing.T) {
 
 func TestEditDroplet_GuardDelivered(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "", 1, 3)
+	item, _ := c.Add("repo", "Title", "", 1)
 	c.CloseItem(item.ID)
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Description: ptr("new")})
@@ -1310,7 +1111,7 @@ func TestEditDroplet_GuardDelivered(t *testing.T) {
 
 func TestEditDroplet_AllowPooled(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "old", 1, 3)
+	item, _ := c.Add("repo", "Title", "old", 1)
 	c.Pool(item.ID, "stuck")
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Description: ptr("updated")})
@@ -1326,33 +1127,12 @@ func TestEditDroplet_AllowPooled(t *testing.T) {
 
 func TestEditDroplet_NoFields(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "desc", 2, 3)
+	item, _ := c.Add("repo", "Title", "desc", 2)
 
 	// No-op: no fields specified should be fine at the client layer.
 	err := c.EditDroplet(item.ID, EditDropletFields{})
 	if err != nil {
 		t.Fatalf("unexpected error for no-op edit: %v", err)
-	}
-}
-
-func TestEditDroplet_InvalidComplexity(t *testing.T) {
-	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "desc", 2, 3)
-
-	for _, bad := range []int{0, -1, 4, 5, 100} {
-		err := c.EditDroplet(item.ID, EditDropletFields{Complexity: ptr(bad)})
-		if err == nil {
-			t.Errorf("expected error for complexity=%d", bad)
-		} else if !strings.Contains(err.Error(), "complexity must be between 1 and 3") {
-			t.Errorf("complexity=%d: unexpected error: %v", bad, err)
-		}
-	}
-
-	// Valid boundary values should succeed.
-	for _, ok := range []int{1, 3} {
-		if err := c.EditDroplet(item.ID, EditDropletFields{Complexity: ptr(ok)}); err != nil {
-			t.Errorf("complexity=%d should be valid, got: %v", ok, err)
-		}
 	}
 }
 
@@ -1367,7 +1147,7 @@ func TestEditDroplet_NotFound(t *testing.T) {
 
 func TestEditDroplet_MultilineDescription(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "", 2, 3)
+	item, _ := c.Add("repo", "Title", "", 2)
 
 	multiline := "line one\nline two\nline three"
 	err := c.EditDroplet(item.ID, EditDropletFields{Description: ptr(multiline)})
@@ -1383,7 +1163,7 @@ func TestEditDroplet_MultilineDescription(t *testing.T) {
 
 func TestEditDroplet_ClearDescription(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("repo", "Title", "has content", 2, 3)
+	item, _ := c.Add("repo", "Title", "has content", 2)
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Description: ptr("")})
 	if err != nil {
@@ -1398,7 +1178,7 @@ func TestEditDroplet_ClearDescription(t *testing.T) {
 
 func TestCancel_SetsStatusCancelled(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Superseded feature", "", 1, 3)
+	item, _ := c.Add("myrepo", "Superseded feature", "", 1)
 
 	if err := c.Cancel(item.ID, "superseded by newer approach"); err != nil {
 		t.Fatal(err)
@@ -1415,7 +1195,7 @@ func TestCancel_SetsStatusCancelled(t *testing.T) {
 
 func TestCancel_RecordsCancelEventWithReason(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Old feature", "", 1, 3)
+	item, _ := c.Add("myrepo", "Old feature", "", 1)
 
 	reason := "filed in error"
 	if err := c.Cancel(item.ID, reason); err != nil {
@@ -1440,7 +1220,7 @@ func TestCancel_RecordsCancelEventWithReason(t *testing.T) {
 
 func TestCancel_RecordsCancelEventWithoutReason(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Old feature", "", 1, 3)
+	item, _ := c.Add("myrepo", "Old feature", "", 1)
 
 	if err := c.Cancel(item.ID, ""); err != nil {
 		t.Fatal(err)
@@ -1464,7 +1244,7 @@ func TestCancel_RecordsCancelEventWithoutReason(t *testing.T) {
 
 func TestCancel_PreservesAssignee(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Obsolete task", "", 1, 2)
+	item, _ := c.Add("myrepo", "Obsolete task", "", 1)
 	c.Assign(item.ID, "worker-1", "implement")
 
 	pre, err := c.Get(item.ID)
@@ -1490,7 +1270,7 @@ func TestCancel_PreservesAssignee(t *testing.T) {
 
 func TestCancel_ClearsOutcome(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Obsolete task", "", 1, 2)
+	item, _ := c.Add("myrepo", "Obsolete task", "", 1)
 	c.Assign(item.ID, "worker-1", "implement")
 	c.SetOutcome(item.ID, "pass")
 
@@ -1517,7 +1297,7 @@ func TestCancel_ClearsOutcome(t *testing.T) {
 
 func TestCancel_ClearsAssignedAqueduct(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Obsolete task", "", 1, 2)
+	item, _ := c.Add("myrepo", "Obsolete task", "", 1)
 	c.SetAssignedAqueduct(item.ID, "cistern-gamma")
 	pre, err := c.Get(item.ID)
 	if err != nil {
@@ -1542,7 +1322,7 @@ func TestCancel_ClearsAssignedAqueduct(t *testing.T) {
 
 func TestCancel_RecordsCancelEvent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Obsolete task", "", 1, 2)
+	item, _ := c.Add("myrepo", "Obsolete task", "", 1)
 
 	reason := "superseded by ct-abc12"
 	if err := c.Cancel(item.ID, reason); err != nil {
@@ -1567,7 +1347,7 @@ func TestCancel_RecordsCancelEvent(t *testing.T) {
 
 func TestCancel_PreservesExistingNotes(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Obsolete task", "", 1, 2)
+	item, _ := c.Add("myrepo", "Obsolete task", "", 1)
 
 	c.AddNote(item.ID, "implement", "started work")
 	c.AddNote(item.ID, "review", "found issues")
@@ -1606,7 +1386,7 @@ func TestCancel_NotFound(t *testing.T) {
 
 func TestCancel_AlreadyCancelled_ReturnsTerminalError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Feature", "", 1, 3)
+	item, _ := c.Add("myrepo", "Feature", "", 1)
 	if err := c.Cancel(item.ID, "first cancel"); err != nil {
 		t.Fatal(err)
 	}
@@ -1621,7 +1401,7 @@ func TestCancel_AlreadyCancelled_ReturnsTerminalError(t *testing.T) {
 
 func TestCancel_Delivered_ReturnsTerminalError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Feature", "", 1, 3)
+	item, _ := c.Add("myrepo", "Feature", "", 1)
 	if err := c.CloseItem(item.ID); err != nil {
 		t.Fatal(err)
 	}
@@ -1636,7 +1416,7 @@ func TestCancel_Delivered_ReturnsTerminalError(t *testing.T) {
 
 func TestCancel_ExcludedFromGetReady(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Old feature", "", 1, 3)
+	item, _ := c.Add("myrepo", "Old feature", "", 1)
 
 	if err := c.Cancel(item.ID, "won't do"); err != nil {
 		t.Fatal(err)
@@ -1654,8 +1434,8 @@ func TestCancel_ExcludedFromGetReady(t *testing.T) {
 
 func TestList_ExcludesCancelledByDefault(t *testing.T) {
 	c := testClient(t)
-	c.Add("myrepo", "Active", "", 1, 3)
-	cancelled, _ := c.Add("myrepo", "Cancelled", "", 1, 3)
+	c.Add("myrepo", "Active", "", 1)
+	cancelled, _ := c.Add("myrepo", "Cancelled", "", 1)
 	c.Cancel(cancelled.ID, "not needed")
 
 	// List with no status filter must not include cancelled items.
@@ -1672,8 +1452,8 @@ func TestList_ExcludesCancelledByDefault(t *testing.T) {
 
 func TestList_CancelledStatus_ReturnsOnlyCancelled(t *testing.T) {
 	c := testClient(t)
-	c.Add("myrepo", "Active", "", 1, 3)
-	cancelled, _ := c.Add("myrepo", "Cancelled", "", 1, 3)
+	c.Add("myrepo", "Active", "", 1)
+	cancelled, _ := c.Add("myrepo", "Cancelled", "", 1)
 	c.Cancel(cancelled.ID, "not needed")
 
 	items, err := c.List("myrepo", "cancelled")
@@ -1710,7 +1490,7 @@ func TestCancel_NotFound_NoOrphanData(t *testing.T) {
 // TestPurge_IncludesCancelled verifies that cancelled droplets are cleaned up by Purge.
 func TestPurge_IncludesCancelled(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Cancelled task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Cancelled task", "", 1)
 	c.Cancel(item.ID, "won't do")
 
 	n, err := c.Purge(-time.Hour, false)
@@ -1729,8 +1509,8 @@ func TestPurge_IncludesCancelled(t *testing.T) {
 // dependency was cancelled is still dispatched (cancelled != unresolved).
 func TestGetReady_CancelledDependency_DoesNotBlock(t *testing.T) {
 	c := testClient(t)
-	dep, _ := c.Add("myrepo", "Dependency", "", 1, 3)
-	child, _ := c.Add("myrepo", "Child", "", 2, 3, dep.ID)
+	dep, _ := c.Add("myrepo", "Dependency", "", 1)
+	child, _ := c.Add("myrepo", "Child", "", 2, dep.ID)
 
 	// Cancel the dependency instead of delivering it.
 	if err := c.Cancel(dep.ID, "no longer needed"); err != nil {
@@ -1754,8 +1534,8 @@ func TestGetReady_CancelledDependency_DoesNotBlock(t *testing.T) {
 // droplets when no status filter is given (consistent with List behaviour).
 func TestSearch_ExcludesCancelledByDefault(t *testing.T) {
 	c := testClient(t)
-	c.Add("myrepo", "Active task", "", 1, 3)
-	cancelled, _ := c.Add("myrepo", "Cancelled task", "", 1, 3)
+	c.Add("myrepo", "Active task", "", 1)
+	cancelled, _ := c.Add("myrepo", "Cancelled task", "", 1)
 	c.Cancel(cancelled.ID, "not needed")
 
 	results, err := c.Search("", "", 0)
@@ -1774,7 +1554,7 @@ func TestSearch_ExcludesCancelledByDefault(t *testing.T) {
 func TestGetReady_CaseInsensitiveRepo_ReturnsDropletStoredWithWrongCase(t *testing.T) {
 	c := testClient(t)
 	// Given: a droplet stored with lower-case repo name.
-	_, err := c.Add("portfoliowebsite", "My task", "", 1, 2)
+	_, err := c.Add("portfoliowebsite", "My task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1798,7 +1578,7 @@ func TestGetReady_CaseInsensitiveRepo_ReturnsDropletStoredWithWrongCase(t *testi
 // ExternalRef — the column defaults to NULL and is scanned as an empty string.
 func TestExternalRef_IsNullByDefault(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1815,7 +1595,7 @@ func TestExternalRef_IsNullByDefault(t *testing.T) {
 // the external reference and Get returns it correctly.
 func TestSetExternalRef_And_Get_RoundTrips(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Imported task", "", 1, 2)
+	item, err := c.Add("myrepo", "Imported task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1839,7 +1619,7 @@ func TestSetExternalRef_And_Get_RoundTrips(t *testing.T) {
 // empty string to SetExternalRef stores NULL (returned as empty string by Get).
 func TestSetExternalRef_ClearsField_WhenEmptyStringPassed(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Imported task", "", 1, 2)
+	item, err := c.Add("myrepo", "Imported task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1866,7 +1646,7 @@ func TestSetExternalRef_ClearsField_WhenEmptyStringPassed(t *testing.T) {
 // external_ref stored on the droplet.
 func TestExternalRef_RoundTrips_ThroughGetReady(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1893,7 +1673,7 @@ func TestExternalRef_RoundTrips_ThroughGetReady(t *testing.T) {
 // external_ref stored on each droplet.
 func TestExternalRef_RoundTrips_ThroughList(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1920,7 +1700,7 @@ func TestExternalRef_RoundTrips_ThroughList(t *testing.T) {
 // external_ref stored on each droplet.
 func TestExternalRef_RoundTrips_ThroughSearch(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Imported feature", "", 1, 2)
+	item, err := c.Add("myrepo", "Imported feature", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1950,7 +1730,7 @@ func TestExternalRef_RoundTrips_ThroughSearch(t *testing.T) {
 // leave LastHeartbeatAt zero and this test would fail.
 func TestHeartbeat_RoundTrips_ThroughGet(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1980,7 +1760,7 @@ func TestHeartbeat_RoundTrips_ThroughGet(t *testing.T) {
 // last_heartbeat_at written by Heartbeat().
 func TestHeartbeat_RoundTrips_ThroughList(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2013,7 +1793,7 @@ func TestHeartbeat_RoundTrips_ThroughList(t *testing.T) {
 // last_heartbeat_at written by Heartbeat().
 func TestHeartbeat_RoundTrips_ThroughSearch(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Heartbeat task", "", 1, 2)
+	item, err := c.Add("myrepo", "Heartbeat task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2046,7 +1826,7 @@ func TestHeartbeat_RoundTrips_ThroughSearch(t *testing.T) {
 // last_heartbeat_at written by Heartbeat().
 func TestHeartbeat_RoundTrips_ThroughGetReady(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2079,7 +1859,7 @@ func TestHeartbeat_RoundTrips_ThroughGetReady(t *testing.T) {
 // GetReadyForAqueduct returns the last_heartbeat_at written by Heartbeat().
 func TestHeartbeat_RoundTrips_ThroughGetReadyForAqueduct(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2123,7 +1903,7 @@ func TestSetExternalRef_ReturnsError_WhenDropletNotFound(t *testing.T) {
 // names or that break the delivery shell awk extraction (spaces, ~, ^, etc.).
 func TestSetExternalRef_RejectsInvalidFormat(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2167,7 +1947,7 @@ func TestSetExternalRef_RejectsInvalidFormat(t *testing.T) {
 // well-formed 'provider:key' values with git-branch-safe characters.
 func TestSetExternalRef_AcceptsValidFormats(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2196,7 +1976,7 @@ func TestSetExternalRef_AcceptsValidFormats(t *testing.T) {
 func TestGetReadyForAqueduct_CaseInsensitiveRepo_ReturnsDroplet(t *testing.T) {
 	c := testClient(t)
 	// Given: a droplet stored with upper-case repo name.
-	_, err := c.Add("CISTERN", "Cistern task", "", 1, 2)
+	_, err := c.Add("CISTERN", "Cistern task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2221,9 +2001,9 @@ func TestGetReadyForAqueduct_CaseInsensitiveRepo_ReturnsDroplet(t *testing.T) {
 func TestList_CaseInsensitiveRepo_ReturnsDroplets(t *testing.T) {
 	c := testClient(t)
 	// Given: droplets stored with mixed-case repo names.
-	c.Add("scaledtest", "Task A", "", 1, 2)
-	c.Add("SCALEDTEST", "Task B", "", 1, 2)
-	c.Add("other", "Task C", "", 1, 2)
+	c.Add("scaledtest", "Task A", "", 1)
+	c.Add("SCALEDTEST", "Task B", "", 1)
+	c.Add("other", "Task C", "", 1)
 
 	// When: List is called with canonical casing.
 	items, err := c.List("ScaledTest", "")
@@ -2255,7 +2035,6 @@ func TestNew_RepoCaseMigration_NormalizesCanonicalRepos(t *testing.T) {
 		title TEXT NOT NULL,
 		description TEXT DEFAULT '',
 		priority INTEGER DEFAULT 2,
-		complexity INTEGER DEFAULT 2,
 		status TEXT DEFAULT 'open',
 		assignee TEXT DEFAULT '',
 		current_cataractae TEXT DEFAULT '',
@@ -2332,7 +2111,7 @@ func TestNew_RepoCaseMigration_IsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c1.Add("cistern", "Task", "", 1, 2)
+	c1.Add("cistern", "Task", "", 1)
 	c1.Close()
 
 	// Second open: migration must be a no-op.
@@ -2356,8 +2135,8 @@ func TestNew_RepoCaseMigration_IsIdempotent(t *testing.T) {
 // status="cancelled" filter returns cancelled droplets.
 func TestSearch_CancelledStatus_ReturnsCancelled(t *testing.T) {
 	c := testClient(t)
-	c.Add("myrepo", "Active task", "", 1, 3)
-	cancelled, _ := c.Add("myrepo", "Cancelled task", "", 1, 3)
+	c.Add("myrepo", "Active task", "", 1)
+	cancelled, _ := c.Add("myrepo", "Cancelled task", "", 1)
 	c.Cancel(cancelled.ID, "not needed")
 
 	results, err := c.Search("", "cancelled", 0)
@@ -2376,7 +2155,7 @@ func TestSearch_CancelledStatus_ReturnsCancelled(t *testing.T) {
 // the assigned_aqueduct so no ghost assignments linger after terminal state.
 func TestCloseItem_ClearsAssignedAqueduct(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Feature", "", 1, 2)
+	item, _ := c.Add("myrepo", "Feature", "", 1)
 	c.SetAssignedAqueduct(item.ID, "cistern-alpha")
 	pre, err := c.Get(item.ID)
 	if err != nil {
@@ -2403,7 +2182,7 @@ func TestCloseItem_ClearsAssignedAqueduct(t *testing.T) {
 // removes assigned_aqueduct so no ghost assignments linger.
 func TestPool_ClearsAssignedAqueduct(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Stuck task", "", 1, 2)
+	item, _ := c.Add("myrepo", "Stuck task", "", 1)
 	c.SetAssignedAqueduct(item.ID, "cistern-beta")
 	pre, err := c.Get(item.ID)
 	if err != nil {
@@ -2431,7 +2210,7 @@ func TestPool_ClearsAssignedAqueduct(t *testing.T) {
 // overwriting an existing assignment.
 func TestSetAssignedAqueduct_WhenAlreadySet_DoesNotOverwrite(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Contested task", "", 1, 2)
+	item, _ := c.Add("myrepo", "Contested task", "", 1)
 
 	// First assignment should succeed.
 	if err := c.SetAssignedAqueduct(item.ID, "cistern-alpha"); err != nil {
@@ -2481,7 +2260,6 @@ func TestNew_LastHeartbeatAtMigration_AddsColumnToExistingDB(t *testing.T) {
 		title TEXT NOT NULL,
 		description TEXT DEFAULT '',
 		priority INTEGER DEFAULT 2,
-		complexity INTEGER DEFAULT 1,
 		status TEXT DEFAULT 'open',
 		assignee TEXT DEFAULT '',
 		current_cataractae TEXT DEFAULT '',
@@ -2532,7 +2310,7 @@ func TestNew_LastHeartbeatAtMigration_AddsColumnToExistingDB(t *testing.T) {
 func TestExternalRef_RoundTrips_ThroughGetReadyForAqueduct(t *testing.T) {
 	c := testClient(t)
 	// Given: a droplet with an external_ref set.
-	item, err := c.Add("myrepo", "Imported task", "", 1, 2)
+	item, err := c.Add("myrepo", "Imported task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2560,8 +2338,7 @@ func TestExternalRef_RoundTrips_ThroughGetReadyForAqueduct(t *testing.T) {
 
 func TestGetDropletChanges_Empty(t *testing.T) {
 	c := testClient(t)
-
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2580,7 +2357,7 @@ func TestGetDropletChanges_Empty(t *testing.T) {
 
 func TestGetDropletChanges_ReturnsOnlyEvents(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2605,7 +2382,7 @@ func TestGetDropletChanges_ReturnsOnlyEvents(t *testing.T) {
 
 func TestGetDropletChanges_ReturnsEvents(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2634,7 +2411,7 @@ func TestGetDropletChanges_ReturnsEvents(t *testing.T) {
 
 func TestGetDropletChanges_MixedNotesAndEvents(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2660,7 +2437,7 @@ func TestGetDropletChanges_MixedNotesAndEvents(t *testing.T) {
 
 func TestGetDropletChanges_RespectsLimit_ReturnsNewest(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2693,7 +2470,7 @@ func TestGetDropletChanges_RespectsLimit_ReturnsNewest(t *testing.T) {
 
 func TestGetDropletChanges_OrderedOldestFirst(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 2)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2731,7 +2508,7 @@ func TestGetDropletChanges_NotFoundReturnEmpty(t *testing.T) {
 
 func TestGetDropletTimeline_ReturnsEvents(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Timeline task", "", 1, 2)
+	item, err := c.Add("myrepo", "Timeline task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2755,7 +2532,7 @@ func TestGetDropletTimeline_ReturnsEvents(t *testing.T) {
 
 func TestGetDropletTimeline_OrderedOldestFirst(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Timeline order", "", 1, 2)
+	item, err := c.Add("myrepo", "Timeline order", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2789,7 +2566,7 @@ func TestGetDropletTimeline_NotFoundReturnEmpty(t *testing.T) {
 
 func TestGetDropletTimeline_IncludesStructuredPayload(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Payload task", "", 1, 2)
+	item, err := c.Add("myrepo", "Payload task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2808,7 +2585,7 @@ func TestGetDropletTimeline_IncludesStructuredPayload(t *testing.T) {
 
 func TestGetDropletTimeline_RespectsLimit_ReturnsNewest(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Limit task", "", 1, 2)
+	item, err := c.Add("myrepo", "Limit task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2835,7 +2612,7 @@ func TestGetDropletTimeline_RespectsLimit_ReturnsNewest(t *testing.T) {
 
 func TestGetDropletTimeline_LimitZero_ReturnsAll(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "No-limit task", "", 1, 2)
+	item, err := c.Add("myrepo", "No-limit task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2860,7 +2637,7 @@ func TestDisplayInfo_MapsEventTypesToHumanReadableLabels(t *testing.T) {
 		wantLabel string
 		wantSub   string
 	}{
-		{"create", `{"repo":"myrepo","title":"My task","priority":1,"complexity":2}`, "created", "repo: myrepo"},
+		{"create", `{"repo":"myrepo","title":"My task","priority":1}`, "created", "repo: myrepo"},
 		{"dispatch", `{"aqueduct":"default","cataractae":"implement"}`, "dispatched", "step: implement"},
 		{"pass", `{"cataractae":"reviewer","notes":"all good"}`, "pass", "by: reviewer"},
 		{"recirculate", `{"cataractae":"reviewer","target":"implement"}`, "recirculate", "to: implement"},
@@ -2909,7 +2686,7 @@ func TestDisplayInfo_UnknownEventType(t *testing.T) {
 
 func TestRestart_WithCataractae(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Stuck feature", "", 1, 3)
+	item, err := c.Add("myrepo", "Stuck feature", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2940,7 +2717,7 @@ func TestRestart_WithCataractae(t *testing.T) {
 
 func TestRestart_WithSameCataractae(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2964,7 +2741,7 @@ func TestRestart_WithSameCataractae(t *testing.T) {
 
 func TestRestart_RecordsRestartEvent(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2992,7 +2769,7 @@ func TestRestart_RecordsRestartEvent(t *testing.T) {
 
 func TestRestart_PreservesExistingNotes(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3021,7 +2798,7 @@ func TestRestart_PreservesExistingNotes(t *testing.T) {
 
 func TestRestart_ClearsOutcomeAndAssignee(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3055,7 +2832,7 @@ func TestRestart_NotFound(t *testing.T) {
 
 func TestRestart_UpdatesTimestamp(t *testing.T) {
 	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1, 3)
+	item, err := c.Add("myrepo", "Task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3073,7 +2850,7 @@ func TestRestart_UpdatesTimestamp(t *testing.T) {
 
 func TestRestart_ClearsStageDispatchedAt(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.GetReady("myrepo")
 	c.Assign(item.ID, "worker-1", "implement")
 
@@ -3098,7 +2875,7 @@ func TestRestart_ClearsStageDispatchedAt(t *testing.T) {
 
 func TestRestart_ClearsLastHeartbeatAt(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	if err := c.Heartbeat(item.ID); err != nil {
 		t.Fatal(err)
@@ -3271,7 +3048,7 @@ func TestClient_DeleteFilterSession_NotFound(t *testing.T) {
 
 func TestRecordEvent_ValidType(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Event test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Event test", "", 1)
 
 	err := c.RecordEvent(item.ID, EventPass, `{"cataractae":"implementer","notes":"all good"}`)
 	if err != nil {
@@ -3296,7 +3073,7 @@ func TestRecordEvent_ValidType(t *testing.T) {
 
 func TestRecordEvent_UnknownType_ReturnsError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Event test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Event test", "", 1)
 
 	err := c.RecordEvent(item.ID, "invalid_type", "{}")
 	if err == nil {
@@ -3309,7 +3086,7 @@ func TestRecordEvent_UnknownType_ReturnsError(t *testing.T) {
 
 func TestRecordEvent_InvalidJSON_ReturnsError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Event test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Event test", "", 1)
 
 	err := c.RecordEvent(item.ID, EventPass, "not json")
 	if err == nil {
@@ -3322,7 +3099,7 @@ func TestRecordEvent_InvalidJSON_ReturnsError(t *testing.T) {
 
 func TestRecordEvent_EmptyPayload(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Event test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Event test", "", 1)
 
 	err := c.RecordEvent(item.ID, EventDelivered, "{}")
 	if err != nil {
@@ -3332,7 +3109,7 @@ func TestRecordEvent_EmptyPayload(t *testing.T) {
 
 func TestAdd_RecordsCreateEvent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Create event test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Create event test", "", 1)
 
 	changes, err := c.GetDropletChanges(item.ID, 100)
 	if err != nil {
@@ -3352,7 +3129,7 @@ func TestAdd_RecordsCreateEvent(t *testing.T) {
 
 func TestGetReady_RecordsDispatchEvent(t *testing.T) {
 	c := testClient(t)
-	c.Add("myrepo", "Dispatch test", "", 1, 2)
+	c.Add("myrepo", "Dispatch test", "", 1)
 
 	_, err := c.GetReady("myrepo")
 	if err != nil {
@@ -3381,7 +3158,7 @@ func TestGetReady_RecordsDispatchEvent(t *testing.T) {
 
 func TestGetReadyForAqueduct_RecordsDispatchEvent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Dispatch aqueduct test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Dispatch aqueduct test", "", 1)
 
 	_, err := c.GetReadyForAqueduct("myrepo", "my-aqueduct")
 	if err != nil {
@@ -3406,7 +3183,7 @@ func TestGetReadyForAqueduct_RecordsDispatchEvent(t *testing.T) {
 
 func TestCloseItem_RecordsDeliveredEvent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Delivered event test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Delivered event test", "", 1)
 
 	if err := c.CloseItem(item.ID); err != nil {
 		t.Fatal(err)
@@ -3430,7 +3207,7 @@ func TestCloseItem_RecordsDeliveredEvent(t *testing.T) {
 
 func TestPool_RecordsPoolEventWithJSONPayload(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Pool event test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Pool event test", "", 1)
 
 	if err := c.Pool(item.ID, "stuck on flaky test"); err != nil {
 		t.Fatal(err)
@@ -3454,7 +3231,7 @@ func TestPool_RecordsPoolEventWithJSONPayload(t *testing.T) {
 
 func TestCancel_RecordsCancelEventWithJSONPayload(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Cancel event test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Cancel event test", "", 1)
 
 	reason := "superseded by new approach"
 	if err := c.Cancel(item.ID, reason); err != nil {
@@ -3479,7 +3256,7 @@ func TestCancel_RecordsCancelEventWithJSONPayload(t *testing.T) {
 
 func TestCancel_NoLongerWritesSchedulerNote(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Cancel no note test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Cancel no note test", "", 1)
 
 	if err := c.Cancel(item.ID, "reason"); err != nil {
 		t.Fatal(err)
@@ -3498,7 +3275,7 @@ func TestCancel_NoLongerWritesSchedulerNote(t *testing.T) {
 
 func TestRestart_NoLongerWritesSchedulerNote(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Restart no note test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Restart no note test", "", 1)
 
 	_, err := c.Restart(item.ID, "implement")
 	if err != nil {
@@ -3518,7 +3295,7 @@ func TestRestart_NoLongerWritesSchedulerNote(t *testing.T) {
 
 func TestEditDroplet_RecordsEditEvent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Edit event test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Edit event test", "", 1)
 
 	err := c.EditDroplet(item.ID, EditDropletFields{Title: ptr("New Title"), Priority: ptr(3)})
 	if err != nil {
@@ -3548,7 +3325,7 @@ func TestValidEventTypes_ContainsAllConstants(t *testing.T) {
 		EventPool, EventCancel,
 		EventExitNoOutcome, EventStall, EventRecovery,
 		EventCircuitBreaker, EventLoopRecovery,
-		EventAutoPromote, EventNoRoute,
+		EventAutoPromote, EventNoRoute, EventHeartbeat,
 	}
 	for _, e := range expected {
 		if !ValidEventTypes[e] {
@@ -3562,7 +3339,7 @@ func TestValidEventTypes_ContainsAllConstants(t *testing.T) {
 
 func TestPass_SetsOutcomeAndRecordsEvent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Pass test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Pass test", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 
 	if err := c.Pass(item.ID, "implementer", "all good"); err != nil {
@@ -3589,7 +3366,7 @@ func TestPass_SetsOutcomeAndRecordsEvent(t *testing.T) {
 
 func TestPass_WhenTerminal_ReturnsError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Pass terminal test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Pass terminal test", "", 1)
 	c.CloseItem(item.ID)
 
 	err := c.Pass(item.ID, "reviewer", "")
@@ -3610,7 +3387,7 @@ func TestPass_NotFound(t *testing.T) {
 
 func TestRecirculate_InProgress_SetsOutcomeAndRecordsEvent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Recirculate test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Recirculate test", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 
 	if err := c.Recirculate(item.ID, "reviewer", "implement", "needs fixes"); err != nil {
@@ -3637,7 +3414,7 @@ func TestRecirculate_InProgress_SetsOutcomeAndRecordsEvent(t *testing.T) {
 
 func TestRecirculate_NonInProgress_AssignsAndRecordsEvent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Recirculate non-in-progress", "", 1, 2)
+	item, _ := c.Add("myrepo", "Recirculate non-in-progress", "", 1)
 	c.Pool(item.ID, "stuck")
 
 	if err := c.Recirculate(item.ID, "reviewer", "implement", ""); err != nil {
@@ -3655,7 +3432,7 @@ func TestRecirculate_NonInProgress_AssignsAndRecordsEvent(t *testing.T) {
 
 func TestRecirculate_NonInProgress_DefaultsToCurrentCataractae(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Recirculate default target", "", 1, 2)
+	item, _ := c.Add("myrepo", "Recirculate default target", "", 1)
 	c.Pool(item.ID, "stuck")
 	c.SetCataractae(item.ID, "review")
 
@@ -3671,7 +3448,7 @@ func TestRecirculate_NonInProgress_DefaultsToCurrentCataractae(t *testing.T) {
 
 func TestRecirculate_WhenTerminal_ReturnsError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Recirculate terminal test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Recirculate terminal test", "", 1)
 	c.Cancel(item.ID, "not needed")
 
 	if err := c.Recirculate(item.ID, "reviewer", "", ""); err == nil {
@@ -3688,7 +3465,7 @@ func TestRecirculate_NotFound(t *testing.T) {
 
 func TestApprove_SetsDeliveryStepAndRecordsEvent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Approve test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Approve test", "", 1)
 	c.SetCataractae(item.ID, "human")
 
 	if err := c.Approve(item.ID, "manual"); err != nil {
@@ -3718,7 +3495,7 @@ func TestApprove_SetsDeliveryStepAndRecordsEvent(t *testing.T) {
 
 func TestApprove_NotHumanGated(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Approve not human test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Approve not human test", "", 1)
 
 	if err := c.Approve(item.ID, "manual"); err == nil {
 		t.Fatal("expected error for non-human gated droplet")
@@ -3727,7 +3504,7 @@ func TestApprove_NotHumanGated(t *testing.T) {
 
 func TestApprove_WhenTerminal_ReturnsError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Approve terminal test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Approve terminal test", "", 1)
 	c.SetCataractae(item.ID, "human")
 	c.Cancel(item.ID, "not needed")
 
@@ -3745,7 +3522,7 @@ func TestApprove_NotFound(t *testing.T) {
 
 func TestPass_DeliveredGuardInWhere(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Pass guard test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Pass guard test", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 
 	c.CloseItem(item.ID)
@@ -3758,7 +3535,7 @@ func TestPass_DeliveredGuardInWhere(t *testing.T) {
 
 func TestRecirculate_CancelledGuardInWhere(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Recirculate guard test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Recirculate guard test", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 
 	c.Cancel(item.ID, "obsolete")
@@ -3771,7 +3548,7 @@ func TestRecirculate_CancelledGuardInWhere(t *testing.T) {
 
 func TestApprove_CataractaeGuardInWhere(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Approve guard test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Approve guard test", "", 1)
 	c.SetCataractae(item.ID, "human")
 
 	c.SetCataractae(item.ID, "delivery")
@@ -3784,7 +3561,7 @@ func TestApprove_CataractaeGuardInWhere(t *testing.T) {
 
 func TestPool_Delivered_ReturnsTerminalError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Pool delivered guard test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Pool delivered guard test", "", 1)
 	c.CloseItem(item.ID)
 
 	err := c.Pool(item.ID, "should fail")
@@ -3803,7 +3580,7 @@ func TestPool_Delivered_ReturnsTerminalError(t *testing.T) {
 
 func TestPool_Cancelled_ReturnsTerminalError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Pool cancelled guard test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Pool cancelled guard test", "", 1)
 	c.Cancel(item.ID, "no longer needed")
 
 	err := c.Pool(item.ID, "should fail")
@@ -3822,7 +3599,7 @@ func TestPool_Cancelled_ReturnsTerminalError(t *testing.T) {
 
 func TestCloseItem_Cancelled_ReturnsTerminalError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Close cancelled guard test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Close cancelled guard test", "", 1)
 	c.Cancel(item.ID, "superseded")
 
 	err := c.CloseItem(item.ID)
@@ -3841,7 +3618,7 @@ func TestCloseItem_Cancelled_ReturnsTerminalError(t *testing.T) {
 
 func TestCloseItem_Delivered_ReturnsTerminalError(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Close delivered guard test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Close delivered guard test", "", 1)
 	c.CloseItem(item.ID)
 
 	err := c.CloseItem(item.ID)
@@ -3855,7 +3632,7 @@ func TestCloseItem_Delivered_ReturnsTerminalError(t *testing.T) {
 
 func TestPool_DeliveredGuardInWhere(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Pool guard where test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Pool guard where test", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 
 	c.CloseItem(item.ID)
@@ -3868,7 +3645,7 @@ func TestPool_DeliveredGuardInWhere(t *testing.T) {
 
 func TestCloseItem_CancelledGuardInWhere(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Close guard where test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Close guard where test", "", 1)
 	c.UpdateStatus(item.ID, "in_progress")
 
 	c.Cancel(item.ID, "obsolete")
@@ -3881,7 +3658,7 @@ func TestCloseItem_CancelledGuardInWhere(t *testing.T) {
 
 func TestCountEventsByType_CountsMatchingEvents(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Count test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Count test", "", 1)
 	payload := `{"session":"s1","worker":"w1","cataractae":"implement"}`
 	c.RecordEvent(item.ID, EventExitNoOutcome, payload)
 	c.RecordEvent(item.ID, EventExitNoOutcome, payload)
@@ -3899,7 +3676,7 @@ func TestCountEventsByType_CountsMatchingEvents(t *testing.T) {
 
 func TestCountEventsByType_RespectsCutoff(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Cutoff test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Cutoff test", "", 1)
 
 	c.RecordEvent(item.ID, EventExitNoOutcome, `{}`)
 	time.Sleep(10 * time.Millisecond)
@@ -3918,7 +3695,7 @@ func TestCountEventsByType_RespectsCutoff(t *testing.T) {
 
 func TestCountEventsByType_ZeroWhenNone(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Zero test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Zero test", "", 1)
 
 	count, err := c.CountEventsByType(item.ID, EventExitNoOutcome, time.Time{})
 	if err != nil {
@@ -3931,7 +3708,7 @@ func TestCountEventsByType_ZeroWhenNone(t *testing.T) {
 
 func TestCountEventsByType_ZeroWhenWrongType(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Wrong type test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Wrong type test", "", 1)
 	c.RecordEvent(item.ID, EventStall, `{"cataractae":"implement"}`)
 
 	count, err := c.CountEventsByType(item.ID, EventExitNoOutcome, time.Time{})
@@ -3945,7 +3722,7 @@ func TestCountEventsByType_ZeroWhenWrongType(t *testing.T) {
 
 func TestMigration018_SchedulerNotesToEvents(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Migration test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Migration test", "", 1)
 
 	notes := []struct {
 		cataractaeName string
@@ -4059,7 +3836,7 @@ func TestMigration018_SchedulerNotesToEvents(t *testing.T) {
 
 func TestMigration018_Idempotent(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Idempotent test", "", 1, 2)
+	item, _ := c.Add("myrepo", "Idempotent test", "", 1)
 
 	ts := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	c.db.Exec(`INSERT INTO cataractae_notes (droplet_id, cataractae_name, content, created_at) VALUES (?, ?, ?, ?)`,

--- a/internal/cistern/event_types.go
+++ b/internal/cistern/event_types.go
@@ -23,10 +23,11 @@ const (
 	EventCircuitBreaker = "circuit_breaker"
 	EventLoopRecovery   = "loop_recovery"
 	EventAutoPromote    = "auto_promote"
+	EventHeartbeat      = "heartbeat"
 	EventNoRoute        = "no_route"
 )
 
-var ValidEventTypes = map[string]bool{
+	var ValidEventTypes = map[string]bool{
 	EventCreate:         true,
 	EventDispatch:       true,
 	EventPass:           true,
@@ -44,6 +45,7 @@ var ValidEventTypes = map[string]bool{
 	EventLoopRecovery:   true,
 	EventAutoPromote:    true,
 	EventNoRoute:        true,
+	EventHeartbeat:      true,
 }
 
 func parsePayload(payload string) map[string]any {
@@ -98,6 +100,8 @@ func DisplayInfo(eventType, payload string) (eventLabel, detail string) {
 		return "auto_promote", displayInfoAutoPromote(m)
 	case EventNoRoute:
 		return "no_route", displayInfoCataractae(m)
+	case EventHeartbeat:
+		return "heartbeat", displayInfoHeartbeat(m)
 	default:
 		return eventType, payload
 	}
@@ -116,9 +120,6 @@ func displayInfoCreate(m map[string]any) string {
 	}
 	if priority, ok := m["priority"]; ok {
 		parts = append(parts, fmt.Sprintf("priority: %v", priority))
-	}
-	if complexity, ok := m["complexity"]; ok {
-		parts = append(parts, fmt.Sprintf("complexity: %v", complexity))
 	}
 	return strings.Join(parts, ", ")
 }
@@ -276,6 +277,23 @@ func displayInfoAutoPromote(m map[string]any) string {
 	}
 	if routedTo, ok := m["routed_to"]; ok && routedTo != "" {
 		parts = append(parts, fmt.Sprintf("routed to: %v", routedTo))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func displayInfoHeartbeat(m map[string]any) string {
+	if m == nil {
+		return "heartbeat recorded"
+	}
+	var parts []string
+	if cat, ok := m["cataractae"]; ok && cat != "" {
+		parts = append(parts, fmt.Sprintf("step: %v", cat))
+	}
+	if elapsed, ok := m["elapsed"]; ok && elapsed != "" {
+		parts = append(parts, fmt.Sprintf("elapsed: %v", elapsed))
+	}
+	if len(parts) == 0 {
+		return "heartbeat recorded"
 	}
 	return strings.Join(parts, ", ")
 }

--- a/internal/cistern/issues_test.go
+++ b/internal/cistern/issues_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAddIssue_And_ListIssues(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	iss, err := c.AddIssue(item.ID, "reviewer", "missing error handling in foo()")
 	if err != nil {
@@ -40,7 +40,7 @@ func TestAddIssue_And_ListIssues(t *testing.T) {
 
 func TestListIssues_OpenOnly(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	iss1, _ := c.AddIssue(item.ID, "reviewer", "issue one")
 	iss2, _ := c.AddIssue(item.ID, "reviewer", "issue two")
@@ -74,7 +74,7 @@ func TestListIssues_OpenOnly(t *testing.T) {
 
 func TestResolveIssue(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "some finding")
 
 	if err := c.ResolveIssue(iss.ID, "grep output shows it's fixed"); err != nil {
@@ -95,7 +95,7 @@ func TestResolveIssue(t *testing.T) {
 
 func TestRejectIssue(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	iss, _ := c.AddIssue(item.ID, "reviewer", "some finding")
 
 	if err := c.RejectIssue(iss.ID, "still present: grep shows it"); err != nil {
@@ -129,7 +129,7 @@ func TestRejectIssue_NotFound(t *testing.T) {
 
 func TestCountOpenIssues(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	n, err := c.CountOpenIssues(item.ID)
 	if err != nil {
@@ -157,7 +157,7 @@ func TestCountOpenIssues(t *testing.T) {
 
 func TestListIssues_FlaggedByFilter(t *testing.T) {
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 
 	// Given: issues from two different cataractae.
 	c.AddIssue(item.ID, "reviewer", "reviewer issue one")
@@ -206,7 +206,7 @@ func TestListIssues_FlaggedByFilter(t *testing.T) {
 func TestSetOutcome_BlockedByOpenIssues(t *testing.T) {
 	// Verify CountOpenIssues returns correct data so the CLI can enforce the block.
 	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1, 3)
+	item, _ := c.Add("myrepo", "Task", "", 1)
 	c.AddIssue(item.ID, "reviewer", "unfixed issue")
 
 	n, err := c.CountOpenIssues(item.ID)

--- a/internal/cistern/migrate_test.go
+++ b/internal/cistern/migrate_test.go
@@ -108,7 +108,7 @@ func TestEndToEndSchemaVerification(t *testing.T) {
 	defer c.Close()
 
 	expectedColumns := []string{
-		"id", "repo", "title", "description", "priority", "complexity",
+		"id", "repo", "title", "description", "priority",
 		"status", "assignee", "current_cataractae", "outcome",
 		"assigned_aqueduct", "last_reviewed_commit", "external_ref",
 		"last_heartbeat_at", "created_at", "updated_at", "stage_dispatched_at",
@@ -154,8 +154,8 @@ func TestEndToEndSchemaVerification(t *testing.T) {
 
 	var migrationCount int
 	c.db.QueryRow(`SELECT COUNT(*) FROM "_schema_migrations"`).Scan(&migrationCount)
-	if migrationCount != 18 {
-		t.Errorf("expected 18 migration records, got %d", migrationCount)
+	if migrationCount != 19 {
+		t.Errorf("expected 19 migration records, got %d", migrationCount)
 	}
 }
 

--- a/internal/cistern/migrations/019_drop_complexity.sql
+++ b/internal/cistern/migrations/019_drop_complexity.sql
@@ -1,0 +1,40 @@
+-- Migration 016: Remove the complexity column from droplets.
+-- The complexity system (standard/full/critical) has been removed.
+-- All droplets now flow through all pipeline stages unconditionally.
+-- SQLite doesn't support DROP COLUMN before 3.35.0, so we recreate the table.
+
+-- Create new table without complexity column.
+CREATE TABLE IF NOT EXISTS "droplets_new" (
+    "id" TEXT PRIMARY KEY,
+    "repo" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT DEFAULT '',
+    "priority" INTEGER DEFAULT 2,
+    "status" TEXT DEFAULT 'open',
+    "assignee" TEXT DEFAULT '',
+    "current_cataractae" TEXT DEFAULT '',
+    "outcome" TEXT DEFAULT NULL,
+    "assigned_aqueduct" TEXT DEFAULT '',
+    "last_reviewed_commit" TEXT DEFAULT NULL,
+    "external_ref" TEXT DEFAULT NULL,
+    "last_heartbeat_at" DATETIME DEFAULT NULL,
+    "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "stage_dispatched_at" DATETIME DEFAULT NULL
+);
+
+-- Copy data (omit complexity column).
+INSERT OR IGNORE INTO "droplets_new" (
+    id, repo, title, description, priority, status, assignee,
+    current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit,
+    external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+)
+SELECT
+    id, repo, title, description, priority, status, assignee,
+    current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit,
+    external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+FROM "droplets";
+
+-- Drop old table and rename.
+DROP TABLE "droplets";
+ALTER TABLE "droplets_new" RENAME TO "droplets";

--- a/internal/cistern/schema.sql
+++ b/internal/cistern/schema.sql
@@ -4,7 +4,6 @@ CREATE TABLE IF NOT EXISTS "droplets" (
     "title" TEXT NOT NULL,
     "description" TEXT DEFAULT '',
     "priority" INTEGER DEFAULT 2,
-    "complexity" INTEGER DEFAULT 2,
     "status" TEXT DEFAULT 'open',
     "assignee" TEXT DEFAULT '',
     "current_cataractae" TEXT DEFAULT '',

--- a/internal/delivery/handler.go
+++ b/internal/delivery/handler.go
@@ -10,7 +10,7 @@ import (
 
 // DropletAdder is the interface for persisting a new droplet.
 type DropletAdder interface {
-	Add(title, repo, description, externalRef string, priority, complexity int) (string, error)
+	Add(title, repo, description, externalRef string, priority int) (string, error)
 }
 
 // Handler is an http.Handler for the droplet ingestion endpoint (POST /droplets).
@@ -57,7 +57,6 @@ type addRequest struct {
 	Description string `json:"description,omitempty"`
 	ExternalRef string `json:"external_ref,omitempty"`
 	Priority    int    `json:"priority,omitempty"`
-	Complexity  int    `json:"complexity,omitempty"`
 }
 
 type addResponse struct {
@@ -104,7 +103,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id, err := h.adder.Add(req.Title, req.Repo, req.Description, req.ExternalRef, req.Priority, req.Complexity)
+	id, err := h.adder.Add(req.Title, req.Repo, req.Description, req.ExternalRef, req.Priority)
 	if err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return

--- a/internal/delivery/handler_test.go
+++ b/internal/delivery/handler_test.go
@@ -16,7 +16,7 @@ type fakeAdder struct {
 	err error
 }
 
-func (f *fakeAdder) Add(title, repo, description, externalRef string, priority, complexity int) (string, error) {
+func (f *fakeAdder) Add(title, repo, description, externalRef string, priority int) (string, error) {
 	return f.id, f.err
 }
 
@@ -361,7 +361,7 @@ type captureAdder struct {
 	gotExternalRef string
 }
 
-func (a *captureAdder) Add(title, repo, description, externalRef string, priority, complexity int) (string, error) {
+func (a *captureAdder) Add(title, repo, description, externalRef string, priority int) (string, error) {
 	a.gotExternalRef = externalRef
 	return "ct-captured", nil
 }

--- a/internal/gates/automated.go
+++ b/internal/gates/automated.go
@@ -11,6 +11,7 @@ package gates
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -85,9 +86,14 @@ func New() *Executor {
 }
 
 // DefaultExec runs a command via os/exec.
+// It sets GIT_EDITOR and GIT_SEQUENCE_EDITOR to prevent git from opening
+// an interactive editor in non-interactive agent contexts.
 func DefaultExec(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
+	if name == "git" {
+		cmd.Env = append(os.Environ(), "GIT_EDITOR=true", "GIT_SEQUENCE_EDITOR=true")
+	}
 	return cmd.CombinedOutput()
 }
 

--- a/internal/testutil/fakeagent/main.go
+++ b/internal/testutil/fakeagent/main.go
@@ -46,12 +46,12 @@ import (
 // hardcodedProposals is the raw text output for FAKEAGENT_MODE=raw_fallback,
 // exercising the non-JSON fallback path in callFilterAgent where stdout
 // becomes filterSessionResult.Text directly.
-const hardcodedProposals = `[{"title":"mock proposal","description":"test description","complexity":"standard","depends_on":[]}]`
+const hardcodedProposals = `[{"title":"mock proposal","description":"test description","depends_on":[]}]`
 
 // hardcodedJSONEnvelope is returned when --output-format is present in
 // non-interactive mode. The result field becomes filterSessionResult.Text;
 // session_id is a stable test value used to verify session_id extraction.
-const hardcodedJSONEnvelope = `{"type":"result","subtype":"success","is_error":false,"result":"[{\"title\":\"mock proposal\",\"description\":\"test description\",\"complexity\":\"standard\",\"depends_on\":[]}]","session_id":"test-session-id-abc123"}`
+const hardcodedJSONEnvelope = `{"type":"result","subtype":"success","is_error":false,"result":"[{\"title\":\"mock proposal\",\"description\":\"test description\",\"depends_on\":[]}]","session_id":"test-session-id-abc123"}`
 
 // hardcodedErrorEnvelope is returned in FAKEAGENT_MODE=error_envelope.
 // is_error is true so callFilterAgent returns an error for the envelope.IsError path.

--- a/internal/testutil/mockllm/mockllm.go
+++ b/internal/testutil/mockllm/mockllm.go
@@ -33,7 +33,7 @@ import (
 
 // HardcodedProposalsJSON is the raw JSON array that every mock response embeds.
 // Tests can unmarshal this to verify the full round-trip.
-const HardcodedProposalsJSON = `[{"title":"mock proposal","description":"test description","complexity":"standard","depends_on":[]}]`
+const HardcodedProposalsJSON = `[{"title":"mock proposal","description":"test description","depends_on":[]}]`
 
 // Request is a snapshot of an HTTP request received by the mock server.
 type Request struct {


### PR DESCRIPTION
## Summary

- Removes the complexity system (standard/full/critical) from Cistern. It was effectively dead code — only a `require_human: true` gate before delivery for critical droplets existed, and it was never enabled in the config.
- All droplets now unconditionally flow through the full 7-stage pipeline: **architect → implement → review → qa → security → docs → delivery**.
- This also ensures the architect cataractae (added in #455) is properly configured in all aqueducts — the synced `~/.cistern/aqueduct/aqueduct.yaml` was missing it.

### Key changes:

1. **Removed `complexity` block from `aqueduct.yaml`** — no more standard/full/critical tier configuration
2. **Removed `ComplexityConfig`, `ComplexityLevel`, `RequireHumanForLevel`** from `aqueduct/types.go`
3. **Removed human-gate routing** from scheduler — `isTerminal("human")` and `handleTerminal("human")` no longer exist
4. **Removed `ct droplet approve`** command (was for human-gated delivery)
5. **Removed `--complexity`/`-x` flags** from `ct droplet add` and `ct droplet edit`
6. **Removed `Droplet.Complexity`** from the DB schema, client, and all queries
7. **Added migration `016_drop_complexity.sql`** to drop the column
8. **Removed complexity display** from list, show, TUI, dashboard, CSV, and inspect output
9. **Updated all 46 affected files** across tests, CLI, scheduler, and API

### Pipeline is now:

```
architect → implement → review → qa → security → docs → delivery
```

All droplets, all the time. No skipping, no human gates, no levels.