### PR TITLE
Web UI: Infrastructure pages (Castellarius, Doctor, Logs, Repos/Skills)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,630 @@
+# Architecture: Web UI — Infrastructure Pages
+
+## Overview
+
+Four new operator-facing pages (Castellarius, Doctor, Logs, Repos/Skills) plus
+a shared component library and a Go SSE log-streaming handler.
+
+---
+
+## 1. TypeScript Types — `web/src/api/types.ts` (additions)
+
+```ts
+// ── Castellarius ──
+
+export interface AqueductStatus {
+  name: string;
+  status: 'idle' | 'flowing';
+  droplet_id: string | null;
+  droplet_title: string | null;
+  current_step: string | null;
+  elapsed: number;           // nanoseconds
+}
+
+export interface CastellariusStatus {
+  running: boolean;
+  pid: number | null;
+  uptime_seconds: number | null;
+  aqueducts: AqueductStatus[];
+  farm_running: boolean;
+}
+
+// ── Doctor ──
+
+export type DoctorCheckStatus = 'pass' | 'fail' | 'warn';
+
+export interface DoctorCheck {
+  name: string;
+  status: DoctorCheckStatus;
+  message: string;
+  category: string;
+}
+
+export interface DoctorResult {
+  checks: DoctorCheck[];
+  summary: { total: number; passed: number };
+  timestamp: string;
+}
+
+// ── Logs ──
+
+export interface LogEntry {
+  line: number;
+  level: 'INFO' | 'WARN' | 'ERROR' | 'DEBUG' | '';
+  text: string;
+  raw: string;
+}
+
+export interface LogSourceInfo {
+  name: string;
+  path: string;
+  size_bytes: number;
+  last_modified: string;
+}
+
+// ── Repos & Skills ──
+
+export interface RepoInfo {
+  name: string;
+  prefix: string;
+  url: string;
+  aqueduct_config: string | null;
+  aqueducts: AqueductBrief[];
+}
+
+export interface AqueductBrief {
+  name: string;
+  steps: string[];
+}
+
+export interface SkillInfo {
+  name: string;
+  source_url: string;
+  installed_at: string;
+}
+```
+
+---
+
+## 2. API Client Modules
+
+One file per domain, all under `web/src/api/`. The pattern follows
+`useAuth.ts`: each module uses `getAuthHeaders()` for authenticated fetch
+and exports async functions + a React hook.
+
+### `web/src/api/castellarius.ts`
+
+```ts
+import { getAuthHeaders } from '../hooks/useAuth';
+import type { CastellariusStatus } from './types';
+
+export async function fetchCastellariusStatus(): Promise<CastellariusStatus> {
+  const resp = await fetch('/api/castellarius/status', { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`castellarius status: ${resp.status}`);
+  return resp.json();
+}
+
+export async function castellariusAction(action: 'start' | 'stop' | 'restart'): Promise<void> {
+  // restart requires confirmation at the UI level, not here
+  const resp = await fetch(`/api/castellarius/${action}`, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({ message: resp.statusText }));
+    throw new Error(body.message || `castellarius ${action} failed: ${resp.status}`);
+  }
+}
+
+export function useCastellariusStatus(intervalMs = 5000) {
+  // Returns { status, loading, error, refresh }
+  // Auto-fetches on mount and polls at intervalMs.
+  // Castellarius page disables auto-poll when unmounted.
+}
+```
+
+### `web/src/api/doctor.ts`
+
+```ts
+import { getAuthHeaders } from '../hooks/useAuth';
+import type { DoctorResult } from './types';
+
+export async function fetchDoctor(fix = false): Promise<DoctorResult> {
+  const url = fix ? '/api/doctor?fix=true' : '/api/doctor';
+  const resp = await fetch(url, { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`doctor: ${resp.status}`);
+  return resp.json();
+}
+
+export function useDoctor() {
+  // Returns { result, loading, error, rerun, fix }
+  // No auto-poll — manual refresh only.
+}
+```
+
+### `web/src/api/logs.ts`
+
+```ts
+import { getAuthParams, getAuthHeaders } from '../hooks/useAuth';
+import type { LogSourceInfo } from './types';
+
+export async function fetchLogHistory(
+  lines = 500,
+  source = 'castellarius'
+): Promise<string[]> {
+  const auth = getAuthParams();
+  const url = auth
+    ? `/api/logs?lines=${lines}&source=${source}&${auth}`
+    : `/api/logs?lines=${lines}&source=${source}`;
+  const resp = await fetch(url, { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`logs: ${resp.status}`);
+  return resp.json();
+}
+
+export function createLogEventSource(
+  source: string,
+  onLine: (line: string) => void,
+  onError: (err: Error) => void,
+): EventSource {
+  const auth = getAuthParams();
+  const url = auth
+    ? `/api/logs/events?source=${source}&${auth}`
+    : `/api/logs/events?source=${source}`;
+  const es = new EventSource(url);
+  es.onmessage = (e) => onLine(e.data);
+  es.onerror = () => { onError(new Error('log stream error')); es.close(); };
+  return es;
+}
+
+export async function fetchLogSources(): Promise<LogSourceInfo[]> {
+  const resp = await fetch('/api/logs/sources', { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`log sources: ${resp.status}`);
+  return resp.json();
+}
+```
+
+### `web/src/api/repos.ts`
+
+```ts
+import { getAuthHeaders } from '../hooks/useAuth';
+import type { RepoInfo, SkillInfo } from './types';
+
+export async function fetchRepos(): Promise<RepoInfo[]> {
+  const resp = await fetch('/api/repos', { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`repos: ${resp.status}`);
+  return resp.json();
+}
+
+export async function fetchSkills(): Promise<SkillInfo[]> {
+  const resp = await fetch('/api/skills', { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`skills: ${resp.status}`);
+  return resp.json();
+}
+```
+
+---
+
+## 3. Shared Components
+
+All under `web/src/components/`. Export from `index.ts`.
+
+### `StatusIndicator.tsx`
+
+A reusable running/stopped/error indicator.
+
+```
+Props:
+  status: 'running' | 'stopped' | 'error'
+  label: string
+  size?: 'sm' | 'lg'   (default 'sm')
+
+Rendering:
+  - running → green circle with pulse-glow CSS animation, green label
+  - stopped → muted/gray circle, muted label
+  - error   → red circle, red label
+  - lg variant → bigger circle (w-4 h-4 vs w-2 h-2), larger text
+
+Uses existing tailwind colors: cistern-green, cistern-muted, cistern-red.
+Uses existing pulse-glow CSS class from index.css.
+```
+
+### `ActionButton.tsx`
+
+Consistent styled button for control actions with loading/error state.
+
+```
+Props:
+  label: string
+  onClick: () => Promise<void>
+  variant?: 'primary' | 'danger' | 'default'   (default 'default')
+  disabled?: boolean
+  icon?: ReactNode                (optional inline SVG)
+  confirm?: string                (if set, click shows confirm dialog before executing)
+
+Rendering:
+  - primary  → bg-cistern-accent text-cistern-bg
+  - danger   → bg-cistern-red text-cistern-bg
+  - default  → border border-cistern-border text-cistern-fg hover:bg-cistern-border/30
+  - disabled → opacity-50 cursor-not-allowed
+  - loading  → shows spinner SVG icon, onClick disabled
+  - confirm  → window.confirm(confirm) before executing onClick
+  - All variants: font-mono text-sm px-3 py-1.5 rounded-md transition-colors
+```
+
+### `LogViewer.tsx`
+
+Terminal-style log display component.
+
+```
+Props:
+  entries: LogEntry[]
+  autoScroll?: boolean               (default true)
+  onAutoScrollChange?: (v: boolean)  // callback when user scrolls up
+  maxHeight?: string                  (default '100%')
+  searchQuery?: string                // highlight matches
+
+Rendering:
+  - Monospace font (font-mono)
+  - Dark theme: bg-cistern-bg text-cistern-fg
+  - Line numbers in gutter: text-cistern-muted text-right pr-2 select-none
+  - Log level color coding:
+      INFO  → text-cyan-400
+      WARN  → text-cistern-yellow
+      ERROR → text-cistern-red
+      DEBUG → text-cistern-muted/50
+  - Search: filter entries whose raw text includes query (case-insensitive).
+    Highlight matching substring with bg-cistern-accent/30.
+  - Auto-scroll: when true, useEffect scrolls container to bottom on every
+    new entry. When user scrolls up (onScroll handler detects scrollTop < 
+    scrollHeight - clientHeight - 40), disable auto-scroll and call 
+    onAutoScrollChange(false).
+  - Container uses overflow-y-auto with the overflow-anchor CSS property
+    for smooth bottom-anchoring.
+```
+
+### `HealthCheckCard.tsx`
+
+Displays a single doctor check result.
+
+```
+Props:
+  check: DoctorCheck
+
+Rendering:
+  - Card: bg-cistern-surface border border-cistern-border rounded-lg p-3
+  - Left: status icon (green ✓ / red ✕ / yellow ⚠)
+  - Right: check name (font-mono text-sm text-cistern-fg)
+  - Below: result message (text-xs text-cistern-muted)
+  - If status=fail: red left border accent (border-l-2 border-cistern-red)
+  - If status=warn: yellow left border accent (border-l-2 border-cistern-yellow)
+```
+
+---
+
+## 4. Page Components
+
+### 4a. `CastellariusPage.tsx` — `/app/castellarius`
+
+Layout (single scrollable column):
+
+```
+┌──────────────────────────────────────┐
+│ Status Indicator                     │
+│  [running/stopped] Castellarius      │
+│  PID: 12345 · Uptime: 2h15m         │
+│                                      │
+│ [Start] [Stop] [Restart]             │
+└──────────────────────────────────────┘
+
+┌──────────────────────────────────────┐
+│ Aqueducts                            │
+│ ┌────────────────────────────────┐   │
+│ │ name       status   current    │   │
+│ │ main       flowing  ci-abc1   │   │
+│ │            step: implementer   │   │
+│ │            elapsed: 12:45      │   │
+│ └────────────────────────────────┘   │
+│ ┌────────────────────────────────┐   │
+│ │ docs        idle               │   │
+│ └────────────────────────────────┘   │
+└──────────────────────────────────────┘
+
+Farm Status: [running/stopped]
+```
+
+Hook: `useCastellariusStatus(5000)` — polls every 5 seconds.
+
+Control buttons:
+- Start: enabled only when `!status.running`, variant='primary'
+- Stop: enabled only when `status.running`, variant='danger'
+- Restart: enabled only when `status.running`, variant='danger', confirm="Restart Castellarius? Active droplets will be interrupted."
+
+Each button click → `castellariusAction()` → spinner during execution → toast on success/failure. Toast implemented as a simple `<div>` with auto-dismiss (3s), styled `bg-cistern-surface border border-cistern-border rounded-lg p-3 fixed bottom-4 right-4`.
+
+Each aqueduct row:
+- Uses existing `AqueductArch` component (mini mode) for active aqueducts
+- Clicking an aqueduct name links to the dashboard (`/app/`) with the aqueduct highlighted
+
+### 4b. `DoctorPage.tsx` — `/app/doctor`
+
+Layout:
+
+```
+┌──────────────────────────────────────┐
+│ Health Checks     [Re-run] [Fix]     │
+│ Summary: 4/5 passed                 │
+│ Last checked: 2025-01-15 14:30 UTC   │
+└──────────────────────────────────────┘
+
+[Category cards grouped by check.category]
+┌──────────────────────────────────────┐
+│ Daemon                               │
+│ ✓ Daemon running    Running (pid 123)│
+│ ✕ Config valid      Missing field X  │
+└──────────────────────────────────────┘
+```
+
+Hook: `useDoctor()` — fetches on mount, no auto-poll.
+Actions: Re-run → `fetchDoctor()`, Fix → `fetchDoctor(true)`.
+
+Summary card at top:
+- `text-cistern-green` if all pass
+- `text-cistern-yellow` if any warn
+- `text-cistern-red` if any fail
+
+Checks grouped by `check.category`, each category a card containing
+`HealthCheckCard` rows.
+
+### 4c. `LogsPage.tsx` — `/app/logs`
+
+Layout:
+
+```
+┌──────────────────────────────────────┐
+│ Source: [▼ castellarius]  Size: 2.1MB │
+│ Last modified: 2025-01-15 14:30      │
+└──────────────────────────────────────┘
+
+┌──────────────────────────────────────┐
+│ [🔍 Filter] [Auto-scroll ✓] [Clear]  │
+├──────────────────────────────────────┤
+│  1 │ 2025-01-15 14:30:01 INFO  ... │
+│  2 │ 2025-01-15 14:30:02 WARN  ... │
+│  3 │ 2025-01-15 14:30:03 ERROR ... │
+└──────────────────────────────────────┘
+```
+
+Data flow:
+1. On mount: `fetchLogHistory(500, activeSource)` → parse lines into 
+   `LogEntry[]` with line numbers and level extraction.
+2. Open SSE: `createLogEventSource(activeSource, onLine, onError)` 
+   → append new entries, auto-scroll if enabled.
+3. Source selector dropdown: `fetchLogSources()` for metadata (name, size, modified).
+   On change → close current SSE, re-fetch history, open new SSE.
+
+Search/filter: simple input field, filters entries whose `raw` includes the
+query (case-insensitive). The LogViewer component handles highlight.
+
+### 4d. `ReposSkillsPage.tsx` — `/app/repos`
+
+Layout:
+
+```
+## Repositories
+
+┌─────────────────────────────────────────┐
+│ my-app                                  │
+│ Prefix: myapp | URL: github.com/org/... │
+│ Aqueducts:                               │
+│   · main: architect → implementer → ... │
+│   · docs: docs-writer                   │
+└─────────────────────────────────────────┘
+
+## Skills
+
+┌──────────────────────────────────────────┐
+│ Name           Source         Installed   │
+│ cistern-signaling  /skills/...  2025-01-10│
+│ cistern-git        /skills/...  2025-01-10│
+└──────────────────────────────────────────┘
+```
+
+Two sections: Repos (card-based) and Skills (simple table).
+
+Repos: `fetchRepos()` on mount. Each repo rendered as a card with:
+- Name (font-mono font-bold text-cistern-fg)
+- Prefix, URL (linked, opens in new tab)
+- Aqueducts listed with step chain shown inline
+
+Skills: `fetchSkills()` on mount. Rendered as a striped table with columns:
+Name, Source URL, Installed date.
+
+---
+
+## 5. Routing Updates — `web/src/main.tsx`
+
+Replace the 5 placeholder routes with actual page imports:
+
+```tsx
+import { CastellariusPage } from './pages/CastellariusPage';
+import { DoctorPage } from './pages/DoctorPage';
+import { LogsPage } from './pages/LogsPage';
+import { ReposSkillsPage } from './pages/ReposSkillsPage';
+
+// In children array, replace:
+{ path: 'castellarius', element: <CastellariusPage /> },
+{ path: 'doctor', element: <DoctorPage /> },
+{ path: 'logs', element: <LogsPage /> },
+{ path: 'repos', element: <ReposSkillsPage /> },
+```
+
+`PlaceholderPage` stays for `droplets` route.
+
+---
+
+## 6. Component Index Update — `web/src/components/index.ts`
+
+Add exports:
+```ts
+export { StatusIndicator } from './StatusIndicator';
+export { ActionButton } from './ActionButton';
+export { LogViewer } from './LogViewer';
+export { HealthCheckCard } from './HealthCheckCard';
+```
+
+---
+
+## 7. Go Server — Log Streaming Handlers
+
+New handlers in `cmd/ct/dashboard_web.go`, registered in `newDashboardMuxInternalWith`.
+
+### `GET /api/logs`
+
+```go
+func handleGetLogs(cfgPath string) http.HandlerFunc {
+    // Query params: ?lines=500&source=castellarius
+    // Read last N lines from the log file.
+    // Default source: castellarius → ~/.cistern/castellarius.log
+    // Returns JSON array of strings (log lines).
+}
+```
+
+### `GET /api/logs/events` (SSE stream)
+
+```go
+func handleLogEvents(cfgPath string) http.HandlerFunc {
+    // Query params: ?source=castellarius
+    // Follows the same pattern as handleDashboardEvents:
+    //   - SSE headers, flush support check, connection limit
+    //   - Tail the log file using fsnotify or polling (fallback: poll every 500ms)
+    //   - On new data, send each line as 'data: <line>\n\n'
+    //   - Context cancellation for cleanup
+}
+```
+
+### `GET /api/logs/sources`
+
+```go
+func handleGetLogSources(cfgPath string) http.HandlerFunc {
+    // Returns JSON array of LogSourceInfo objects.
+    // Currently just castellarius.log, but extensible.
+    // Each entry: { name, path, size_bytes, last_modified }
+}
+```
+
+### Route registration (add near line 1073)
+
+```go
+// Logs
+mux.HandleFunc("GET /api/logs", handleGetLogs(cfgPath))
+mux.HandleFunc("GET /api/logs/events", handleLogEvents(cfgPath))
+mux.HandleFunc("GET /api/logs/sources", handleGetLogSources(cfgPath))
+```
+
+---
+
+## 8. Castellarius Status Enhancement (Go)
+
+The current `handleCastellariusStatus()` returns only `{ "status": "ok" }`.
+It needs to be enhanced (droplet 1's responsibility) to return the full
+`CastellariusStatus` struct. The frontend is designed against the full
+response shape defined in types.ts. If the backend still returns the stub,
+the page should gracefully degrade (show "Running" as unknown, empty
+aqueducts table).
+
+The frontend should handle both the stub response and the full response:
+
+```ts
+// In useCastellariusStatus:
+const running = status?.running ?? (status?.status === 'ok');
+```
+
+---
+
+## 9. Doctor Handler Enhancement (Go)
+
+The current `handleDoctor()` returns `{ config_ok: true, repos: [...] }`.
+The frontend expects the `DoctorResult` shape with individual check objects
+grouped by category. Until the Go handler is fully implemented, the frontend
+page should transform the stub response into the expected format:
+
+```ts
+// Fallback: if response has config_ok, synthesize a single check
+if (result.checks === undefined) {
+  result = {
+    checks: [{ name: 'Config Valid', status: data.config_ok ? 'pass' : 'fail', message: '...', category: 'Config' }],
+    summary: { total: 1, passed: data.config_ok ? 1 : 0 },
+    timestamp: new Date().toISOString(),
+  };
+}
+```
+
+---
+
+## 10. File Manifest
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `web/src/api/castellarius.ts` | API client + hook for Castellarius |
+| `web/src/api/doctor.ts` | API client + hook for Doctor |
+| `web/src/api/logs.ts` | API client + SSE hook for Logs |
+| `web/src/api/repos.ts` | API client for Repos & Skills |
+| `web/src/components/StatusIndicator.tsx` | Running/stopped/error pulse dot |
+| `web/src/components/ActionButton.tsx` | Styled button with loading/confirm |
+| `web/src/components/LogViewer.tsx` | Terminal log viewer component |
+| `web/src/components/HealthCheckCard.tsx` | Doctor check row component |
+| `web/src/pages/CastellariusPage.tsx` | Castellarius control page |
+| `web/src/pages/DoctorPage.tsx` | Health check page |
+| `web/src/pages/LogsPage.tsx` | Log viewer page |
+| `web/src/pages/ReposSkillsPage.tsx` | Repos & Skills display page |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `web/src/api/types.ts` | Add CastellariusStatus, AqueductStatus, DoctorCheck, DoctorResult, LogEntry, LogSourceInfo, RepoInfo, AqueductBrief, SkillInfo |
+| `web/src/components/index.ts` | Add 4 new component exports |
+| `web/src/main.tsx` | Replace 4 placeholder routes with actual page components |
+| `cmd/ct/dashboard_web.go` | Add handleGetLogs, handleLogEvents, handleGetLogSources handlers + route registration |
+
+### No changes
+
+| File | Reason |
+|------|--------|
+| `web/src/pages/Placeholder.tsx` | Kept for droplets route |
+| `web/src/components/Sidebar.tsx` | Nav items already in place |
+| `web/src/App.tsx` | Layout unchanged |
+
+---
+
+## 11. Design Principles
+
+1. **Existing patterns**: Follow the functional component + named-export + tailwind
+   pattern established by Dashboard, AqueductArch, etc. No default exports.
+   No component libraries.
+
+2. **Auth**: All API calls use `getAuthHeaders()` for REST and `getAuthParams()`
+   for SSE query strings. No new auth logic needed.
+
+3. **Error handling**: Each page shows a centered error state if the initial
+   fetch fails (matching Dashboard's pattern). Toasts for action feedback
+   only (Castellarius actions).
+
+4. **Loading states**: Every page shows "Loading…" until data arrives.
+   ActionButton handles its own loading spinner during async operations.
+
+5. **No external dependencies**: No new npm packages. Build on React + Tailwind
+   + react-router-dom (already installed).
+
+6. **Graceful degradation**: Each page handles stub backend responses
+   gracefully (see sections 8 & 9) and shows partial data rather than crashing.
+
+7. **Responsive**: All pages use the existing sidebar + main layout. Content
+   uses `grid` and `flex-wrap` for responsive adaptation, matching Dashboard
+   patterns (e.g., `grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3`).
+
+8. **Cistern palette**: All colors come from the `cistern-*` tailwind theme.
+   No custom color values. Font is always `font-mono` for data and labels,
+   `font-mono` for headings (matching Dashboard).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,33 @@ Built the Droplets pages — the core interaction surface for monitoring and man
 - `internal/cistern/client.go` — `GetDependents` method for reverse dependency direction
 - `web/src/main.tsx` — routes for `/app/droplets` and `/app/droplets/:id`
 
+### Web UI: Infrastructure pages (ci-3pou0)
+
+Added four operator-facing infrastructure pages to the web dashboard: Castellarius control, Doctor health checks, log viewer, and repos/skills browser. Also adds Go-side SSE log streaming and log history endpoints.
+
+**Key features:**
+- **Castellarius page** (`/app/castellarius`): running/stopped status with pulse animation, PID and uptime display, aqueduct table (status, current droplet, step, elapsed), farm status badge, start/stop/restart action buttons (restart requires confirmation), toast notifications, auto-refresh every 5 seconds
+- **Doctor page** (`/app/doctor`): health check display with pass/fail/warn indicators grouped by category, summary card (X/Y passed), re-run and fix buttons, timestamp of last check
+- **Logs page** (`/app/logs`): real-time SSE log streaming with source selector, log level color coding (INFO=cyan, WARN=yellow, ERROR=red, DEBUG=dim), search/filter, auto-scroll toggle, line numbers, clear button, file size and last-modified metadata; monospace dark theme
+- **Repos & Skills page** (`/app/repos`): repository cards with aqueduct chains and step visualization, skills table with name/source/installed date; display-only (no install/uninstall from UI)
+- **Go log streaming**: `GET /api/logs` (last N lines with line numbers), `GET /api/logs/events` (SSE stream with connection pool limit), `GET /api/logs/sources` (available log files with metadata)
+- **Security**: path traversal protection via whitelist validation, URL parameter encoding, generic error messages, SSE line sanitization via json.Marshal, rate-limited lines (max 5000), 1MB scanner buffer, log rotation detection with offset reset, separate connection pools for droplet SSE (64) and log SSE (32), 20-retry limit for missing log files
+- **Shared components**: `StatusIndicator` (running/stopped/error with pulse animation), `ActionButton` (loading states, confirmation dialogs, variants), `LogViewer` (terminal-style display with search, auto-scroll, color coding), `HealthCheckCard` (pass/fail/warn indicators)
+- **Frontend**: 94 tests, all passing; TypeScript type check clean; graceful degradation for stub backend responses
+
+**Files added:**
+- `web/src/pages/CastellariusPage.tsx`, `DoctorPage.tsx`, `LogsPage.tsx`, `ReposSkillsPage.tsx`
+- `web/src/api/castellarius.ts`, `doctor.ts`, `logs.ts`, `repos.ts`
+- `web/src/api/types.ts` (extended with CastellariusStatus, AqueductStatus, DoctorCheck/Result, LogEntry, LogSourceInfo, RepoInfo, SkillInfo)
+- `web/src/components/StatusIndicator.tsx`, `ActionButton.tsx`, `LogViewer.tsx`, `HealthCheckCard.tsx`
+- `web/src/__tests__/castellarius.test.ts`, `doctor.test.ts`, `logs.test.ts`, `repos.test.ts`, `LogViewer.test.ts`, `infraTypes.test.ts`
+
+**Files changed:**
+- `cmd/ct/dashboard_web.go` — log history/SSE/sources handlers, connection pool management, path traversal validation, log rotation detection, scanner error handling
+- `cmd/ct/dashboard_api_test.go` — integration tests for log endpoints (history, SSE, sources, path traversal, rotation, connection limits)
+- `web/src/main.tsx` — route definitions for the four new pages
+- `web/src/components/index.ts` — exports for new shared components
+
 ### Web UI: Front-end foundation and dashboard (ci-jecbi)
 
 Added a React SPA dashboard at `/app/` with live aqueduct visualization, real-time SSE updates, authentication, and live terminal peek — the visual centerpiece of the web UI.

--- a/README.md
+++ b/README.md
@@ -610,6 +610,10 @@ SSE stream and `/ws/aqueducts/{name}/peek` WebSocket used by the TUI.
   indicator with progress bar, real-time notes timeline (SSE), signal action dialogs
   (pass/recirculate/pool), dependencies with add/remove (resolves/blocked_by/blocks),
   issue tracker with file/resolve/reject, modals for notes/metadata/restart
+- **Castellarius control page** (`/app/castellarius`) — view running/stopped status, PID, uptime; start/stop/restart the daemon; aqueduct table with flow status, current droplet, step, and elapsed time; auto-refreshes every 5 seconds
+- **Doctor page** (`/app/doctor`) — run health checks with pass/fail/warn indicators; re-run or fix from the UI; grouped by category with summary card
+- **Logs page** (`/app/logs`) — real-time log viewer with SSE streaming; source selector (castellarius.log and other available logs); log level color coding (INFO=cyan, WARN=yellow, ERROR=red, DEBUG=dim); search/filter, auto-scroll toggle, line numbers; file size and last-modified metadata
+- **Repos & Skills page** (`/app/repos`) — browse configured repositories with aqueduct chains; view installed skills with source URLs and install dates; display-only (install/uninstall remains CLI-only)
 - Dark theme matching the Cistern color palette
 - Responsive sidebar navigation that collapses on mobile
 - Authentication — when `CISTERN_DASHBOARD_API_KEY` is configured, a login page
@@ -707,14 +711,22 @@ The web dashboard exposes a REST API at `/api/` that mirrors all TUI operations.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/api/castellarius/status` | Current Castellarius status |
+| `GET` | `/api/castellarius/status` | Current Castellarius status (running, PID, uptime, aqueducts, farm status) |
 | `POST` | `/api/castellarius/start` | Start the daemon (requires auth) |
 | `POST` | `/api/castellarius/stop` | Stop the daemon (requires auth) |
 | `POST` | `/api/castellarius/restart` | Restart the daemon (requires auth) |
 | `GET` | `/api/doctor` | Run health check (query param: `?fix=true`) |
-| `GET` | `/api/repos` | List configured repos |
+| `GET` | `/api/repos` | List configured repos with aqueduct chains |
 | `GET` | `/api/repos/{name}/steps` | List pipeline step names for a repo |
 | `GET` | `/api/skills` | List installed skills |
+
+### Logs
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/logs` | Get recent log lines (query params: `?lines=500&source=castellarius`) |
+| `GET` | `/api/logs/events` | SSE stream of new log lines (query param: `?source=castellarius`) |
+| `GET` | `/api/logs/sources` | List available log sources with file size and last-modified time |
 
 ### Input validation
 

--- a/cmd/ct/dashboard_api_test.go
+++ b/cmd/ct/dashboard_api_test.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -2537,6 +2540,161 @@ func TestAPI_InputLimit_PassDropletNotesTooLong(t *testing.T) {
 	mux.ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("pass with long notes: status = %d, want 400", w.Code)
+	}
+}
+
+func TestAPI_Logs_PathTraversal_SourceParam(t *testing.T) {
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	traversalCases := []string{
+		"../etc/passwd",
+		"..%2Fetc%2Fpasswd",
+		"....//etc/passwd",
+		"/etc/passwd",
+		"castellarius/../../etc/passwd",
+	}
+	for _, src := range traversalCases {
+		t.Run(src, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/logs?source="+url.QueryEscape(src), nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("path traversal source=%q: status = %d, want 400", src, w.Code)
+			}
+		})
+	}
+}
+
+func TestAPI_Logs_PathTraversal_DirectSlashInSource(t *testing.T) {
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?source=/etc/passwd", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("absolute path source: status = %d, want 400", w.Code)
+	}
+}
+
+func TestAPI_Logs_LinesUpperBound(t *testing.T) {
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?lines=999999", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("large lines param: status = %d, want 200 (capped internally)", w.Code)
+	}
+}
+
+func TestAPI_Logs_NegativeLinesParam(t *testing.T) {
+	mux := newDashboardMux(tempCfg(t), tempCfg(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?lines=-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("negative lines param: status = %d, want 200 (uses default)", w.Code)
+	}
+}
+
+func TestAPI_Logs_ZeroLinesParam(t *testing.T) {
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?lines=0", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("zero lines param: status = %d, want 200 (uses default)", w.Code)
+	}
+}
+
+func TestAPI_Logs_NotFoundReturnsEmpty(t *testing.T) {
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?source=nonexistent_log_that_does_not_exist", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("missing log file: status = %d, want 200", w.Code)
+	}
+	var result []string
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("missing log file: got %d lines, want 0", len(result))
+	}
+}
+
+func TestAPI_LogSources_ReturnsAvailableLogs(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	logDir := filepath.Join(home, ".cistern")
+	origLog, _ := os.Stat(filepath.Join(logDir, "castellarius.log"))
+
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/sources", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("log sources: status = %d, want 200", w.Code)
+	}
+	var sources []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&sources); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if origLog != nil {
+		found := false
+		for _, s := range sources {
+			if s.Name == "castellarius" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("castellarius log source not found in response")
+		}
+	}
+}
+
+func TestAPI_LogSSE_PathTraversalInSource(t *testing.T) {
+	orig := currentSSEConnections
+	defer func() { currentSSEConnections = orig }()
+	atomic.StoreInt64(&currentSSEConnections, 0)
+
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/events?source=..%2Fetc%2Fpasswd", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("SSE path traversal: status = %d, want 400", w.Code)
+	}
+}
+
+func TestAPI_LogFilePath_ValidSource(t *testing.T) {
+	tests := []struct {
+		source string
+		valid  bool
+	}{
+		{"castellarius", true},
+		{"", true},
+		{"my-app", true},
+		{"app_123", true},
+		{"../etc/passwd", false},
+		{"/etc/passwd", false},
+		{"..", false},
+		{"a/b", false},
+		{"a\\b", false},
+		{"a b", false},
+		{"a:b", false},
+		{"a;b", false},
+		{".hidden", false},
+		{"castellarius.log", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			got := isValidLogSource(tt.source)
+			if got != tt.valid {
+				t.Errorf("isValidLogSource(%q) = %v, want %v", tt.source, got, tt.valid)
+			}
+		})
 	}
 }
 

--- a/cmd/ct/dashboard_api_test.go
+++ b/cmd/ct/dashboard_api_test.go
@@ -2719,3 +2719,77 @@ func TestAPI_InputLimit_CancelDropletReasonTooLong(t *testing.T) {
 		t.Errorf("cancel with long reason: status = %d, want 400", w.Code)
 	}
 }
+
+func TestAPI_LogSSE_StreamResumesAfterRotation(t *testing.T) {
+	orig := currentSSEConnections
+	defer func() { currentSSEConnections = orig }()
+	atomic.StoreInt64(&currentSSEConnections, 0)
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	cisternDir := filepath.Join(tmpDir, ".cistern")
+	if err := os.MkdirAll(cisternDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(cisternDir, "castellarius.log")
+
+	initialContent := "aaaaaaaaaa line-before-rotation aaaaaaaaaa\n"
+	if err := os.WriteFile(logPath, []byte(initialContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := tempCfg(t)
+	mux := newDashboardMux(cfg, tempDB(t))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/api/logs/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	time.Sleep(800 * time.Millisecond)
+
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("line-after-rotation\n")
+	f.Close()
+
+	var allData string
+	readCh := make(chan struct{})
+	go func() {
+		defer close(readCh)
+		buf := make([]byte, 8192)
+		for {
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				allData += string(buf[:n])
+			}
+			if allData != "" && strings.Contains(allData, "line-after-rotation") {
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-readCh:
+		if !strings.Contains(allData, "line-after-rotation") {
+			t.Errorf("SSE stream did not emit data after log rotation; got: %q", allData)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out; data so far: %q", allData)
+	}
+}

--- a/cmd/ct/dashboard_api_test.go
+++ b/cmd/ct/dashboard_api_test.go
@@ -2720,6 +2720,89 @@ func TestAPI_InputLimit_CancelDropletReasonTooLong(t *testing.T) {
 	}
 }
 
+func TestAPI_Logs_InvalidSource_NoUserInputInError(t *testing.T) {
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?source=../../../etc/passwd", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid source: status = %d, want 400", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "../../../etc/passwd") {
+		t.Errorf("error message reflects user input: %q", body)
+	}
+}
+
+func TestAPI_LogSSE_InitialContext(t *testing.T) {
+	orig := currentSSEConnections
+	defer func() { currentSSEConnections = orig }()
+	atomic.StoreInt64(&currentSSEConnections, 0)
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	cisternDir := filepath.Join(tmpDir, ".cistern")
+	if err := os.MkdirAll(cisternDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := make([]string, 200)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("existing-line-%04d", i)
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	logPath := filepath.Join(cisternDir, "castellarius.log")
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := tempCfg(t)
+	mux := newDashboardMux(cfg, tempDB(t))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/api/logs/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var allData string
+	readCh := make(chan struct{})
+	go func() {
+		defer close(readCh)
+		buf := make([]byte, 32768)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				allData += string(buf[:n])
+			}
+			if strings.Contains(allData, "existing-line-0199") {
+				return
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-readCh:
+		if !strings.Contains(allData, "existing-line-0199") {
+			t.Errorf("SSE stream did not send existing log data on connect; got: %q", allData)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatalf("timed out; SSE should have sent recent context on connect; data so far (len=%d): %q", len(allData), allData[:min(len(allData), 500)])
+	}
+}
+
 func TestAPI_LogSSE_StreamResumesAfterRotation(t *testing.T) {
 	orig := currentSSEConnections
 	defer func() { currentSSEConnections = orig }()

--- a/cmd/ct/dashboard_api_test.go
+++ b/cmd/ct/dashboard_api_test.go
@@ -2612,7 +2612,10 @@ func TestAPI_Logs_NotFoundReturnsEmpty(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("missing log file: status = %d, want 200", w.Code)
 	}
-	var result []string
+	var result []struct {
+		Line int64  `json:"line"`
+		Text string `json:"text"`
+	}
 	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -2902,15 +2905,70 @@ func TestAPI_Logs_LongLine_Handled(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("long line logs: status = %d, want 200", w.Code)
 	}
-	var result []string
+	var result []struct {
+		Line int64  `json:"line"`
+		Text string `json:"text"`
+	}
 	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(result) < 2 {
 		t.Fatalf("expected at least 2 lines from log with long line, got %d", len(result))
 	}
-	if result[len(result)-1] != "short-line" {
-		t.Errorf("last line = %q, want %q", result[len(result)-1], "short-line")
+	if result[len(result)-1].Text != "short-line" {
+		t.Errorf("last line = %q, want %q", result[len(result)-1].Text, "short-line")
+	}
+}
+
+func TestAPI_Logs_ReturnsAbsoluteLineNumbers(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	cisternDir := filepath.Join(tmpDir, ".cistern")
+	if err := os.MkdirAll(cisternDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var content strings.Builder
+	for i := 1; i <= 1000; i++ {
+		fmt.Fprintf(&content, "line-%d\n", i)
+	}
+	logPath := filepath.Join(cisternDir, "castellarius.log")
+	if err := os.WriteFile(logPath, []byte(content.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?lines=5", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("absolute line numbers: status = %d, want 200", w.Code)
+	}
+	var result []struct {
+		Line int64  `json:"line"`
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result) != 5 {
+		t.Fatalf("expected 5 lines, got %d", len(result))
+	}
+	if result[0].Line != 996 {
+		t.Errorf("first line number = %d, want 996", result[0].Line)
+	}
+	if result[0].Text != "line-996" {
+		t.Errorf("first line text = %q, want %q", result[0].Text, "line-996")
+	}
+	if result[4].Line != 1000 {
+		t.Errorf("last line number = %d, want 1000", result[4].Line)
+	}
+	if result[4].Text != "line-1000" {
+		t.Errorf("last line text = %q, want %q", result[4].Text, "line-1000")
 	}
 }
 

--- a/cmd/ct/dashboard_api_test.go
+++ b/cmd/ct/dashboard_api_test.go
@@ -2585,7 +2585,7 @@ func TestAPI_Logs_LinesUpperBound(t *testing.T) {
 }
 
 func TestAPI_Logs_NegativeLinesParam(t *testing.T) {
-	mux := newDashboardMux(tempCfg(t), tempCfg(t))
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
 	req := httptest.NewRequest(http.MethodGet, "/api/logs?lines=-1", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
@@ -2985,5 +2985,116 @@ func TestAPI_LogSSE_ScannerError_DoesNotStall(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timed out waiting for SSE stream to emit appended line; data: %q", allData)
+	}
+}
+
+func TestCountLinesUpTo(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.log")
+	content := "line1\nline2\nline3\nline4\nline5\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		offset  int64
+		wantLns int64
+	}{
+		{0, 0},
+		{6, 1},
+		{12, 2},
+		{30, 5},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("offset_%d", tt.offset), func(t *testing.T) {
+			got := countLinesUpTo(path, tt.offset)
+			if got != tt.wantLns {
+				t.Errorf("countLinesUpTo(%d) = %d, want %d", tt.offset, got, tt.wantLns)
+			}
+		})
+	}
+}
+
+func TestAPI_LogSSE_LineNumbersInJSON(t *testing.T) {
+	orig := currentSSEConnections
+	defer func() { currentSSEConnections = orig }()
+	atomic.StoreInt64(&currentSSEConnections, 0)
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	cisternDir := filepath.Join(tmpDir, ".cistern")
+	if err := os.MkdirAll(cisternDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := "first-line\nsecond-line\nthird-line\n"
+	logPath := filepath.Join(cisternDir, "castellarius.log")
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := tempCfg(t)
+	mux := newDashboardMux(cfg, tempDB(t))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/api/logs/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var allData string
+	readCh := make(chan struct{})
+	go func() {
+		defer close(readCh)
+		buf := make([]byte, 8192)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				allData += string(buf[:n])
+			}
+			if strings.Contains(allData, "third-line") {
+				return
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-readCh:
+		events := strings.Split(allData, "data: ")
+		var lineNums []int
+		for _, ev := range events {
+			ev = strings.TrimSpace(ev)
+			if ev == "" {
+				continue
+			}
+			var payload struct {
+				Line int    `json:"line"`
+				Text string `json:"text"`
+			}
+			if err := json.Unmarshal([]byte(ev), &payload); err != nil {
+				continue
+			}
+			lineNums = append(lineNums, payload.Line)
+		}
+		if len(lineNums) < 3 {
+			t.Fatalf("expected at least 3 SSE events, got %d; data: %q", len(lineNums), allData[:min(len(allData), 500)])
+		}
+		if lineNums[0] != 1 || lineNums[1] != 2 || lineNums[2] != 3 {
+			t.Errorf("line numbers not sequential: got %v, want [1 2 3]", lineNums[:3])
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatalf("timed out; data so far: %q", allData[:min(len(allData), 500)])
 	}
 }

--- a/cmd/ct/dashboard_api_test.go
+++ b/cmd/ct/dashboard_api_test.go
@@ -2192,9 +2192,9 @@ func TestAPI_SSALimit_ConnectionLimit(t *testing.T) {
 	d, _ := c.Add("myrepo", "Test", "", 1, 2)
 	c.Close()
 
-	original := currentSSEConnections
-	defer func() { currentSSEConnections = original }()
-	atomic.StoreInt64(&currentSSEConnections, maxSSEConnections)
+	original := currentDropletSSEConnections
+	defer func() { currentDropletSSEConnections = original }()
+	atomic.StoreInt64(&currentDropletSSEConnections, maxDropletSSEConnections)
 
 	mux := newDashboardMux(tempCfg(t), db)
 	req := httptest.NewRequest(http.MethodGet, "/api/droplets/"+d.ID+"/events", nil)
@@ -2658,9 +2658,9 @@ func TestAPI_LogSources_ReturnsAvailableLogs(t *testing.T) {
 }
 
 func TestAPI_LogSSE_PathTraversalInSource(t *testing.T) {
-	orig := currentSSEConnections
-	defer func() { currentSSEConnections = orig }()
-	atomic.StoreInt64(&currentSSEConnections, 0)
+	orig := currentLogSSEConnections
+	defer func() { currentLogSSEConnections = orig }()
+	atomic.StoreInt64(&currentLogSSEConnections, 0)
 
 	mux := newDashboardMux(tempCfg(t), tempDB(t))
 	req := httptest.NewRequest(http.MethodGet, "/api/logs/events?source=..%2Fetc%2Fpasswd", nil)
@@ -2738,9 +2738,9 @@ func TestAPI_Logs_InvalidSource_NoUserInputInError(t *testing.T) {
 }
 
 func TestAPI_LogSSE_InitialContext(t *testing.T) {
-	orig := currentSSEConnections
-	defer func() { currentSSEConnections = orig }()
-	atomic.StoreInt64(&currentSSEConnections, 0)
+	orig := currentLogSSEConnections
+	defer func() { currentLogSSEConnections = orig }()
+	atomic.StoreInt64(&currentLogSSEConnections, 0)
 
 	origHome := os.Getenv("HOME")
 	defer os.Setenv("HOME", origHome)
@@ -2807,9 +2807,9 @@ func TestAPI_LogSSE_InitialContext(t *testing.T) {
 }
 
 func TestAPI_LogSSE_StreamResumesAfterRotation(t *testing.T) {
-	orig := currentSSEConnections
-	defer func() { currentSSEConnections = orig }()
-	atomic.StoreInt64(&currentSSEConnections, 0)
+	orig := currentLogSSEConnections
+	defer func() { currentLogSSEConnections = orig }()
+	atomic.StoreInt64(&currentLogSSEConnections, 0)
 
 	origHome := os.Getenv("HOME")
 	defer os.Setenv("HOME", origHome)
@@ -2973,9 +2973,9 @@ func TestAPI_Logs_ReturnsAbsoluteLineNumbers(t *testing.T) {
 }
 
 func TestAPI_LogSSE_ScannerError_DoesNotStall(t *testing.T) {
-	orig := currentSSEConnections
-	defer func() { currentSSEConnections = orig }()
-	atomic.StoreInt64(&currentSSEConnections, 0)
+	orig := currentLogSSEConnections
+	defer func() { currentLogSSEConnections = orig }()
+	atomic.StoreInt64(&currentLogSSEConnections, 0)
 
 	origHome := os.Getenv("HOME")
 	defer os.Setenv("HOME", origHome)
@@ -3074,9 +3074,9 @@ func TestCountLinesUpTo(t *testing.T) {
 }
 
 func TestAPI_LogSSE_LineNumbersInJSON(t *testing.T) {
-	orig := currentSSEConnections
-	defer func() { currentSSEConnections = orig }()
-	atomic.StoreInt64(&currentSSEConnections, 0)
+	orig := currentLogSSEConnections
+	defer func() { currentLogSSEConnections = orig }()
+	atomic.StoreInt64(&currentLogSSEConnections, 0)
 
 	origHome := os.Getenv("HOME")
 	defer os.Setenv("HOME", origHome)
@@ -3154,5 +3154,119 @@ func TestAPI_LogSSE_LineNumbersInJSON(t *testing.T) {
 		}
 	case <-time.After(4 * time.Second):
 		t.Fatalf("timed out; data so far: %q", allData[:min(len(allData), 500)])
+	}
+}
+
+func TestAPI_LogSSE_TerminatesOnMissingFile(t *testing.T) {
+	orig := currentLogSSEConnections
+	defer func() { currentLogSSEConnections = orig }()
+	atomic.StoreInt64(&currentLogSSEConnections, 0)
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	cisternDir := filepath.Join(tmpDir, ".cistern")
+	if err := os.MkdirAll(cisternDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := tempCfg(t)
+	mux := newDashboardMux(cfg, tempDB(t))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/api/logs/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	buf := make([]byte, 1024)
+	_, readErr := resp.Body.Read(buf)
+	if readErr == nil {
+		_, readErr = resp.Body.Read(buf)
+	}
+
+	if readErr == nil {
+		t.Error("expected SSE stream to terminate when log file is missing, but it continued indefinitely")
+	}
+}
+
+func TestAPI_SSE_SeparateConnectionPools(t *testing.T) {
+	origDroplet := currentDropletSSEConnections
+	defer func() { currentDropletSSEConnections = origDroplet }()
+
+	origLog := currentLogSSEConnections
+	defer func() { currentLogSSEConnections = origLog }()
+
+	atomic.StoreInt64(&currentDropletSSEConnections, maxDropletSSEConnections)
+	atomic.StoreInt64(&currentLogSSEConnections, 0)
+
+	db := tempDB(t)
+	c, err := cistern.New(db, "mr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, _ := c.Add("myrepo", "Test", "", 1, 2)
+	c.Close()
+
+	mux := newDashboardMux(tempCfg(t), db)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/droplets/"+d.ID+"/events", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("droplet SSE at connection limit: status = %d, want 503", w.Code)
+	}
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	cisternDir := filepath.Join(tmpDir, ".cistern")
+	if err := os.MkdirAll(cisternDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(cisternDir, "castellarius.log")
+	if err := os.WriteFile(logPath, []byte("test log line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logReq := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	logW := httptest.NewRecorder()
+	mux.ServeHTTP(logW, logReq)
+	if logW.Code != http.StatusOK {
+		t.Errorf("log API should still work even when droplet SSE pool is full: status = %d", logW.Code)
+	}
+}
+
+func TestAPI_LogSSE_ConnectionLimit(t *testing.T) {
+	orig := currentLogSSEConnections
+	defer func() { currentLogSSEConnections = orig }()
+	atomic.StoreInt64(&currentLogSSEConnections, maxLogSSEConnections)
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+
+	cfg := tempCfg(t)
+	mux := newDashboardMux(cfg, tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/events", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("log SSE at connection limit: status = %d, want 503", w.Code)
+	}
+	var body map[string]string
+	json.Unmarshal(w.Body.Bytes(), &body)
+	if !strings.Contains(body["error"], "too many") {
+		t.Errorf("error = %q, want 'too many' keyword", body["error"])
 	}
 }

--- a/cmd/ct/dashboard_api_test.go
+++ b/cmd/ct/dashboard_api_test.go
@@ -2793,3 +2793,114 @@ func TestAPI_LogSSE_StreamResumesAfterRotation(t *testing.T) {
 		t.Fatalf("timed out; data so far: %q", allData)
 	}
 }
+
+func TestAPI_Logs_LongLine_Handled(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	cisternDir := filepath.Join(tmpDir, ".cistern")
+	if err := os.MkdirAll(cisternDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	longLine := strings.Repeat("x", 100*1024) + " readable-after\nshort-line\n"
+	logPath := filepath.Join(cisternDir, "castellarius.log")
+	if err := os.WriteFile(logPath, []byte(longLine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newDashboardMux(tempCfg(t), tempDB(t))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?lines=100", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("long line logs: status = %d, want 200", w.Code)
+	}
+	var result []string
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result) < 2 {
+		t.Fatalf("expected at least 2 lines from log with long line, got %d", len(result))
+	}
+	if result[len(result)-1] != "short-line" {
+		t.Errorf("last line = %q, want %q", result[len(result)-1], "short-line")
+	}
+}
+
+func TestAPI_LogSSE_ScannerError_DoesNotStall(t *testing.T) {
+	orig := currentSSEConnections
+	defer func() { currentSSEConnections = orig }()
+	atomic.StoreInt64(&currentSSEConnections, 0)
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	cisternDir := filepath.Join(tmpDir, ".cistern")
+	if err := os.MkdirAll(cisternDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(cisternDir, "castellarius.log")
+
+	shortContent := "first-line\n"
+	if err := os.WriteFile(logPath, []byte(shortContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := tempCfg(t)
+	mux := newDashboardMux(cfg, tempDB(t))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/api/logs/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	time.Sleep(800 * time.Millisecond)
+
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("second-line\n")
+	f.Close()
+
+	var allData string
+	readCh := make(chan struct{})
+	go func() {
+		defer close(readCh)
+		buf := make([]byte, 8192)
+		for {
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				allData += string(buf[:n])
+			}
+			if allData != "" && strings.Contains(allData, "second-line") {
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-readCh:
+		if !strings.Contains(allData, "second-line") {
+			t.Errorf("SSE stream did not emit second-line after append; got: %q", allData)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for SSE stream to emit appended line; data: %q", allData)
+	}
+}

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -2297,12 +2297,43 @@ func handleGetSkills() http.HandlerFunc {
 
 // ── Log handlers ──
 
-func logFilePath(cfgPath, source string) string {
+const maxLogLines = 5000
+
+// isValidLogSource checks that source is a safe, non-traversal log file name.
+// Only alphanumeric, hyphens, and underscores are allowed. No dots, slashes,
+// or other characters that could enable path traversal.
+func isValidLogSource(source string) bool {
+	if source == "" || source == "castellarius" {
+		return true
+	}
+	if len(source) > 64 {
+		return false
+	}
+	for _, ch := range source {
+		if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func logFilePath(cfgPath, source string) (string, error) {
+	if !isValidLogSource(source) {
+		return "", fmt.Errorf("invalid log source: %q", source)
+	}
 	home, _ := os.UserHomeDir()
 	if source == "" || source == "castellarius" {
-		return filepath.Join(home, ".cistern", "castellarius.log")
+		return filepath.Join(home, ".cistern", "castellarius.log"), nil
 	}
-	return filepath.Join(home, ".cistern", source+".log")
+	return filepath.Join(home, ".cistern", source+".log"), nil
+}
+
+// sanitizeSSEData escapes newlines in data for safe SSE transmission.
+// Per the SSE spec, data fields must not contain raw newlines.
+func sanitizeSSEData(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return strings.ReplaceAll(s, "\n", "\\n")
 }
 
 // handleGetLogs returns the last N lines of the log file.
@@ -2314,12 +2345,21 @@ func handleGetLogs(cfgPath string) http.HandlerFunc {
 		if n, err := strconv.Atoi(linesStr); err == nil && n > 0 {
 			lines = n
 		}
+		if lines > maxLogLines {
+			lines = maxLogLines
+		}
+
 		source := r.URL.Query().Get("source")
 		if source == "" {
 			source = "castellarius"
 		}
 
-		path := logFilePath(cfgPath, source)
+		path, err := logFilePath(cfgPath, source)
+		if err != nil {
+			writeAPIError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
 		f, err := os.Open(path)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -2331,17 +2371,33 @@ func handleGetLogs(cfgPath string) http.HandlerFunc {
 		}
 		defer f.Close()
 
+		// Ring buffer approach: only keep the last `lines` entries in memory.
+		ring := make([]string, 0, lines)
 		scanner := bufio.NewScanner(f)
-		var allLines []string
+		count := 0
 		for scanner.Scan() {
-			allLines = append(allLines, scanner.Text())
+			if len(ring) < lines {
+				ring = append(ring, scanner.Text())
+			} else {
+				ring[count%lines] = scanner.Text()
+			}
+			count++
+		}
+		if err := scanner.Err(); err != nil {
+			writeAPIError(w, http.StatusInternalServerError, "internal error")
+			return
 		}
 
-		start := len(allLines) - lines
-		if start < 0 {
-			start = 0
+		var result []string
+		if count <= lines {
+			result = ring[:count]
+		} else {
+			// Ring buffer: elements need to be reordered from oldest to newest.
+			start := count % lines
+			result = make([]string, lines)
+			copy(result, ring[start:])
+			copy(result[lines-start:], ring[:start])
 		}
-		result := allLines[start:]
 		writeAPIJSON(w, http.StatusOK, result)
 	}
 }
@@ -2366,7 +2422,11 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 		if source == "" {
 			source = "castellarius"
 		}
-		path := logFilePath(cfgPath, source)
+		path, err := logFilePath(cfgPath, source)
+		if err != nil {
+			writeAPIError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
@@ -2403,7 +2463,7 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 				scanner := bufio.NewScanner(f)
 				for scanner.Scan() {
 					line := scanner.Text()
-					fmt.Fprintf(w, "data: %s\n\n", line)
+					fmt.Fprintf(w, "data: %s\n\n", sanitizeSSEData(line))
 				}
 				offset, _ = f.Seek(0, io.SeekCurrent)
 				f.Close()
@@ -2417,26 +2477,38 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 func handleGetLogSources(cfgPath string) http.HandlerFunc {
 	type logSourceInfo struct {
 		Name         string `json:"name"`
-		Path         string `json:"path"`
 		SizeBytes    int64  `json:"size_bytes"`
 		LastModified string `json:"last_modified"`
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		home, _ := os.UserHomeDir()
-		path := filepath.Join(home, ".cistern", "castellarius.log")
+		logDir := filepath.Join(home, ".cistern")
 		var sources []logSourceInfo
 
-		info, err := os.Stat(path)
-		if err == nil {
+		entries, err := os.ReadDir(logDir)
+		if err != nil {
+			writeAPIJSON(w, http.StatusOK, sources)
+			return
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".log") {
+				continue
+			}
+			name := strings.TrimSuffix(entry.Name(), ".log")
+			if !isValidLogSource(name) {
+				continue
+			}
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
 			sources = append(sources, logSourceInfo{
-				Name:         "castellarius",
-				Path:         path,
+				Name:         name,
 				SizeBytes:    info.Size(),
 				LastModified: info.ModTime().UTC().Format(time.RFC3339),
 			})
 		}
-
 		writeAPIJSON(w, http.StatusOK, sources)
 	}
 }

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -2451,7 +2451,9 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 				if err != nil {
 					continue
 				}
-				if info.Size() <= offset {
+				if info.Size() < offset {
+					offset = 0
+				} else if info.Size() == offset {
 					continue
 				}
 

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -2299,6 +2299,8 @@ func handleGetSkills() http.HandlerFunc {
 
 const maxLogLines = 5000
 
+const sseInitialTail int64 = 32 * 1024 // Send last ~32KB of existing log on connect
+
 const maxScanTokenSize = 1024 * 1024 // 1MB — accommodate long log lines
 
 // isValidLogSource checks that source is a safe, non-traversal log file name.
@@ -2321,7 +2323,7 @@ func isValidLogSource(source string) bool {
 
 func logFilePath(cfgPath, source string) (string, error) {
 	if !isValidLogSource(source) {
-		return "", fmt.Errorf("invalid log source: %q", source)
+		return "", fmt.Errorf("invalid log source name")
 	}
 	home, _ := os.UserHomeDir()
 	if source == "" || source == "castellarius" {
@@ -2442,7 +2444,9 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 
 		var offset int64
 		if info, err := os.Stat(path); err == nil {
-			offset = info.Size()
+			if info.Size() > sseInitialTail {
+				offset = info.Size() - sseInitialTail
+			}
 		}
 
 		for {

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -2340,6 +2340,37 @@ func sanitizeSSEData(s string) string {
 	return strings.ReplaceAll(s, "\n", "\\n")
 }
 
+// countLinesUpTo counts newlines in the file up to (but not including) the
+// given byte offset. Used by the SSE handler to compute line numbers when
+// starting mid-file.
+func countLinesUpTo(path string, offset int64) int64 {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	var count int64
+	buf := make([]byte, 32*1024)
+	remaining := offset
+	for remaining > 0 {
+		chunk := int64(len(buf))
+		if remaining < chunk {
+			chunk = remaining
+		}
+		n, err := f.Read(buf[:chunk])
+		if err != nil || n == 0 {
+			break
+		}
+		for i := 0; i < n; i++ {
+			if buf[i] == '\n' {
+				count++
+			}
+		}
+		remaining -= int64(n)
+	}
+	return count
+}
+
 // handleGetLogs returns the last N lines of the log file.
 // Query params: ?lines=500&source=castellarius
 func handleGetLogs(cfgPath string) http.HandlerFunc {
@@ -2443,9 +2474,11 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 		defer ticker.Stop()
 
 		var offset int64
+		lineNum := int64(1)
 		if info, err := os.Stat(path); err == nil {
 			if info.Size() > sseInitialTail {
 				offset = info.Size() - sseInitialTail
+				lineNum = countLinesUpTo(path, offset) + 1
 			}
 		}
 
@@ -2460,6 +2493,7 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 				}
 				if info.Size() < offset {
 					offset = 0
+					lineNum = 1
 				} else if info.Size() == offset {
 					continue
 				}
@@ -2468,25 +2502,40 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 				if err != nil {
 					continue
 				}
-				f.Seek(offset, io.SeekStart)
-				scanner := bufio.NewScanner(f)
-				scanner.Buffer(make([]byte, 0, maxScanTokenSize), maxScanTokenSize)
-				for scanner.Scan() {
-					line := scanner.Text()
-					fmt.Fprintf(w, "data: %s\n\n", sanitizeSSEData(line))
-				}
-				if err := scanner.Err(); err != nil {
-					newOffset, _ := f.Seek(0, io.SeekCurrent)
+				func() {
+					defer f.Close()
+					f.Seek(offset, io.SeekStart)
+					scanner := bufio.NewScanner(f)
+					scanner.Buffer(make([]byte, 0, maxScanTokenSize), maxScanTokenSize)
+					var newOffset int64
+					for scanner.Scan() {
+						line := scanner.Text()
+						type sseLine struct {
+							Line int64  `json:"line"`
+							Text string `json:"text"`
+						}
+						payload, _ := json.Marshal(sseLine{Line: lineNum, Text: line})
+						_, err := fmt.Fprintf(w, "data: %s\n\n", payload)
+						if err != nil {
+							return
+						}
+						lineNum++
+						newOffset, _ = f.Seek(0, io.SeekCurrent)
+					}
+					if err := scanner.Err(); err != nil {
+						if newOffset > offset {
+							offset = newOffset
+						}
+						flusher.Flush()
+						return
+					}
 					if newOffset > offset {
 						offset = newOffset
+					} else {
+						offset, _ = f.Seek(0, io.SeekCurrent)
 					}
-					f.Close()
 					flusher.Flush()
-					continue
-				}
-				offset, _ = f.Seek(0, io.SeekCurrent)
-				f.Close()
-				flusher.Flush()
+				}()
 			}
 		}
 	}

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -2371,9 +2371,15 @@ func countLinesUpTo(path string, offset int64) int64 {
 	return count
 }
 
-// handleGetLogs returns the last N lines of the log file.
+// handleGetLogs returns the last N lines of the log file with absolute line numbers.
 // Query params: ?lines=500&source=castellarius
+// Returns: [{line: <int>, text: "<string>"}] with line numbers matching the file position.
 func handleGetLogs(cfgPath string) http.HandlerFunc {
+	type logLine struct {
+		Line int64  `json:"line"`
+		Text string `json:"text"`
+	}
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		linesStr := r.URL.Query().Get("lines")
 		lines := 500
@@ -2398,7 +2404,7 @@ func handleGetLogs(cfgPath string) http.HandlerFunc {
 		f, err := os.Open(path)
 		if err != nil {
 			if os.IsNotExist(err) {
-				writeAPIJSON(w, http.StatusOK, []string{})
+				writeAPIJSON(w, http.StatusOK, []logLine{})
 				return
 			}
 			writeAPIError(w, http.StatusInternalServerError, "internal error")
@@ -2406,33 +2412,44 @@ func handleGetLogs(cfgPath string) http.HandlerFunc {
 		}
 		defer f.Close()
 
-		// Ring buffer approach: only keep the last `lines` entries in memory.
-		ring := make([]string, 0, lines)
+		// Ring buffer approach: only keep the last `lines` entries in memory,
+		// tracking absolute line numbers.
+		type ringEntry struct {
+			Line int64
+			Text string
+		}
+		ring := make([]ringEntry, 0, lines)
 		scanner := bufio.NewScanner(f)
 		scanner.Buffer(make([]byte, 0, maxScanTokenSize), maxScanTokenSize)
-		count := 0
+		lineNum := int64(0)
 		for scanner.Scan() {
+			lineNum++
+			entry := ringEntry{Line: lineNum, Text: scanner.Text()}
 			if len(ring) < lines {
-				ring = append(ring, scanner.Text())
+				ring = append(ring, entry)
 			} else {
-				ring[count%lines] = scanner.Text()
+				ring[int((lineNum-1)%int64(lines))] = entry
 			}
-			count++
 		}
 		if err := scanner.Err(); err != nil {
 			writeAPIError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
 
-		var result []string
-		if count <= lines {
-			result = ring[:count]
+		var result []logLine
+		if lineNum <= int64(lines) {
+			result = make([]logLine, lineNum)
+			for i, e := range ring {
+				result[i] = logLine{Line: e.Line, Text: e.Text}
+			}
 		} else {
 			// Ring buffer: elements need to be reordered from oldest to newest.
-			start := count % lines
-			result = make([]string, lines)
-			copy(result, ring[start:])
-			copy(result[lines-start:], ring[:start])
+			start := int(lineNum % int64(lines))
+			result = make([]logLine, lines)
+			for i := 0; i < lines; i++ {
+				e := ring[(start+i)%lines]
+				result[i] = logLine{Line: e.Line, Text: e.Text}
+			}
 		}
 		writeAPIJSON(w, http.StatusOK, result)
 	}

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -1077,6 +1077,11 @@ func newDashboardMuxInternalWith(cfgPath, dbPath string, tui *DashboardTUI, fetc
 	apiMux.HandleFunc("GET /api/repos/{name}/steps", handleGetRepoSteps(cfgPath))
 	apiMux.HandleFunc("GET /api/skills", handleGetSkills())
 
+	// Logs
+	apiMux.HandleFunc("GET /api/logs", handleGetLogs(cfgPath))
+	apiMux.HandleFunc("GET /api/logs/events", handleLogEvents(cfgPath))
+	apiMux.HandleFunc("GET /api/logs/sources", handleGetLogSources(cfgPath))
+
 	// SSE for droplet detail
 	apiMux.HandleFunc("GET /api/droplets/{id}/events", handleDropletEvents(cfgPath, dbPath))
 
@@ -2287,6 +2292,152 @@ func handleGetSkills() http.HandlerFunc {
 			return
 		}
 		writeAPIJSON(w, http.StatusOK, entries)
+	}
+}
+
+// ── Log handlers ──
+
+func logFilePath(cfgPath, source string) string {
+	home, _ := os.UserHomeDir()
+	if source == "" || source == "castellarius" {
+		return filepath.Join(home, ".cistern", "castellarius.log")
+	}
+	return filepath.Join(home, ".cistern", source+".log")
+}
+
+// handleGetLogs returns the last N lines of the log file.
+// Query params: ?lines=500&source=castellarius
+func handleGetLogs(cfgPath string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		linesStr := r.URL.Query().Get("lines")
+		lines := 500
+		if n, err := strconv.Atoi(linesStr); err == nil && n > 0 {
+			lines = n
+		}
+		source := r.URL.Query().Get("source")
+		if source == "" {
+			source = "castellarius"
+		}
+
+		path := logFilePath(cfgPath, source)
+		f, err := os.Open(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				writeAPIJSON(w, http.StatusOK, []string{})
+				return
+			}
+			writeAPIError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		var allLines []string
+		for scanner.Scan() {
+			allLines = append(allLines, scanner.Text())
+		}
+
+		start := len(allLines) - lines
+		if start < 0 {
+			start = 0
+		}
+		result := allLines[start:]
+		writeAPIJSON(w, http.StatusOK, result)
+	}
+}
+
+// handleLogEvents streams new log lines via SSE.
+func handleLogEvents(cfgPath string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt64(&currentSSEConnections, 1) > maxSSEConnections {
+			atomic.AddInt64(&currentSSEConnections, -1)
+			writeAPIError(w, http.StatusServiceUnavailable, "too many SSE connections")
+			return
+		}
+		defer atomic.AddInt64(&currentSSEConnections, -1)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			writeAPIError(w, http.StatusInternalServerError, "streaming unsupported")
+			return
+		}
+
+		source := r.URL.Query().Get("source")
+		if source == "" {
+			source = "castellarius"
+		}
+		path := logFilePath(cfgPath, source)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+		flusher.Flush()
+
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+
+		var offset int64
+		if info, err := os.Stat(path); err == nil {
+			offset = info.Size()
+		}
+
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ticker.C:
+				info, err := os.Stat(path)
+				if err != nil {
+					continue
+				}
+				if info.Size() <= offset {
+					continue
+				}
+
+				f, err := os.Open(path)
+				if err != nil {
+					continue
+				}
+				f.Seek(offset, io.SeekStart)
+				scanner := bufio.NewScanner(f)
+				for scanner.Scan() {
+					line := scanner.Text()
+					fmt.Fprintf(w, "data: %s\n\n", line)
+				}
+				offset, _ = f.Seek(0, io.SeekCurrent)
+				f.Close()
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+// handleGetLogSources returns metadata about available log files.
+func handleGetLogSources(cfgPath string) http.HandlerFunc {
+	type logSourceInfo struct {
+		Name         string `json:"name"`
+		Path         string `json:"path"`
+		SizeBytes    int64  `json:"size_bytes"`
+		LastModified string `json:"last_modified"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		home, _ := os.UserHomeDir()
+		path := filepath.Join(home, ".cistern", "castellarius.log")
+		var sources []logSourceInfo
+
+		info, err := os.Stat(path)
+		if err == nil {
+			sources = append(sources, logSourceInfo{
+				Name:         "castellarius",
+				Path:         path,
+				SizeBytes:    info.Size(),
+				LastModified: info.ModTime().UTC().Format(time.RFC3339),
+			})
+		}
+
+		writeAPIJSON(w, http.StatusOK, sources)
 	}
 }
 

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -2299,6 +2299,8 @@ func handleGetSkills() http.HandlerFunc {
 
 const maxLogLines = 5000
 
+const maxScanTokenSize = 1024 * 1024 // 1MB — accommodate long log lines
+
 // isValidLogSource checks that source is a safe, non-traversal log file name.
 // Only alphanumeric, hyphens, and underscores are allowed. No dots, slashes,
 // or other characters that could enable path traversal.
@@ -2374,6 +2376,7 @@ func handleGetLogs(cfgPath string) http.HandlerFunc {
 		// Ring buffer approach: only keep the last `lines` entries in memory.
 		ring := make([]string, 0, lines)
 		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, maxScanTokenSize), maxScanTokenSize)
 		count := 0
 		for scanner.Scan() {
 			if len(ring) < lines {
@@ -2463,9 +2466,19 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 				}
 				f.Seek(offset, io.SeekStart)
 				scanner := bufio.NewScanner(f)
+				scanner.Buffer(make([]byte, 0, maxScanTokenSize), maxScanTokenSize)
 				for scanner.Scan() {
 					line := scanner.Text()
 					fmt.Fprintf(w, "data: %s\n\n", sanitizeSSEData(line))
+				}
+				if err := scanner.Err(); err != nil {
+					newOffset, _ := f.Seek(0, io.SeekCurrent)
+					if newOffset > offset {
+						offset = newOffset
+					}
+					f.Close()
+					flusher.Flush()
+					continue
 				}
 				offset, _ = f.Seek(0, io.SeekCurrent)
 				f.Close()

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -79,12 +79,21 @@ const (
 // Prevents unbounded memory consumption from large payloads.
 const apiMaxBodyBytes = 1 << 20 // 1 MiB
 
-// maxSSEConnections limits the number of simultaneous SSE client connections
-// per server to prevent resource exhaustion.
-const maxSSEConnections = 64
+// maxDropletSSEConnections limits the number of simultaneous SSE connections
+// for droplet detail streams, preventing resource exhaustion independent of
+// log viewer connections.
+const maxDropletSSEConnections = 64
 
-// currentSSEConnections tracks the number of active SSE connections.
-var currentSSEConnections int64
+// maxLogSSEConnections limits the number of simultaneous SSE connections
+// for log viewer streams. Separate from droplet connections so log viewers
+// cannot starve dashboard detail views.
+const maxLogSSEConnections = 32
+
+// currentDropletSSEConnections tracks the number of active droplet SSE connections.
+var currentDropletSSEConnections int64
+
+// currentLogSSEConnections tracks the number of active log SSE connections.
+var currentLogSSEConnections int64
 
 // dashboardDefaultFontFamily is the CSS font-family fallback used when
 // dashboard_font_family is not set in cistern.yaml.
@@ -2455,15 +2464,19 @@ func handleGetLogs(cfgPath string) http.HandlerFunc {
 	}
 }
 
+// maxLogSSERetries is the maximum number of consecutive poll cycles where the
+// log file is missing before the SSE handler terminates the connection.
+const maxLogSSERetries = 20 // 20 × 500ms = 10 seconds
+
 // handleLogEvents streams new log lines via SSE.
 func handleLogEvents(cfgPath string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if atomic.AddInt64(&currentSSEConnections, 1) > maxSSEConnections {
-			atomic.AddInt64(&currentSSEConnections, -1)
-			writeAPIError(w, http.StatusServiceUnavailable, "too many SSE connections")
+		if atomic.AddInt64(&currentLogSSEConnections, 1) > maxLogSSEConnections {
+			atomic.AddInt64(&currentLogSSEConnections, -1)
+			writeAPIError(w, http.StatusServiceUnavailable, "too many log SSE connections")
 			return
 		}
-		defer atomic.AddInt64(&currentSSEConnections, -1)
+		defer atomic.AddInt64(&currentLogSSEConnections, -1)
 
 		flusher, ok := w.(http.Flusher)
 		if !ok {
@@ -2499,6 +2512,7 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 			}
 		}
 
+		missCount := 0
 		for {
 			select {
 			case <-r.Context().Done():
@@ -2506,8 +2520,13 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 			case <-ticker.C:
 				info, err := os.Stat(path)
 				if err != nil {
+					missCount++
+					if missCount >= maxLogSSERetries {
+						return
+					}
 					continue
 				}
+				missCount = 0
 				if info.Size() < offset {
 					offset = 0
 					lineNum = 1
@@ -2609,12 +2628,12 @@ func handleDropletEvents(cfgPath, dbPath string) http.HandlerFunc {
 		id := r.PathValue("id")
 
 		// Limit concurrent SSE connections to prevent resource exhaustion.
-		if atomic.AddInt64(&currentSSEConnections, 1) > maxSSEConnections {
-			atomic.AddInt64(&currentSSEConnections, -1)
+		if atomic.AddInt64(&currentDropletSSEConnections, 1) > maxDropletSSEConnections {
+			atomic.AddInt64(&currentDropletSSEConnections, -1)
 			writeAPIError(w, http.StatusServiceUnavailable, "too many SSE connections")
 			return
 		}
-		defer atomic.AddInt64(&currentSSEConnections, -1)
+		defer atomic.AddInt64(&currentDropletSSEConnections, -1)
 
 		// Validate droplet existence and flusher support before setting SSE headers,
 		// so error responses use clean Content-Type instead of text/event-stream.

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -2504,7 +2504,11 @@ func handleLogEvents(cfgPath string) http.HandlerFunc {
 				}
 				func() {
 					defer f.Close()
-					f.Seek(offset, io.SeekStart)
+					seekOffset, seekErr := f.Seek(offset, io.SeekStart)
+					if seekErr != nil {
+						return
+					}
+					_ = seekOffset
 					scanner := bufio.NewScanner(f)
 					scanner.Buffer(make([]byte, 0, maxScanTokenSize), maxScanTokenSize)
 					var newOffset int64

--- a/web/src/__tests__/LogViewer.test.ts
+++ b/web/src/__tests__/LogViewer.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { parseLogLines } from '../components/LogViewer';
+
+describe('parseLogLines', () => {
+  it('parses lines with level extraction', () => {
+    const lines = [
+      '2026-04-19 12:00:01 INFO server started',
+      '2026-04-19 12:00:02 WARN low disk',
+      '2026-04-19 12:00:03 ERROR connection lost',
+      'stack trace line',
+    ];
+    const entries = parseLogLines(lines);
+    expect(entries).toHaveLength(4);
+    expect(entries[0].line).toBe(1);
+    expect(entries[0].level).toBe('INFO');
+    expect(entries[1].level).toBe('WARN');
+    expect(entries[2].level).toBe('ERROR');
+    expect(entries[3].level).toBe('');
+  });
+
+  it('assigns sequential line numbers', () => {
+    const lines = ['line1', 'line2', 'line3'];
+    const entries = parseLogLines(lines);
+    expect(entries[0].line).toBe(1);
+    expect(entries[1].line).toBe(2);
+    expect(entries[2].line).toBe(3);
+  });
+
+  it('preserves raw text', () => {
+    const lines = ['2026-04-19 12:00:01 DEBUG something'];
+    const entries = parseLogLines(lines);
+    expect(entries[0].raw).toBe('2026-04-19 12:00:01 DEBUG something');
+    expect(entries[0].text).toBe('2026-04-19 12:00:01 DEBUG something');
+  });
+
+  it('handles empty array', () => {
+    const entries = parseLogLines([]);
+    expect(entries).toHaveLength(0);
+  });
+
+  it('extracts DEBUG level', () => {
+    const entries = parseLogLines(['DEBUG processing']);
+    expect(entries[0].level).toBe('DEBUG');
+  });
+
+  it('only extracts first log level match', () => {
+    const entries = parseLogLines(['INFO something ERROR nested']);
+    expect(entries[0].level).toBe('INFO');
+  });
+});

--- a/web/src/__tests__/castellarius.test.ts
+++ b/web/src/__tests__/castellarius.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('fetchCastellariusStatus', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('transforms stub response into CastellariusStatus', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'ok' }),
+    }));
+    const { fetchCastellariusStatus } = await import('../api/castellarius');
+    const result = await fetchCastellariusStatus();
+    expect(result.running).toBe(true);
+    expect(result.aqueducts).toEqual([]);
+    expect(result.farm_running).toBe(false);
+  });
+
+  it('passes through full response', async () => {
+    const fullStatus = {
+      running: true,
+      pid: 123,
+      uptime_seconds: 3600,
+      aqueducts: [{ name: 'default', status: 'flowing', droplet_id: 'ci-abc', droplet_title: 'Test', current_step: 'implement', elapsed: 300000000000 }],
+      farm_running: true,
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fullStatus),
+    }));
+    const { fetchCastellariusStatus } = await import('../api/castellarius');
+    const result = await fetchCastellariusStatus();
+    expect(result.running).toBe(true);
+    expect(result.pid).toBe(123);
+    expect(result.aqueducts).toHaveLength(1);
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }));
+    const { fetchCastellariusStatus } = await import('../api/castellarius');
+    await expect(fetchCastellariusStatus()).rejects.toThrow('castellarius status: 500');
+  });
+});
+
+describe('castellariusAction', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls POST /api/castellarius/{action}', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+    const { castellariusAction } = await import('../api/castellarius');
+    await castellariusAction('start');
+    expect(mockFetch).toHaveBeenCalledWith('/api/castellarius/start', {
+      method: 'POST',
+      headers: {},
+    });
+  });
+
+  it('throws with error message on failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 501,
+      json: () => Promise.resolve({ message: 'not yet supported' }),
+    }));
+    const { castellariusAction } = await import('../api/castellarius');
+    await expect(castellariusAction('stop')).rejects.toThrow('not yet supported');
+  });
+});

--- a/web/src/__tests__/doctor.test.ts
+++ b/web/src/__tests__/doctor.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('fetchDoctor', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('transforms stub response with config_ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ config_ok: true, repos: [{ name: 'cistern', url: 'https://github.com/org/cistern' }] }),
+    }));
+    const { fetchDoctor } = await import('../api/doctor');
+    const result = await fetchDoctor();
+    expect(result.checks.length).toBeGreaterThanOrEqual(1);
+    expect(result.checks[0].name).toBe('Config Valid');
+    expect(result.checks[0].status).toBe('pass');
+    expect(result.summary.total).toBe(result.checks.length);
+    expect(result.summary.passed).toBe(result.checks.length);
+    expect(result.timestamp).toBeTruthy();
+  });
+
+  it('transforms stub response with config_ok=false', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ config_ok: false, repos: [] }),
+    }));
+    const { fetchDoctor } = await import('../api/doctor');
+    const result = await fetchDoctor();
+    const configCheck = result.checks.find(c => c.name === 'Config Valid');
+    expect(configCheck).toBeDefined();
+    expect(configCheck!.status).toBe('fail');
+  });
+
+  it('passes through full DoctorResult response', async () => {
+    const fullResult = {
+      checks: [
+        { name: 'Daemon running', status: 'pass', message: 'Running', category: 'Daemon' },
+      ],
+      summary: { total: 1, passed: 1 },
+      timestamp: '2026-04-19T00:00:00Z',
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fullResult),
+    }));
+    const { fetchDoctor } = await import('../api/doctor');
+    const result = await fetchDoctor();
+    expect(result.checks).toHaveLength(1);
+    expect(result.timestamp).toBe('2026-04-19T00:00:00Z');
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }));
+    const { fetchDoctor } = await import('../api/doctor');
+    await expect(fetchDoctor()).rejects.toThrow('doctor: 500');
+  });
+});

--- a/web/src/__tests__/infraTypes.test.ts
+++ b/web/src/__tests__/infraTypes.test.ts
@@ -116,7 +116,6 @@ describe('LogSourceInfo type', () => {
   it('accepts source info', () => {
     const info: LogSourceInfo = {
       name: 'castellarius',
-      path: '/home/user/.cistern/castellarius.log',
       size_bytes: 2048576,
       last_modified: '2026-04-19T12:00:00Z',
     };

--- a/web/src/__tests__/infraTypes.test.ts
+++ b/web/src/__tests__/infraTypes.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  CastellariusStatus,
+  AqueductStatus,
+  DoctorResult,
+  LogEntry,
+  LogSourceInfo,
+  RepoInfo,
+  AqueductBrief,
+  SkillInfo,
+} from '../api/types';
+
+describe('CastellariusStatus type', () => {
+  it('accepts full status', () => {
+    const status: CastellariusStatus = {
+      running: true,
+      pid: 12345,
+      uptime_seconds: 8100,
+      aqueducts: [],
+      farm_running: true,
+    };
+    expect(status.running).toBe(true);
+    expect(status.pid).toBe(12345);
+    expect(status.uptime_seconds).toBe(8100);
+  });
+
+  it('accepts status with null optional fields', () => {
+    const status: CastellariusStatus = {
+      running: false,
+      pid: null,
+      uptime_seconds: null,
+      aqueducts: [],
+      farm_running: false,
+    };
+    expect(status.running).toBe(false);
+    expect(status.pid).toBeNull();
+  });
+
+  it('accepts aqueducts with flowing status', () => {
+    const aq: AqueductStatus = {
+      name: 'default',
+      status: 'flowing',
+      droplet_id: 'ci-abc1',
+      droplet_title: 'Test droplet',
+      current_step: 'implement',
+      elapsed: 300000000000,
+    };
+    expect(aq.status).toBe('flowing');
+    expect(aq.droplet_id).toBe('ci-abc1');
+  });
+
+  it('accepts aqueducts with idle status', () => {
+    const aq: AqueductStatus = {
+      name: 'docs',
+      status: 'idle',
+      droplet_id: null,
+      droplet_title: null,
+      current_step: null,
+      elapsed: 0,
+    };
+    expect(aq.status).toBe('idle');
+    expect(aq.droplet_id).toBeNull();
+  });
+});
+
+describe('DoctorResult type', () => {
+  it('accepts check result with categories', () => {
+    const result: DoctorResult = {
+      checks: [
+        { name: 'Daemon running', status: 'pass' as const, message: 'Running (pid 123)', category: 'Daemon' },
+        { name: 'Config valid', status: 'fail' as const, message: 'Missing field X', category: 'Config' },
+        { name: 'Disk space', status: 'warn' as const, message: 'Low disk space', category: 'System' },
+      ],
+      summary: { total: 3, passed: 1 },
+      timestamp: '2026-04-19T00:00:00Z',
+    };
+    expect(result.checks).toHaveLength(3);
+    expect(result.summary.passed).toBe(1);
+    expect(result.checks[1].status).toBe('fail');
+  });
+
+  it('accepts empty check result', () => {
+    const result: DoctorResult = {
+      checks: [],
+      summary: { total: 0, passed: 0 },
+      timestamp: '',
+    };
+    expect(result.checks).toHaveLength(0);
+  });
+});
+
+describe('LogEntry type', () => {
+  it('accepts log entry with level', () => {
+    const entry: LogEntry = {
+      line: 1,
+      level: 'INFO',
+      text: '2026-04-19 12:00:01 INFO server started',
+      raw: '2026-04-19 12:00:01 INFO server started',
+    };
+    expect(entry.level).toBe('INFO');
+    expect(entry.line).toBe(1);
+  });
+
+  it('accepts log entry with empty level', () => {
+    const entry: LogEntry = {
+      line: 5,
+      level: '',
+      text: 'stack trace line',
+      raw: 'stack trace line',
+    };
+    expect(entry.level).toBe('');
+  });
+});
+
+describe('LogSourceInfo type', () => {
+  it('accepts source info', () => {
+    const info: LogSourceInfo = {
+      name: 'castellarius',
+      path: '/home/user/.cistern/castellarius.log',
+      size_bytes: 2048576,
+      last_modified: '2026-04-19T12:00:00Z',
+    };
+    expect(info.name).toBe('castellarius');
+    expect(info.size_bytes).toBeGreaterThan(0);
+  });
+});
+
+describe('RepoInfo type', () => {
+  it('accepts repo with aqueducts', () => {
+    const repo: RepoInfo = {
+      name: 'my-app',
+      prefix: 'myapp',
+      url: 'https://github.com/org/my-app',
+      aqueduct_config: '/path/to/aqueduct.yaml',
+      aqueducts: [
+        { name: 'main', steps: ['architect', 'implement', 'review', 'qa'] },
+        { name: 'docs', steps: ['docs-writer'] },
+      ],
+    };
+    expect(repo.aqueducts).toHaveLength(2);
+    expect(repo.aqueducts[0].steps).toHaveLength(4);
+  });
+
+  it('accepts repo with no aqueducts', () => {
+    const repo: RepoInfo = {
+      name: 'simple',
+      prefix: 'simple',
+      url: 'https://github.com/org/simple',
+      aqueduct_config: null,
+      aqueducts: [],
+    };
+    expect(repo.aqueduct_config).toBeNull();
+  });
+});
+
+describe('AqueductBrief type', () => {
+  it('accepts brief with steps', () => {
+    const brief: AqueductBrief = {
+      name: 'default',
+      steps: ['flag', 'implement', 'review', 'qa'],
+    };
+    expect(brief.steps).toHaveLength(4);
+  });
+});
+
+describe('SkillInfo type', () => {
+  it('accepts skill info', () => {
+    const skill: SkillInfo = {
+      name: 'cistern-git',
+      source_url: '/skills/cistern-git/SKILL.md',
+      installed_at: '2026-01-10T00:00:00Z',
+    };
+    expect(skill.name).toBe('cistern-git');
+  });
+});

--- a/web/src/__tests__/infraTypes.test.ts
+++ b/web/src/__tests__/infraTypes.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect } from 'vitest';
+import { parseLogLines } from '../components/LogViewer';
 import type {
   CastellariusStatus,
-  AqueductStatus,
   DoctorResult,
   LogEntry,
   LogSourceInfo,
   RepoInfo,
-  AqueductBrief,
   SkillInfo,
 } from '../api/types';
 
-describe('CastellariusStatus type', () => {
-  it('accepts full status', () => {
+describe('CastellariusStatus shape validation', () => {
+  it('running status has all required fields for rendering', () => {
     const status: CastellariusStatus = {
       running: true,
       pid: 12345,
@@ -19,12 +18,14 @@ describe('CastellariusStatus type', () => {
       aqueducts: [],
       farm_running: true,
     };
-    expect(status.running).toBe(true);
-    expect(status.pid).toBe(12345);
-    expect(status.uptime_seconds).toBe(8100);
+    expect(typeof status.running).toBe('boolean');
+    expect(typeof status.pid === 'number' || status.pid === null).toBe(true);
+    expect(typeof status.uptime_seconds === 'number' || status.uptime_seconds === null).toBe(true);
+    expect(Array.isArray(status.aqueducts)).toBe(true);
+    expect(typeof status.farm_running).toBe('boolean');
   });
 
-  it('accepts status with null optional fields', () => {
+  it('stopped status renders correctly with null optionals', () => {
     const status: CastellariusStatus = {
       running: false,
       pid: null,
@@ -32,100 +33,96 @@ describe('CastellariusStatus type', () => {
       aqueducts: [],
       farm_running: false,
     };
-    expect(status.running).toBe(false);
-    expect(status.pid).toBeNull();
+    const label = status.running ? 'Running' : 'Stopped';
+    expect(label).toBe('Stopped');
   });
 
-  it('accepts aqueducts with flowing status', () => {
-    const aq: AqueductStatus = {
-      name: 'default',
-      status: 'flowing',
-      droplet_id: 'ci-abc1',
-      droplet_title: 'Test droplet',
-      current_step: 'implement',
-      elapsed: 300000000000,
+  it('aqueduct with flowing status has droplet metadata', () => {
+    const status: CastellariusStatus = {
+      running: true,
+      pid: 1,
+      uptime_seconds: 0,
+      aqueducts: [{
+        name: 'default',
+        status: 'flowing',
+        droplet_id: 'ci-abc1',
+        droplet_title: 'Test droplet',
+        current_step: 'implement',
+        elapsed: 300_000_000_000,
+      }],
+      farm_running: false,
     };
-    expect(aq.status).toBe('flowing');
-    expect(aq.droplet_id).toBe('ci-abc1');
-  });
-
-  it('accepts aqueducts with idle status', () => {
-    const aq: AqueductStatus = {
-      name: 'docs',
-      status: 'idle',
-      droplet_id: null,
-      droplet_title: null,
-      current_step: null,
-      elapsed: 0,
-    };
-    expect(aq.status).toBe('idle');
-    expect(aq.droplet_id).toBeNull();
+    const flowing = status.aqueducts.filter(a => a.status === 'flowing');
+    expect(flowing).toHaveLength(1);
+    expect(flowing[0].droplet_id).toBeTruthy();
   });
 });
 
-describe('DoctorResult type', () => {
-  it('accepts check result with categories', () => {
+describe('DoctorResult rendering logic', () => {
+  it('computes pass/fail/warn counts from checks', () => {
     const result: DoctorResult = {
       checks: [
-        { name: 'Daemon running', status: 'pass' as const, message: 'Running (pid 123)', category: 'Daemon' },
-        { name: 'Config valid', status: 'fail' as const, message: 'Missing field X', category: 'Config' },
-        { name: 'Disk space', status: 'warn' as const, message: 'Low disk space', category: 'System' },
+        { name: 'Daemon running', status: 'pass', message: 'Running', category: 'Daemon' },
+        { name: 'Config valid', status: 'fail', message: 'Missing field', category: 'Config' },
+        { name: 'Disk space', status: 'warn', message: 'Low', category: 'System' },
       ],
       summary: { total: 3, passed: 1 },
       timestamp: '2026-04-19T00:00:00Z',
     };
-    expect(result.checks).toHaveLength(3);
-    expect(result.summary.passed).toBe(1);
-    expect(result.checks[1].status).toBe('fail');
+    const passes = result.checks.filter(c => c.status === 'pass').length;
+    const fails = result.checks.filter(c => c.status === 'fail').length;
+    const warns = result.checks.filter(c => c.status === 'warn').length;
+    expect(passes).toBe(1);
+    expect(fails).toBe(1);
+    expect(warns).toBe(1);
   });
 
-  it('accepts empty check result', () => {
+  it('groups checks by category', () => {
     const result: DoctorResult = {
-      checks: [],
-      summary: { total: 0, passed: 0 },
+      checks: [
+        { name: 'A', status: 'pass', message: '', category: 'Daemon' },
+        { name: 'B', status: 'pass', message: '', category: 'Daemon' },
+        { name: 'C', status: 'fail', message: '', category: 'Config' },
+      ],
+      summary: { total: 3, passed: 2 },
       timestamp: '',
     };
-    expect(result.checks).toHaveLength(0);
+    const groups = new Map<string, typeof result.checks>();
+    for (const c of result.checks) {
+      const list = groups.get(c.category) ?? [];
+      list.push(c);
+      groups.set(c.category, list);
+    }
+    expect(groups.get('Daemon')).toHaveLength(2);
+    expect(groups.get('Config')).toHaveLength(1);
   });
 });
 
-describe('LogEntry type', () => {
-  it('accepts log entry with level', () => {
-    const entry: LogEntry = {
-      line: 1,
-      level: 'INFO',
-      text: '2026-04-19 12:00:01 INFO server started',
-      raw: '2026-04-19 12:00:01 INFO server started',
-    };
-    expect(entry.level).toBe('INFO');
-    expect(entry.line).toBe(1);
+describe('LogEntry and parseLogLines integration', () => {
+  it('parseLogLines produces valid LogEntry objects', () => {
+    const entries: LogEntry[] = parseLogLines([
+      '2026-04-19 12:00:01 INFO server started',
+      'stack trace',
+    ]);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ line: 1, level: 'INFO' });
+    expect(entries[1]).toMatchObject({ line: 2, level: '' });
   });
 
-  it('accepts log entry with empty level', () => {
-    const entry: LogEntry = {
-      line: 5,
-      level: '',
-      text: 'stack trace line',
-      raw: 'stack trace line',
-    };
-    expect(entry.level).toBe('');
-  });
-});
-
-describe('LogSourceInfo type', () => {
-  it('accepts source info', () => {
+  it('LogSourceInfo has required display fields', () => {
     const info: LogSourceInfo = {
       name: 'castellarius',
       size_bytes: 2048576,
       last_modified: '2026-04-19T12:00:00Z',
     };
-    expect(info.name).toBe('castellarius');
-    expect(info.size_bytes).toBeGreaterThan(0);
+    expect(info.name).toBeTruthy();
+    expect(info.size_bytes).toBeGreaterThanOrEqual(0);
+    expect(new Date(info.last_modified).toString()).not.toBe('Invalid Date');
   });
 });
 
-describe('RepoInfo type', () => {
-  it('accepts repo with aqueducts', () => {
+describe('RepoInfo aqueduct rendering', () => {
+  it('renders step chain from aqueducts', () => {
     const repo: RepoInfo = {
       name: 'my-app',
       prefix: 'myapp',
@@ -136,11 +133,11 @@ describe('RepoInfo type', () => {
         { name: 'docs', steps: ['docs-writer'] },
       ],
     };
-    expect(repo.aqueducts).toHaveLength(2);
-    expect(repo.aqueducts[0].steps).toHaveLength(4);
+    const stepCount = repo.aqueducts.reduce((sum, aq) => sum + aq.steps.length, 0);
+    expect(stepCount).toBe(5);
   });
 
-  it('accepts repo with no aqueducts', () => {
+  it('handles repo with no aqueduct config', () => {
     const repo: RepoInfo = {
       name: 'simple',
       prefix: 'simple',
@@ -149,26 +146,19 @@ describe('RepoInfo type', () => {
       aqueducts: [],
     };
     expect(repo.aqueduct_config).toBeNull();
+    expect(repo.aqueducts).toHaveLength(0);
   });
 });
 
-describe('AqueductBrief type', () => {
-  it('accepts brief with steps', () => {
-    const brief: AqueductBrief = {
-      name: 'default',
-      steps: ['flag', 'implement', 'review', 'qa'],
-    };
-    expect(brief.steps).toHaveLength(4);
-  });
-});
-
-describe('SkillInfo type', () => {
-  it('accepts skill info', () => {
+describe('SkillInfo display fields', () => {
+  it('has name and URL for rendering', () => {
     const skill: SkillInfo = {
       name: 'cistern-git',
       source_url: '/skills/cistern-git/SKILL.md',
       installed_at: '2026-01-10T00:00:00Z',
     };
-    expect(skill.name).toBe('cistern-git');
+    expect(skill.name).toBeTruthy();
+    expect(skill.source_url).toBeTruthy();
+    expect(new Date(skill.installed_at).toString()).not.toBe('Invalid Date');
   });
 });

--- a/web/src/__tests__/logs.test.ts
+++ b/web/src/__tests__/logs.test.ts
@@ -51,6 +51,34 @@ describe('fetchLogHistory', () => {
     expect(calls[0]).not.toContain('source=app&evil');
   });
 
+  it('maps server line-numbered response to LogEntry objects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        { line: 996, text: '2026 INFO old' },
+        { line: 997, text: '2026 WARN mid' },
+        { line: 998, text: '2026 ERROR err' },
+        { line: 999, text: '2026 DEBUG dbg' },
+        { line: 1000, text: '2026 plain end' },
+      ]),
+    }));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { fetchLogHistory } = await import('../api/logs');
+    const entries = await fetchLogHistory(500, 'castellarius');
+    expect(entries).toHaveLength(5);
+    expect(entries[0]).toEqual({ line: 996, level: 'INFO', text: '2026 INFO old', raw: '2026 INFO old' });
+    expect(entries[1]).toEqual({ line: 997, level: 'WARN', text: '2026 WARN mid', raw: '2026 WARN mid' });
+    expect(entries[2]).toEqual({ line: 998, level: 'ERROR', text: '2026 ERROR err', raw: '2026 ERROR err' });
+    expect(entries[3]).toEqual({ line: 999, level: 'DEBUG', text: '2026 DEBUG dbg', raw: '2026 DEBUG dbg' });
+    expect(entries[4]).toEqual({ line: 1000, level: '', text: '2026 plain end', raw: '2026 plain end' });
+  });
+
   it('throws on non-ok response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
@@ -197,5 +225,37 @@ describe('createLogEventSource', () => {
     expect(receivedEntries).toHaveLength(2);
     expect(receivedEntries[0].line).toBe(11);
     expect(receivedEntries[1].line).toBe(42);
+  });
+
+  it('SSE overlap dedup works with absolute line numbers from history', async () => {
+    const receivedEntries: Array<{ line: number; text: string }> = [];
+    const mockEventSource = {
+      onmessage: null as ((e: { data: string }) => void) | null,
+      onerror: null as (() => void) | null,
+      close: vi.fn(),
+    };
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation(function(this: EventSource) { return mockEventSource; }));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { createLogEventSource } = await import('../api/logs');
+    const lastHistoryLine = 500;
+    createLogEventSource('castellarius', (entry) => {
+      if (entry.line <= lastHistoryLine) return;
+      receivedEntries.push({ line: entry.line, text: entry.text });
+    }, () => {});
+
+    mockEventSource.onmessage!({ data: '{"line":498,"text":"overlap-1"}' });
+    mockEventSource.onmessage!({ data: '{"line":499,"text":"overlap-2"}' });
+    mockEventSource.onmessage!({ data: '{"line":500,"text":"overlap-3"}' });
+    mockEventSource.onmessage!({ data: '{"line":501,"text":"new-1"}' });
+    mockEventSource.onmessage!({ data: '{"line":502,"text":"new-2"}' });
+    expect(receivedEntries).toHaveLength(2);
+    expect(receivedEntries[0].line).toBe(501);
+    expect(receivedEntries[1].line).toBe(502);
   });
 });

--- a/web/src/__tests__/logs.test.ts
+++ b/web/src/__tests__/logs.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('fetchLogHistory', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('encodes source parameter in URL', async () => {
+    const calls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      calls.push(url);
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    }));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { fetchLogHistory } = await import('../api/logs');
+    await fetchLogHistory(100, 'my-app');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('source=my-app');
+    expect(calls[0]).toContain('lines=100');
+  });
+
+  it('encodes special characters in source', async () => {
+    const calls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      calls.push(url);
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    }));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { fetchLogHistory } = await import('../api/logs');
+    await fetchLogHistory(50, 'app&evil=injection');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('source=app%26evil%3Dinjection');
+    expect(calls[0]).not.toContain('source=app&evil');
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { fetchLogHistory } = await import('../api/logs');
+    await expect(fetchLogHistory()).rejects.toThrow('logs: 500');
+  });
+});
+
+describe('createLogEventSource', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('encodes source parameter in SSE URL', async () => {
+    const calls: string[] = [];
+    const mockEventSource = { onmessage: null as (() => void) | null, onerror: null as (() => void) | null, close: vi.fn() };
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation((url: string) => {
+      calls.push(url);
+      return mockEventSource;
+    }));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { createLogEventSource } = await import('../api/logs');
+    createLogEventSource('my-app', () => {}, () => {});
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('source=my-app');
+  });
+
+  it('encodes special characters in SSE source', async () => {
+    const calls: string[] = [];
+    const mockEventSource = { onmessage: null as (() => void) | null, onerror: null as (() => void) | null, close: vi.fn() };
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation((url: string) => {
+      calls.push(url);
+      return mockEventSource;
+    }));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { createLogEventSource } = await import('../api/logs');
+    createLogEventSource('app&evil=injection', () => {}, () => {});
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('source=app%26evil%3Dinjection');
+    expect(calls[0]).not.toContain('source=app&evil');
+  });
+});

--- a/web/src/__tests__/logs.test.ts
+++ b/web/src/__tests__/logs.test.ts
@@ -167,4 +167,35 @@ describe('createLogEventSource', () => {
     expect(receivedEntries).toHaveLength(1);
     expect(receivedEntries[0].text).toBe('not-json');
   });
+
+  it('SSE onEntry callback filters entries by lastHistoryLine', async () => {
+    const receivedEntries: Array<{ line: number; text: string }> = [];
+    const mockEventSource = {
+      onmessage: null as ((e: { data: string }) => void) | null,
+      onerror: null as (() => void) | null,
+      close: vi.fn(),
+    };
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation(function(this: EventSource) { return mockEventSource; }));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { createLogEventSource } = await import('../api/logs');
+    const lastHistoryLine = 10;
+    createLogEventSource('castellarius', (entry) => {
+      if (entry.line <= lastHistoryLine) return;
+      receivedEntries.push({ line: entry.line, text: entry.text });
+    }, () => {});
+
+    mockEventSource.onmessage!({ data: '{"line":5,"text":"old line"}' });
+    mockEventSource.onmessage!({ data: '{"line":10,"text":"boundary line"}' });
+    mockEventSource.onmessage!({ data: '{"line":11,"text":"new line"}' });
+    mockEventSource.onmessage!({ data: '{"line":42,"text":"future line"}' });
+    expect(receivedEntries).toHaveLength(2);
+    expect(receivedEntries[0].line).toBe(11);
+    expect(receivedEntries[1].line).toBe(42);
+  });
 });

--- a/web/src/__tests__/logs.test.ts
+++ b/web/src/__tests__/logs.test.ts
@@ -113,4 +113,58 @@ describe('createLogEventSource', () => {
     expect(calls[0]).toContain('source=app%26evil%3Dinjection');
     expect(calls[0]).not.toContain('source=app&evil');
   });
+
+  it('parses JSON SSE events into LogEntry objects', async () => {
+    const receivedEntries: Array<{ line: number; level: string; text: string }> = [];
+    const mockEventSource = {
+      onmessage: null as ((e: { data: string }) => void) | null,
+      onerror: null as (() => void) | null,
+      close: vi.fn(),
+    };
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation((_url: string) => {
+      return mockEventSource;
+    }));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { createLogEventSource } = await import('../api/logs');
+    createLogEventSource('castellarius', (entry) => {
+      receivedEntries.push({ line: entry.line, level: entry.level, text: entry.text });
+    }, () => {});
+
+    mockEventSource.onmessage!({ data: '{"line":42,"text":"2026-04-19 12:00:01 INFO server started"}' });
+    expect(receivedEntries).toHaveLength(1);
+    expect(receivedEntries[0].line).toBe(42);
+    expect(receivedEntries[0].level).toBe('INFO');
+    expect(receivedEntries[0].text).toBe('2026-04-19 12:00:01 INFO server started');
+  });
+
+  it('gracefully handles unparseable SSE data', async () => {
+    const receivedEntries: Array<{ line: number; text: string }> = [];
+    const mockEventSource = {
+      onmessage: null as ((e: { data: string }) => void) | null,
+      onerror: null as (() => void) | null,
+      close: vi.fn(),
+    };
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation(() => mockEventSource));
+
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { createLogEventSource } = await import('../api/logs');
+    createLogEventSource('castellarius', (entry) => {
+      receivedEntries.push({ line: entry.line, text: entry.text });
+    }, () => {});
+
+    mockEventSource.onmessage!({ data: 'not-json' });
+    expect(receivedEntries).toHaveLength(1);
+    expect(receivedEntries[0].text).toBe('not-json');
+  });
 });

--- a/web/src/__tests__/logs.test.ts
+++ b/web/src/__tests__/logs.test.ts
@@ -76,7 +76,7 @@ describe('createLogEventSource', () => {
   it('encodes source parameter in SSE URL', async () => {
     const calls: string[] = [];
     const mockEventSource = { onmessage: null as (() => void) | null, onerror: null as (() => void) | null, close: vi.fn() };
-    vi.stubGlobal('EventSource', vi.fn().mockImplementation((url: string) => {
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation(function(this: EventSource, url: string) {
       calls.push(url);
       return mockEventSource;
     }));
@@ -96,7 +96,7 @@ describe('createLogEventSource', () => {
   it('encodes special characters in SSE source', async () => {
     const calls: string[] = [];
     const mockEventSource = { onmessage: null as (() => void) | null, onerror: null as (() => void) | null, close: vi.fn() };
-    vi.stubGlobal('EventSource', vi.fn().mockImplementation((url: string) => {
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation(function(this: EventSource, url: string) {
       calls.push(url);
       return mockEventSource;
     }));
@@ -121,7 +121,7 @@ describe('createLogEventSource', () => {
       onerror: null as (() => void) | null,
       close: vi.fn(),
     };
-    vi.stubGlobal('EventSource', vi.fn().mockImplementation((_url: string) => {
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation(function(this: EventSource, _url: string) {
       return mockEventSource;
     }));
 
@@ -150,7 +150,7 @@ describe('createLogEventSource', () => {
       onerror: null as (() => void) | null,
       close: vi.fn(),
     };
-    vi.stubGlobal('EventSource', vi.fn().mockImplementation(() => mockEventSource));
+    vi.stubGlobal('EventSource', vi.fn().mockImplementation(function(this: EventSource) { return mockEventSource; }));
 
     vi.stubGlobal('localStorage', {
       getItem: () => null,

--- a/web/src/__tests__/repos.test.ts
+++ b/web/src/__tests__/repos.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('fetchRepos', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('transforms stub repos without aqueducts', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ name: 'cistern', url: 'https://github.com/org/cistern' }]),
+    }));
+    const { fetchRepos } = await import('../api/repos');
+    const result = await fetchRepos();
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('cistern');
+    expect(result[0].url).toBe('https://github.com/org/cistern');
+    expect(result[0].aqueducts).toEqual([]);
+  });
+
+  it('passes through full repos', async () => {
+    const repos = [{
+      name: 'cistern',
+      prefix: 'ci',
+      url: 'https://github.com/org/cistern',
+      aqueduct_config: '/path/to/config',
+      aqueducts: [{ name: 'default', steps: ['flag', 'implement'] }],
+    }];
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(repos),
+    }));
+    const { fetchRepos } = await import('../api/repos');
+    const result = await fetchRepos();
+    expect(result[0].aqueducts).toHaveLength(1);
+    expect(result[0].prefix).toBe('ci');
+  });
+});
+
+describe('fetchSkills', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns skills from API', async () => {
+    const skills = [
+      { name: 'cistern-git', source_url: '/skills/cistern-git/SKILL.md', installed_at: '2026-01-10T00:00:00Z' },
+    ];
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(skills),
+    }));
+    const { fetchSkills } = await import('../api/repos');
+    const result = await fetchSkills();
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('cistern-git');
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }));
+    const { fetchSkills } = await import('../api/repos');
+    await expect(fetchSkills()).rejects.toThrow('skills: 500');
+  });
+});

--- a/web/src/api/castellarius.ts
+++ b/web/src/api/castellarius.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { getAuthHeaders } from '../hooks/useAuth';
+import type { CastellariusStatus } from './types';
+
+export async function fetchCastellariusStatus(): Promise<CastellariusStatus> {
+  const resp = await fetch('/api/castellarius/status', { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`castellarius status: ${resp.status}`);
+  const data = await resp.json();
+  if (data.aqueducts === undefined) {
+    return {
+      running: data.status === 'ok',
+      pid: null,
+      uptime_seconds: null,
+      aqueducts: [],
+      farm_running: false,
+    };
+  }
+  return data as CastellariusStatus;
+}
+
+export async function castellariusAction(action: 'start' | 'stop' | 'restart'): Promise<void> {
+  const resp = await fetch(`/api/castellarius/${action}`, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({ message: resp.statusText }));
+    throw new Error(body.message || `castellarius ${action} failed: ${resp.status}`);
+  }
+}
+
+export function useCastellariusStatus(intervalMs = 5000) {
+  const [status, setStatus] = useState<CastellariusStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const mountedRef = useRef(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await fetchCastellariusStatus();
+      if (!mountedRef.current) return;
+      setStatus(data);
+      setError(null);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    refresh();
+    const id = setInterval(refresh, intervalMs);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(id);
+    };
+  }, [refresh, intervalMs]);
+
+  return { status, loading, error, refresh };
+}

--- a/web/src/api/doctor.ts
+++ b/web/src/api/doctor.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getAuthHeaders } from '../hooks/useAuth';
+import type { DoctorResult, DoctorCheck } from './types';
+
+export async function fetchDoctor(fix = false): Promise<DoctorResult> {
+  const url = fix ? '/api/doctor?fix=true' : '/api/doctor';
+  const resp = await fetch(url, { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`doctor: ${resp.status}`);
+  const data = await resp.json();
+  if (data.checks === undefined) {
+    const checks: DoctorCheck[] = [
+      {
+        name: 'Config Valid',
+        status: data.config_ok ? 'pass' : 'fail',
+        message: data.config_ok ? 'Configuration is valid' : 'Configuration has errors',
+        category: 'Config',
+      },
+    ];
+    const repos: DoctorCheck[] = Array.isArray(data.repos)
+      ? data.repos.map((r: { name: string; url: string }) => ({
+          name: `Repo: ${r.name}`,
+          status: 'pass' as const,
+          message: r.url,
+          category: 'Repos',
+        }))
+      : [];
+    const allChecks = [...checks, ...repos];
+    return {
+      checks: allChecks,
+      summary: {
+        total: allChecks.length,
+        passed: allChecks.filter(c => c.status === 'pass').length,
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+  return data as DoctorResult;
+}
+
+export function useDoctor() {
+  const [result, setResult] = useState<DoctorResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const runDoctor = useCallback(async (fix = false) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchDoctor(fix);
+      setResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    runDoctor();
+  }, [runDoctor]);
+
+  const rerun = useCallback(() => runDoctor(false), [runDoctor]);
+  const fix = useCallback(() => runDoctor(true), [runDoctor]);
+
+  return { result, loading, error, rerun, fix };
+}

--- a/web/src/api/doctor.ts
+++ b/web/src/api/doctor.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { getAuthHeaders } from '../hooks/useAuth';
 import type { DoctorResult, DoctorCheck } from './types';
 
@@ -41,22 +41,29 @@ export function useDoctor() {
   const [result, setResult] = useState<DoctorResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const mountedRef = useRef(true);
 
   const runDoctor = useCallback(async (fix = false) => {
     setLoading(true);
     setError(null);
     try {
       const data = await fetchDoctor(fix);
+      if (!mountedRef.current) return;
       setResult(data);
     } catch (err) {
+      if (!mountedRef.current) return;
       setError(err instanceof Error ? err : new Error(String(err)));
     } finally {
-      setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     runDoctor();
+    return () => {
+      mountedRef.current = false;
+    };
   }, [runDoctor]);
 
   const rerun = useCallback(() => runDoctor(false), [runDoctor]);

--- a/web/src/api/logs.ts
+++ b/web/src/api/logs.ts
@@ -1,6 +1,11 @@
 import { getAuthHeaders, getAuthParams } from '../hooks/useAuth';
 import type { LogSourceInfo, LogEntry } from './types';
 
+interface LogHistoryItem {
+  line: number;
+  text: string;
+}
+
 interface SSELogEvent {
   line: number;
   text: string;
@@ -9,7 +14,7 @@ interface SSELogEvent {
 export async function fetchLogHistory(
   lines = 500,
   source = 'castellarius',
-): Promise<string[]> {
+): Promise<LogEntry[]> {
   const auth = getAuthParams();
   const encodedSource = encodeURIComponent(source);
   const url = auth
@@ -17,7 +22,13 @@ export async function fetchLogHistory(
     : `/api/logs?lines=${lines}&source=${encodedSource}`;
   const resp = await fetch(url, { headers: getAuthHeaders() });
   if (!resp.ok) throw new Error(`logs: ${resp.status}`);
-  return resp.json();
+  const items: LogHistoryItem[] = await resp.json();
+  return items.map(item => ({
+    line: item.line,
+    level: parseLevel(item.text),
+    text: item.text,
+    raw: item.text,
+  }));
 }
 
 export function createLogEventSource(

--- a/web/src/api/logs.ts
+++ b/web/src/api/logs.ts
@@ -1,0 +1,39 @@
+import { getAuthHeaders, getAuthParams } from '../hooks/useAuth';
+import type { LogSourceInfo } from './types';
+
+export async function fetchLogHistory(
+  lines = 500,
+  source = 'castellarius',
+): Promise<string[]> {
+  const auth = getAuthParams();
+  const url = auth
+    ? `/api/logs?lines=${lines}&source=${source}&${auth}`
+    : `/api/logs?lines=${lines}&source=${source}`;
+  const resp = await fetch(url, { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`logs: ${resp.status}`);
+  return resp.json();
+}
+
+export function createLogEventSource(
+  source: string,
+  onLine: (line: string) => void,
+  onError: (err: Error) => void,
+): EventSource {
+  const auth = getAuthParams();
+  const url = auth
+    ? `/api/logs/events?source=${source}&${auth}`
+    : `/api/logs/events?source=${source}`;
+  const es = new EventSource(url);
+  es.onmessage = (e) => onLine(e.data);
+  es.onerror = () => {
+    onError(new Error('log stream error'));
+    es.close();
+  };
+  return es;
+}
+
+export async function fetchLogSources(): Promise<LogSourceInfo[]> {
+  const resp = await fetch('/api/logs/sources', { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`log sources: ${resp.status}`);
+  return resp.json();
+}

--- a/web/src/api/logs.ts
+++ b/web/src/api/logs.ts
@@ -1,5 +1,10 @@
 import { getAuthHeaders, getAuthParams } from '../hooks/useAuth';
-import type { LogSourceInfo } from './types';
+import type { LogSourceInfo, LogEntry } from './types';
+
+interface SSELogEvent {
+  line: number;
+  text: string;
+}
 
 export async function fetchLogHistory(
   lines = 500,
@@ -17,7 +22,7 @@ export async function fetchLogHistory(
 
 export function createLogEventSource(
   source: string,
-  onLine: (line: string) => void,
+  onEntry: (entry: LogEntry) => void,
   onError: (err: Error) => void,
 ): EventSource {
   const auth = getAuthParams();
@@ -26,12 +31,34 @@ export function createLogEventSource(
     ? `/api/logs/events?source=${encodedSource}&${auth}`
     : `/api/logs/events?source=${encodedSource}`;
   const es = new EventSource(url);
-  es.onmessage = (e) => onLine(e.data);
+  es.onmessage = (e) => {
+    try {
+      const event: SSELogEvent = JSON.parse(e.data);
+      const level = parseLevel(event.text);
+      onEntry({
+        line: event.line,
+        level,
+        text: event.text,
+        raw: event.text,
+      });
+    } catch {
+      const text = e.data;
+      onEntry({ line: 1, level: '', text, raw: text });
+    }
+  };
   es.onerror = () => {
     onError(new Error('log stream error'));
     es.close();
   };
   return es;
+}
+
+const levelPattern = /\b(INFO|WARN|ERROR|DEBUG)\b/;
+
+function parseLevel(raw: string): LogEntry['level'] {
+  const m = raw.match(levelPattern);
+  if (m) return m[1] as LogEntry['level'];
+  return '';
 }
 
 export async function fetchLogSources(): Promise<LogSourceInfo[]> {

--- a/web/src/api/logs.ts
+++ b/web/src/api/logs.ts
@@ -6,9 +6,10 @@ export async function fetchLogHistory(
   source = 'castellarius',
 ): Promise<string[]> {
   const auth = getAuthParams();
+  const encodedSource = encodeURIComponent(source);
   const url = auth
-    ? `/api/logs?lines=${lines}&source=${source}&${auth}`
-    : `/api/logs?lines=${lines}&source=${source}`;
+    ? `/api/logs?lines=${lines}&source=${encodedSource}&${auth}`
+    : `/api/logs?lines=${lines}&source=${encodedSource}`;
   const resp = await fetch(url, { headers: getAuthHeaders() });
   if (!resp.ok) throw new Error(`logs: ${resp.status}`);
   return resp.json();
@@ -20,9 +21,10 @@ export function createLogEventSource(
   onError: (err: Error) => void,
 ): EventSource {
   const auth = getAuthParams();
+  const encodedSource = encodeURIComponent(source);
   const url = auth
-    ? `/api/logs/events?source=${source}&${auth}`
-    : `/api/logs/events?source=${source}`;
+    ? `/api/logs/events?source=${encodedSource}&${auth}`
+    : `/api/logs/events?source=${encodedSource}`;
   const es = new EventSource(url);
   es.onmessage = (e) => onLine(e.data);
   es.onerror = () => {

--- a/web/src/api/repos.ts
+++ b/web/src/api/repos.ts
@@ -1,0 +1,24 @@
+import { getAuthHeaders } from '../hooks/useAuth';
+import type { RepoInfo, SkillInfo } from './types';
+
+export async function fetchRepos(): Promise<RepoInfo[]> {
+  const resp = await fetch('/api/repos', { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`repos: ${resp.status}`);
+  const data = await resp.json();
+  if (Array.isArray(data) && data.length > 0 && data[0].aqueducts === undefined) {
+    return data.map((r: { name: string; url: string }) => ({
+      name: r.name,
+      prefix: '',
+      url: r.url,
+      aqueduct_config: null,
+      aqueducts: [],
+    }));
+  }
+  return data as RepoInfo[];
+}
+
+export async function fetchSkills(): Promise<SkillInfo[]> {
+  const resp = await fetch('/api/skills', { headers: getAuthHeaders() });
+  if (!resp.ok) throw new Error(`skills: ${resp.status}`);
+  return resp.json();
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -174,7 +174,6 @@ export interface LogEntry {
 
 export interface LogSourceInfo {
   name: string;
-  path: string;
   size_bytes: number;
   last_modified: string;
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -127,3 +127,68 @@ export interface DashboardData {
   farm_running: boolean;
   fetched_at: string;
 }
+
+export interface AqueductBrief {
+  name: string;
+  steps: string[];
+}
+
+export interface AqueductStatus {
+  name: string;
+  status: 'idle' | 'flowing';
+  droplet_id: string | null;
+  droplet_title: string | null;
+  current_step: string | null;
+  elapsed: number;
+}
+
+export interface CastellariusStatus {
+  running: boolean;
+  pid: number | null;
+  uptime_seconds: number | null;
+  aqueducts: AqueductStatus[];
+  farm_running: boolean;
+}
+
+export type DoctorCheckStatus = 'pass' | 'fail' | 'warn';
+
+export interface DoctorCheck {
+  name: string;
+  status: DoctorCheckStatus;
+  message: string;
+  category: string;
+}
+
+export interface DoctorResult {
+  checks: DoctorCheck[];
+  summary: { total: number; passed: number };
+  timestamp: string;
+}
+
+export interface LogEntry {
+  line: number;
+  level: 'INFO' | 'WARN' | 'ERROR' | 'DEBUG' | '';
+  text: string;
+  raw: string;
+}
+
+export interface LogSourceInfo {
+  name: string;
+  path: string;
+  size_bytes: number;
+  last_modified: string;
+}
+
+export interface RepoInfo {
+  name: string;
+  prefix: string;
+  url: string;
+  aqueduct_config: string | null;
+  aqueducts: AqueductBrief[];
+}
+
+export interface SkillInfo {
+  name: string;
+  source_url: string;
+  installed_at: string;
+}

--- a/web/src/components/ActionButton.tsx
+++ b/web/src/components/ActionButton.tsx
@@ -1,0 +1,48 @@
+import { useState, type ReactNode } from 'react';
+
+interface ActionButtonProps {
+  label: string;
+  onClick: () => Promise<void>;
+  variant?: 'primary' | 'danger' | 'default';
+  disabled?: boolean;
+  icon?: ReactNode;
+  confirm?: string;
+}
+
+const variantClasses: Record<string, string> = {
+  primary: 'bg-cistern-accent text-cistern-bg hover:bg-cistern-accent/80',
+  danger: 'bg-cistern-red text-cistern-bg hover:bg-cistern-red/80',
+  default: 'border border-cistern-border text-cistern-fg hover:bg-cistern-border/30',
+};
+
+export function ActionButton({ label, onClick, variant = 'default', disabled = false, icon, confirm }: ActionButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    if (confirm) {
+      if (!window.confirm(confirm)) return;
+    }
+    setLoading(true);
+    try {
+      await onClick();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={disabled || loading}
+      className={`inline-flex items-center gap-1.5 font-mono text-sm px-3 py-1.5 rounded-md transition-colors ${variantClasses[variant]} ${disabled || loading ? 'opacity-50 cursor-not-allowed' : ''}`}
+    >
+      {loading ? (
+        <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+        </svg>
+      ) : icon}
+      {label}
+    </button>
+  );
+}

--- a/web/src/components/HealthCheckCard.tsx
+++ b/web/src/components/HealthCheckCard.tsx
@@ -1,0 +1,41 @@
+import type { DoctorCheck } from '../api/types';
+
+interface HealthCheckCardProps {
+  check: DoctorCheck;
+}
+
+const statusIcons: Record<string, string> = {
+  pass: '✓',
+  fail: '✕',
+  warn: '⚠',
+};
+
+const statusColors: Record<string, string> = {
+  pass: 'text-cistern-green',
+  fail: 'text-cistern-red',
+  warn: 'text-cistern-yellow',
+};
+
+const borderAccents: Record<string, string> = {
+  pass: '',
+  fail: 'border-l-2 border-l-cistern-red',
+  warn: 'border-l-2 border-l-cistern-yellow',
+};
+
+export function HealthCheckCard({ check }: HealthCheckCardProps) {
+  return (
+    <div className={`bg-cistern-surface border border-cistern-border rounded-lg p-3 ${borderAccents[check.status]}`}>
+      <div className="flex items-start gap-2">
+        <span className={`text-lg ${statusColors[check.status]}`}>
+          {statusIcons[check.status]}
+        </span>
+        <div className="min-w-0">
+          <div className="font-mono text-sm text-cistern-fg">{check.name}</div>
+          {check.message && (
+            <div className="text-xs text-cistern-muted mt-0.5">{check.message}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/LogViewer.tsx
+++ b/web/src/components/LogViewer.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { LogEntry } from '../api/types';
+
+const levelPattern = /\b(INFO|WARN|ERROR|DEBUG)\b/;
+
+function parseLevel(raw: string): LogEntry['level'] {
+  const m = raw.match(levelPattern);
+  if (m) return m[1] as LogEntry['level'];
+  return '';
+}
+
+function parseLogLines(lines: string[]): LogEntry[] {
+  return lines.map((raw, i) => ({
+    line: i + 1,
+    level: parseLevel(raw),
+    text: raw,
+    raw,
+  }));
+}
+
+const levelColor: Record<string, string> = {
+  INFO: 'text-cyan-400',
+  WARN: 'text-cistern-yellow',
+  ERROR: 'text-cistern-red',
+  DEBUG: 'text-cistern-muted/50',
+  '': 'text-cistern-fg',
+};
+
+interface LogViewerProps {
+  entries: LogEntry[];
+  autoScroll?: boolean;
+  onAutoScrollChange?: (v: boolean) => void;
+  maxHeight?: string;
+  searchQuery?: string;
+}
+
+export function LogViewer({ entries, autoScroll = true, onAutoScrollChange, maxHeight = '100%', searchQuery }: LogViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [internalAutoScroll, setInternalAutoScroll] = useState(autoScroll);
+
+  useEffect(() => {
+    setInternalAutoScroll(autoScroll);
+  }, [autoScroll]);
+
+  const scrollToBottom = useCallback(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (internalAutoScroll) {
+      scrollToBottom();
+    }
+  }, [entries, internalAutoScroll, scrollToBottom]);
+
+  const handleScroll = () => {
+    if (!containerRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+    if (scrollTop < scrollHeight - clientHeight - 40) {
+      setInternalAutoScroll(false);
+      onAutoScrollChange?.(false);
+    }
+  };
+
+  const filtered = searchQuery
+    ? entries.filter(e => e.raw.toLowerCase().includes(searchQuery.toLowerCase()))
+    : entries;
+
+  const highlightText = (text: string, query: string) => {
+    if (!query) return text;
+    const idx = text.toLowerCase().indexOf(query.toLowerCase());
+    if (idx === -1) return text;
+    return (
+      <>
+        {text.slice(0, idx)}
+        <span className="bg-cistern-accent/30">{text.slice(idx, idx + query.length)}</span>
+        {text.slice(idx + query.length)}
+      </>
+    );
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      className="font-mono text-xs bg-cistern-bg text-cistern-fg overflow-y-auto"
+      style={{ maxHeight }}
+    >
+      {filtered.map((entry) => (
+        <div key={entry.line} className="flex hover:bg-cistern-surface/50">
+          <span className="text-right pr-2 select-none text-cistern-muted w-12 shrink-0">
+            {entry.line}
+          </span>
+          <span className={levelColor[entry.level] || levelColor['']}>
+            {searchQuery ? highlightText(entry.text, searchQuery) : entry.text}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export { parseLogLines };

--- a/web/src/components/StatusIndicator.tsx
+++ b/web/src/components/StatusIndicator.tsx
@@ -1,0 +1,34 @@
+interface StatusIndicatorProps {
+  status: 'running' | 'stopped' | 'error';
+  label: string;
+  size?: 'sm' | 'lg';
+}
+
+const sizeClasses = {
+  sm: { dot: 'w-2 h-2', text: 'text-sm' },
+  lg: { dot: 'w-4 h-4', text: 'text-lg' },
+};
+
+const statusClasses: Record<string, string> = {
+  running: 'bg-cistern-green',
+  stopped: 'bg-cistern-muted',
+  error: 'bg-cistern-red',
+};
+
+const labelClasses: Record<string, string> = {
+  running: 'text-cistern-green',
+  stopped: 'text-cistern-muted',
+  error: 'text-cistern-red',
+};
+
+export function StatusIndicator({ status, label, size = 'sm' }: StatusIndicatorProps) {
+  const s = sizeClasses[size];
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        className={`${s.dot} rounded-full ${statusClasses[status]} ${status === 'running' ? 'pulse-glow' : ''}`}
+      />
+      <span className={`font-mono ${s.text} ${labelClasses[status]}`}>{label}</span>
+    </div>
+  );
+}

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -14,3 +14,7 @@ export { ActionDialog } from './ActionDialog';
 export { AddNoteModal } from './AddNoteModal';
 export { EditMetadataModal } from './EditMetadataModal';
 export { RestartModal } from './RestartModal';
+export { StatusIndicator } from './StatusIndicator';
+export { ActionButton } from './ActionButton';
+export { LogViewer } from './LogViewer';
+export { HealthCheckCard } from './HealthCheckCard';

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { AppLayout } from './App';
 import { Dashboard } from './pages/Dashboard';
-import { PlaceholderPage } from './pages/Placeholder';
 import { DropletsList } from './pages/DropletsList';
 import { DropletDetail } from './pages/DropletDetail';
 import { CastellariusPage } from './pages/CastellariusPage';

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,10 @@ import { Dashboard } from './pages/Dashboard';
 import { PlaceholderPage } from './pages/Placeholder';
 import { DropletsList } from './pages/DropletsList';
 import { DropletDetail } from './pages/DropletDetail';
+import { CastellariusPage } from './pages/CastellariusPage';
+import { DoctorPage } from './pages/DoctorPage';
+import { LogsPage } from './pages/LogsPage';
+import { ReposSkillsPage } from './pages/ReposSkillsPage';
 import './index.css';
 
 const router = createBrowserRouter([
@@ -16,10 +20,10 @@ const router = createBrowserRouter([
       { index: true, element: <Dashboard /> },
       { path: 'droplets', element: <DropletsList /> },
       { path: 'droplets/:id', element: <DropletDetail /> },
-      { path: 'castellarius', element: <PlaceholderPage title="Castellarius" /> },
-      { path: 'doctor', element: <PlaceholderPage title="Doctor" /> },
-      { path: 'logs', element: <PlaceholderPage title="Logs" /> },
-      { path: 'repos', element: <PlaceholderPage title="Repos / Skills" /> },
+      { path: 'castellarius', element: <CastellariusPage /> },
+      { path: 'doctor', element: <DoctorPage /> },
+      { path: 'logs', element: <LogsPage /> },
+      { path: 'repos', element: <ReposSkillsPage /> },
     ],
   },
 ]);

--- a/web/src/pages/CastellariusPage.tsx
+++ b/web/src/pages/CastellariusPage.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import { StatusIndicator } from '../components/StatusIndicator';
+import { ActionButton } from '../components/ActionButton';
+import { useCastellariusStatus, castellariusAction } from '../api/castellarius';
+
+interface Toast {
+  message: string;
+  type: 'success' | 'error';
+}
+
+export function CastellariusPage() {
+  const { status, loading, error, refresh } = useCastellariusStatus(5000);
+  const [toast, setToast] = useState<Toast | null>(null);
+
+  const showToast = (message: string, type: Toast['type']) => {
+    setToast({ message, type });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const handleAction = async (action: 'start' | 'stop' | 'restart') => {
+    try {
+      await castellariusAction(action);
+      showToast(`${action} succeeded`, 'success');
+      refresh();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : `${action} failed`, 'error');
+    }
+  };
+
+  if (error && !status) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <div className="text-cistern-red text-lg font-mono mb-2">Connection Error</div>
+          <div className="text-cistern-muted text-sm">{error.message}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading && !status) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-cistern-muted font-mono">Loading…</div>
+      </div>
+    );
+  }
+
+  if (!status) return null;
+
+  const indicatorStatus = status.running ? 'running' : 'stopped';
+  const uptimeStr = status.uptime_seconds != null
+    ? `${Math.floor(status.uptime_seconds / 3600)}h${Math.floor((status.uptime_seconds % 3600) / 60).toString().padStart(2, '0')}m`
+    : null;
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6">
+      <section className="bg-cistern-surface border border-cistern-border rounded-lg p-4">
+        <div className="flex items-center justify-between mb-4">
+          <StatusIndicator status={indicatorStatus} label="Castellarius" size="lg" />
+          <div className="flex items-center gap-2">
+            <ActionButton
+              label="Start"
+              onClick={() => handleAction('start')}
+              variant="primary"
+              disabled={status.running}
+            />
+            <ActionButton
+              label="Stop"
+              onClick={() => handleAction('stop')}
+              variant="danger"
+              disabled={!status.running}
+            />
+            <ActionButton
+              label="Restart"
+              onClick={() => handleAction('restart')}
+              variant="danger"
+              disabled={!status.running}
+              confirm="Restart Castellarius? Active droplets will be interrupted."
+            />
+          </div>
+        </div>
+        <div className="flex items-center gap-4 text-sm text-cistern-muted font-mono">
+          {status.pid != null && <span>PID: {status.pid}</span>}
+          {uptimeStr && <span>Uptime: {uptimeStr}</span>}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-sm font-mono text-cistern-muted uppercase tracking-wider mb-3">Aqueducts</h2>
+        <div className="space-y-3">
+          {status.aqueducts.length === 0 && (
+            <div className="text-cistern-muted text-sm font-mono">No aqueducts active</div>
+          )}
+          {status.aqueducts.map((aq) => (
+            <AqueductRow key={aq.name} aqueduct={aq} />
+          ))}
+        </div>
+      </section>
+
+      <div className="flex items-center gap-2">
+        <StatusIndicator status={status.farm_running ? 'running' : 'stopped'} label={`Farm ${status.farm_running ? 'Running' : 'Stopped'}`} />
+      </div>
+
+      {toast && (
+        <div className={`fixed bottom-4 right-4 bg-cistern-surface border border-cistern-border rounded-lg p-3 font-mono text-sm ${
+          toast.type === 'success' ? 'text-cistern-green' : 'text-cistern-red'
+        }`}>
+          {toast.message}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AqueductRow({ aqueduct }: { aqueduct: { name: string; status: string; droplet_id: string | null; droplet_title: string | null; current_step: string | null; elapsed: number } }) {
+  const elapsedSec = Math.floor(aqueduct.elapsed / 1e9);
+  const elapsedStr = elapsedSec >= 3600
+    ? `${Math.floor(elapsedSec / 3600)}h${Math.floor((elapsedSec % 3600) / 60).toString().padStart(2, '0')}m`
+    : `${Math.floor(elapsedSec / 60)}:${(elapsedSec % 60).toString().padStart(2, '0')}`;
+
+  return (
+    <div className={`bg-cistern-surface border rounded-lg p-4 ${
+      aqueduct.status === 'flowing' ? 'border-cistern-accent/40' : 'border-cistern-border'
+    }`}>
+      <div className="flex items-center justify-between mb-2">
+        <a href="/app/" className="font-mono font-bold text-cistern-fg hover:text-cistern-accent">
+          {aqueduct.name}
+        </a>
+        <span className={`text-xs font-mono px-2 py-0.5 rounded-full ${
+          aqueduct.status === 'flowing'
+            ? 'bg-cistern-green/20 text-cistern-green'
+            : 'bg-cistern-muted/20 text-cistern-muted'
+        }`}>
+          {aqueduct.status}
+        </span>
+      </div>
+      {aqueduct.droplet_id && aqueduct.status === 'flowing' && (
+        <div className="text-sm font-mono">
+          <span className="text-cistern-green">{aqueduct.droplet_id}</span>
+          {aqueduct.droplet_title && (
+            <>
+              <span className="text-cistern-muted mx-2">·</span>
+              <span className="text-cistern-fg">{aqueduct.droplet_title}</span>
+            </>
+          )}
+          {aqueduct.current_step && (
+            <>
+              <span className="text-cistern-muted mx-2">·</span>
+              <span className="text-cistern-accent">{aqueduct.current_step}</span>
+            </>
+          )}
+          <span className="text-cistern-muted mx-2">·</span>
+          <span className="text-cistern-muted">{elapsedStr}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/CastellariusPage.tsx
+++ b/web/src/pages/CastellariusPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { StatusIndicator } from '../components/StatusIndicator';
 import { ActionButton } from '../components/ActionButton';
 import { useCastellariusStatus, castellariusAction } from '../api/castellarius';
@@ -11,11 +11,26 @@ interface Toast {
 export function CastellariusPage() {
   const { status, loading, error, refresh } = useCastellariusStatus(5000);
   const [toast, setToast] = useState<Toast | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const showToast = (message: string, type: Toast['type']) => {
+  const showToast = useCallback((message: string, type: Toast['type']) => {
+    if (toastTimerRef.current !== null) {
+      clearTimeout(toastTimerRef.current);
+    }
     setToast({ message, type });
-    setTimeout(() => setToast(null), 3000);
-  };
+    toastTimerRef.current = setTimeout(() => {
+      toastTimerRef.current = null;
+      setToast(null);
+    }, 3000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current !== null) {
+        clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleAction = async (action: 'start' | 'stop' | 'restart') => {
     try {

--- a/web/src/pages/DoctorPage.tsx
+++ b/web/src/pages/DoctorPage.tsx
@@ -1,0 +1,79 @@
+import { useDoctor } from '../api/doctor';
+import type { DoctorCheck } from '../api/types';
+import { HealthCheckCard } from '../components/HealthCheckCard';
+import { ActionButton } from '../components/ActionButton';
+
+export function DoctorPage() {
+  const { result, loading, error, rerun, fix } = useDoctor();
+
+  if (error && !result) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <div className="text-cistern-red text-lg font-mono mb-2">Error</div>
+          <div className="text-cistern-muted text-sm">{error.message}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading && !result) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-cistern-muted font-mono">Running health checks…</div>
+      </div>
+    );
+  }
+
+  if (!result) return null;
+
+  const categories = groupByCategory(result.checks);
+  const summaryColor = result.summary.passed === result.summary.total
+    ? 'text-cistern-green'
+    : result.checks.some(c => c.status === 'fail')
+    ? 'text-cistern-red'
+    : 'text-cistern-yellow';
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6">
+      <section className="bg-cistern-surface border border-cistern-border rounded-lg p-4">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-mono text-cistern-muted uppercase tracking-wider">Health Checks</h2>
+          <div className="flex gap-2">
+            <ActionButton label="Re-run" onClick={rerun} />
+            <ActionButton label="Fix" onClick={fix} variant="primary" />
+          </div>
+        </div>
+        <div className={`text-lg font-mono font-bold ${summaryColor}`}>
+          {result.summary.passed}/{result.summary.total} passed
+        </div>
+        {result.timestamp && (
+          <div className="text-xs text-cistern-muted font-mono mt-1">
+            Last checked: {new Date(result.timestamp).toLocaleString()}
+          </div>
+        )}
+      </section>
+
+      {Object.entries(categories).map(([category, checks]) => (
+        <section key={category}>
+          <h3 className="text-sm font-mono text-cistern-muted uppercase tracking-wider mb-2">{category}</h3>
+          <div className="space-y-2">
+            {checks.map((check) => (
+              <HealthCheckCard key={check.name} check={check} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function groupByCategory(checks: DoctorCheck[]): Record<string, DoctorCheck[]> {
+  const groups: Record<string, DoctorCheck[]> = {};
+  for (const check of checks) {
+    const cat = check.category || 'General';
+    if (!groups[cat]) groups[cat] = [];
+    groups[cat].push(check);
+  }
+  return groups;
+}

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { LogViewer, parseLogLines } from '../components/LogViewer';
+import { LogViewer } from '../components/LogViewer';
 import { fetchLogHistory, createLogEventSource, fetchLogSources } from '../api/logs';
 import type { LogEntry, LogSourceInfo } from '../api/types';
 
@@ -27,11 +27,10 @@ export function LogsPage() {
     setLoading(true);
     setError(null);
     try {
-      const lines = await fetchLogHistory(500, source);
+      const logEntries = await fetchLogHistory(500, source);
       if (sourceRef.current !== source) return;
-      const parsed = parseLogLines(lines);
-      lastHistoryLine.current = parsed.length > 0 ? parsed[parsed.length - 1].line : 0;
-      setEntries(parsed);
+      lastHistoryLine.current = logEntries.length > 0 ? logEntries[logEntries.length - 1].line : 0;
+      setEntries(logEntries);
     } catch (err) {
       if (sourceRef.current !== source) return;
       setError(err instanceof Error ? err : new Error(String(err)));

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -27,11 +27,13 @@ export function LogsPage() {
     setError(null);
     try {
       const lines = await fetchLogHistory(500, source);
+      if (sourceRef.current !== source) return;
       setEntries(parseLogLines(lines));
     } catch (err) {
+      if (sourceRef.current !== source) return;
       setError(err instanceof Error ? err : new Error(String(err)));
     } finally {
-      setLoading(false);
+      if (sourceRef.current === source) setLoading(false);
     }
   }, []);
 

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -13,6 +13,7 @@ export function LogsPage() {
   const [error, setError] = useState<Error | null>(null);
   const esRef = useRef<EventSource | null>(null);
   const sourceRef = useRef(activeSource);
+  const lastHistoryLine = useRef(0);
 
   useEffect(() => {
     sourceRef.current = activeSource;
@@ -28,7 +29,9 @@ export function LogsPage() {
     try {
       const lines = await fetchLogHistory(500, source);
       if (sourceRef.current !== source) return;
-      setEntries(parseLogLines(lines));
+      const parsed = parseLogLines(lines);
+      lastHistoryLine.current = parsed.length > 0 ? parsed[parsed.length - 1].line : 0;
+      setEntries(parsed);
     } catch (err) {
       if (sourceRef.current !== source) return;
       setError(err instanceof Error ? err : new Error(String(err)));
@@ -39,6 +42,8 @@ export function LogsPage() {
 
   useEffect(() => {
     const source = activeSource;
+    lastHistoryLine.current = 0;
+    setEntries([]);
     loadHistory(source);
 
     if (esRef.current) {
@@ -50,6 +55,7 @@ export function LogsPage() {
       source,
       (entry) => {
         if (sourceRef.current !== source) return;
+        if (entry.line <= lastHistoryLine.current) return;
         setEntries(prev => [...prev, entry]);
       },
       (err) => {

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,0 +1,145 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { LogViewer, parseLogLines } from '../components/LogViewer';
+import { fetchLogHistory, createLogEventSource, fetchLogSources } from '../api/logs';
+import type { LogEntry, LogSourceInfo } from '../api/types';
+
+export function LogsPage() {
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [sources, setSources] = useState<LogSourceInfo[]>([]);
+  const [activeSource, setActiveSource] = useState('castellarius');
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    fetchLogSources().then(setSources).catch(() => {});
+  }, []);
+
+  const loadHistory = useCallback(async (source: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const lines = await fetchLogHistory(500, source);
+      setEntries(parseLogLines(lines));
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadHistory(activeSource);
+
+    if (esRef.current) {
+      esRef.current.close();
+    }
+    esRef.current = createLogEventSource(
+      activeSource,
+      (line) => {
+        const parsed = parseLogLines([line]);
+        setEntries(prev => [...prev, ...parsed]);
+      },
+      (err) => {
+        setError(err);
+      },
+    );
+
+    return () => {
+      if (esRef.current) {
+        esRef.current.close();
+        esRef.current = null;
+      }
+    };
+  }, [activeSource, loadHistory]);
+
+  const handleSourceChange = (source: string) => {
+    setActiveSource(source);
+    setAutoScroll(true);
+  };
+
+  const clearEntries = () => {
+    setEntries([]);
+  };
+
+  const activeSourceInfo = sources.find(s => s.name === activeSource);
+
+  if (error && entries.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <div className="text-cistern-red text-lg font-mono mb-2">Error</div>
+          <div className="text-cistern-muted text-sm">{error.message}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-4 px-4 md:px-6 py-3 border-b border-cistern-border bg-cistern-surface/50">
+        <select
+          value={activeSource}
+          onChange={e => handleSourceChange(e.target.value)}
+          className="bg-cistern-surface border border-cistern-border text-cistern-fg font-mono text-sm rounded-md px-2 py-1"
+        >
+          {sources.length === 0 && <option value="castellarius">castellarius</option>}
+          {sources.map(s => (
+            <option key={s.name} value={s.name}>{s.name}</option>
+          ))}
+        </select>
+        {activeSourceInfo && (
+          <div className="text-xs text-cistern-muted font-mono">
+            {formatBytes(activeSourceInfo.size_bytes)} · {new Date(activeSourceInfo.last_modified).toLocaleString()}
+          </div>
+        )}
+        <div className="flex-1" />
+        <input
+          type="text"
+          placeholder="Filter…"
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          className="bg-cistern-bg border border-cistern-border text-cistern-fg font-mono text-xs px-2 py-1 rounded-md w-32"
+        />
+        <label className="flex items-center gap-1 text-xs font-mono text-cistern-muted cursor-pointer">
+          <input
+            type="checkbox"
+            checked={autoScroll}
+            onChange={e => setAutoScroll(e.target.checked)}
+            className="accent-cistern-accent"
+          />
+          Auto-scroll
+        </label>
+        <button
+          onClick={clearEntries}
+          className="text-xs font-mono text-cistern-muted hover:text-cistern-fg border border-cistern-border rounded-md px-2 py-1 transition-colors"
+        >
+          Clear
+        </button>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {loading && entries.length === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <div className="text-cistern-muted font-mono">Loading logs…</div>
+          </div>
+        ) : (
+          <LogViewer
+            entries={entries}
+            autoScroll={autoScroll}
+            onAutoScrollChange={setAutoScroll}
+            maxHeight="100%"
+            searchQuery={searchQuery}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -12,6 +12,11 @@ export function LogsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const esRef = useRef<EventSource | null>(null);
+  const sourceRef = useRef(activeSource);
+
+  useEffect(() => {
+    sourceRef.current = activeSource;
+  }, [activeSource]);
 
   useEffect(() => {
     fetchLogSources().then(setSources).catch(() => {});
@@ -31,18 +36,22 @@ export function LogsPage() {
   }, []);
 
   useEffect(() => {
-    loadHistory(activeSource);
+    const source = activeSource;
+    loadHistory(source);
 
     if (esRef.current) {
       esRef.current.close();
+      esRef.current = null;
     }
+
     esRef.current = createLogEventSource(
-      activeSource,
-      (line) => {
-        const parsed = parseLogLines([line]);
-        setEntries(prev => [...prev, ...parsed]);
+      source,
+      (entry) => {
+        if (sourceRef.current !== source) return;
+        setEntries(prev => [...prev, entry]);
       },
       (err) => {
+        if (sourceRef.current !== source) return;
         setError(err);
       },
     );

--- a/web/src/pages/ReposSkillsPage.tsx
+++ b/web/src/pages/ReposSkillsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { fetchRepos, fetchSkills } from '../api/repos';
 import type { RepoInfo, SkillInfo } from '../api/types';
 
@@ -7,16 +7,24 @@ export function ReposSkillsPage() {
   const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
     setLoading(true);
     Promise.all([fetchRepos(), fetchSkills()])
       .then(([r, s]) => {
+        if (!mountedRef.current) return;
         setRepos(r);
         setSkills(s);
       })
-      .catch(err => setError(err instanceof Error ? err : new Error(String(err))))
-      .finally(() => setLoading(false));
+      .catch(err => {
+        if (!mountedRef.current) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      })
+      .finally(() => {
+        if (mountedRef.current) setLoading(false);
+      });
+    return () => { mountedRef.current = false; };
   }, []);
 
   if (error && repos.length === 0 && skills.length === 0) {

--- a/web/src/pages/ReposSkillsPage.tsx
+++ b/web/src/pages/ReposSkillsPage.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect } from 'react';
+import { fetchRepos, fetchSkills } from '../api/repos';
+import type { RepoInfo, SkillInfo } from '../api/types';
+
+export function ReposSkillsPage() {
+  const [repos, setRepos] = useState<RepoInfo[]>([]);
+  const [skills, setSkills] = useState<SkillInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([fetchRepos(), fetchSkills()])
+      .then(([r, s]) => {
+        setRepos(r);
+        setSkills(s);
+      })
+      .catch(err => setError(err instanceof Error ? err : new Error(String(err))))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (error && repos.length === 0 && skills.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <div className="text-cistern-red text-lg font-mono mb-2">Error</div>
+          <div className="text-cistern-muted text-sm">{error.message}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-cistern-muted font-mono">Loading…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-8">
+      <section>
+        <h2 className="text-sm font-mono text-cistern-muted uppercase tracking-wider mb-3">Repositories</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {repos.map(repo => (
+            <div key={repo.name} className="bg-cistern-surface border border-cistern-border rounded-lg p-4">
+              <div className="font-mono font-bold text-cistern-fg mb-2">{repo.name}</div>
+              <div className="text-xs text-cistern-muted font-mono space-y-1">
+                {repo.prefix && <div>Prefix: {repo.prefix}</div>}
+                <div>
+                  URL:{' '}
+                  <a href={repo.url} target="_blank" rel="noopener noreferrer" className="text-cistern-accent hover:underline">
+                    {repo.url}
+                  </a>
+                </div>
+              </div>
+              {repo.aqueducts.length > 0 && (
+                <div className="mt-3 space-y-1">
+                  <div className="text-xs text-cistern-muted font-mono uppercase">Aqueducts</div>
+                  {repo.aqueducts.map(aq => (
+                    <div key={aq.name} className="text-xs font-mono text-cistern-fg">
+                      <span className="text-cistern-accent">{aq.name}</span>
+                      {aq.steps.length > 0 && (
+                        <span className="text-cistern-muted"> · {aq.steps.join(' → ')}</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+          {repos.length === 0 && (
+            <div className="text-cistern-muted text-sm font-mono">No repositories configured</div>
+          )}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-sm font-mono text-cistern-muted uppercase tracking-wider mb-3">Skills</h2>
+        {skills.length === 0 ? (
+          <div className="text-cistern-muted text-sm font-mono">No skills installed</div>
+        ) : (
+          <div className="bg-cistern-surface border border-cistern-border rounded-lg overflow-hidden">
+            <table className="w-full text-sm font-mono">
+              <thead>
+                <tr className="border-b border-cistern-border">
+                  <th className="text-left text-cistern-muted px-4 py-2 text-xs uppercase">Name</th>
+                  <th className="text-left text-cistern-muted px-4 py-2 text-xs uppercase">Source</th>
+                  <th className="text-left text-cistern-muted px-4 py-2 text-xs uppercase">Installed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {skills.map((skill, i) => (
+                  <tr key={skill.name} className={i % 2 === 1 ? 'bg-cistern-surface/50' : ''}>
+                    <td className="px-4 py-2 text-cistern-fg">{skill.name}</td>
+                    <td className="px-4 py-2 text-cistern-muted">{skill.source_url}</td>
+                    <td className="px-4 py-2 text-cistern-muted">{new Date(skill.installed_at).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds four operator-facing infrastructure pages to the web dashboard: Castellarius control (`/app/castellarius`), Doctor health checks (`/app/doctor`), real-time log viewer (`/app/logs`), and Repos/Skills browser (`/app/repos`)
- Implements Go-side SSE log streaming with `GET /api/logs`, `GET /api/logs/events`, and `GET /api/logs/sources` endpoints
- Security hardening: path traversal protection via whitelist validation, URL parameter encoding, generic error messages, json.Marshal SSE sanitization, separate connection pools (64 droplet SSE + 32 log SSE), 20-retry limit for missing files, 5000 line cap, 1MB scanner buffer, log rotation detection with offset reset
- Shared reusable components: StatusIndicator, ActionButton, LogViewer, HealthCheckCard
- 166 frontend tests, all Go tests passing, tsc --noEmit clean

Closes ci-3pou0