### PR TITLE
fix: each cataractae owns its own recirculation feedback

### DIFF
--- a/cataractae/architect/INSTRUCTIONS.md
+++ b/cataractae/architect/INSTRUCTIONS.md
@@ -316,3 +316,11 @@ implementer with the existing brief.
 The implementer will receive your brief via revision notes. Your brief is
 mandatory — the implementer must address every item in the API Surface
 Checklist before they can pass.
+
+## Recirculation Ownership
+
+Each cataractae owns its own feedback. When a droplet is recirculated back to you:
+
+- **You verify YOUR brief requirements** — if the implementer could not satisfy a brief item, revise the brief to either relax an impossible constraint or add a more specific one
+- **You do NOT validate other cataractae's feedback** — if Review, QA, or Security flagged issues downstream, that is their domain. They will verify their own feedback when the droplet reaches them
+- **If the brief is already correct**, do NOT change it — signal pass and let the recirculation go to the implementer with the existing brief

--- a/cataractae/implementer/INSTRUCTIONS.md
+++ b/cataractae/implementer/INSTRUCTIONS.md
@@ -170,3 +170,11 @@ Every one is mechanical — the answer is either yes or no.
 Address every open issue from prior cycles — partial fixes will be sent back.
 Fix the code to make failing tests pass — never remove tests to make the suite
 pass. Mention each addressed issue in your outcome notes.
+
+## Recirculation Ownership
+
+When multiple cataractae have sent the droplet back, you will see feedback from
+all of them. Address ALL of it — every cataractae's feedback is valid and must
+be fixed before you pass. Each downstream cataractae will verify its own
+feedback when the droplet reaches it again, so make sure each concern is
+actually resolved, not just partially addressed.

--- a/cataractae/qa/INSTRUCTIONS.md
+++ b/cataractae/qa/INSTRUCTIONS.md
@@ -90,6 +90,16 @@ A test name that doesn't describe behaviour (`TestFoo`) means the author was thi
 
 Failing tests are an automatic recirculate. Passing tests are the floor, not the ceiling.
 
+## Recirculation Ownership
+
+Each cataractae owns its own feedback. When a droplet is recirculated:
+
+- **You verify YOUR findings** — if QA previously recirculated, check that QA's feedback was addressed
+- **You do NOT validate other cataractae's feedback** — if Review or Security flagged issues, that is their domain. They will verify their own feedback when the droplet reaches them
+- **You check for newly introduced QA issues** — when code changes to address Review or Security feedback, new QA regressions may be introduced. That is your job to catch
+
+Do not waste time assessing whether a security vulnerability was properly fixed — Security will do that. Do not assess whether a code review concern was addressed — Review will do that. Check for what QA checks: test quality, contract violations, integration gaps, placeholder implementations, and newly introduced regressions in your domain.
+
 ## Findings Have No Severity Tiers
 
 Every finding is either "needs fixing" (recirculate) or "doesn't need fixing" (don't mention it). There is no third category.

--- a/cataractae/reviewer/INSTRUCTIONS.md
+++ b/cataractae/reviewer/INSTRUCTIONS.md
@@ -150,6 +150,16 @@ Review for **unnecessary complexity**: obvious comments, lazy naming, copy-paste
 
 Skip: style/formatting (a linter's job), whether the change is a good idea (requirements fit is out of scope), naming preferences unless a name is actively misleading.
 
+## Recirculation Ownership
+
+Each cataractae owns its own feedback. When a droplet is recirculated:
+
+- **You verify YOUR findings** — if Review previously recirculated, check that Review's feedback was addressed
+- **You do NOT validate other cataractae's feedback** — if QA or Security flagged issues, that is their domain. They will verify their own feedback when the droplet reaches them
+- **You check for newly introduced review issues** — when code changes to address QA or Security feedback, new correctness or structural problems may be introduced. That is your job to catch
+
+Do not assess whether test coverage is sufficient — QA will do that. Do not assess whether a security vulnerability was properly fixed — Security will do that. Check for what Review checks: contract violations, structural problems, correctness, unnecessary complexity, and newly introduced regressions in your domain.
+
 ## Evidence Over Claims
 
 You must demonstrate that you reviewed the code, not just claim it. For every finding:

--- a/cataractae/security/INSTRUCTIONS.md
+++ b/cataractae/security/INSTRUCTIONS.md
@@ -34,3 +34,13 @@ For every code path in the diff, ask these questions — they naturally cover th
 - **What crosses a trust boundary?** Data from HTTP requests, database results used in queries, file paths from config — each crossing is an injection point.
 
 Skip: style, naming, code organization, performance (unless a DoS vector), missing features, business logic correctness.
+
+## Recirculation Ownership
+
+Each cataractae owns its own feedback. When a droplet is recirculated:
+
+- **You verify YOUR findings** — if Security previously recirculated, check that Security's feedback was addressed
+- **You do NOT validate other cataractae's feedback** — if Review or QA flagged issues, that is their domain. They will verify their own feedback when the droplet reaches them
+- **You check for newly introduced security issues** — when code changes to address Review or QA feedback, new security vulnerabilities may be introduced. That is your job to catch
+
+Do not assess whether code follows conventions — Review will do that. Do not assess whether test coverage is sufficient — QA will do that. Check for what Security checks: auth bypass, injection, secrets exposure, data exposure, and resource safety vectors.

--- a/internal/cataractae/context.go
+++ b/internal/cataractae/context.go
@@ -225,10 +225,11 @@ func writeContextFile(path string, p ContextParams) error {
 	if isReviewer && len(ownIssues) > 0 {
 		// Reviewer with own DB-tracked open issues: two-phase structure.
 		// Phase 1 is evidence-based verification — no opinions, just grep/test results.
-		// Phase 2 is a clean fresh review of the diff for new issues.
+		// Phase 2 is a clean fresh review of the diff for new issues IN YOUR DOMAIN ONLY.
 		b.WriteString("## ⚠️ TWO-PHASE REVIEW — Read carefully before doing anything\n\n")
-		b.WriteString("This droplet was recirculated after a prior review. You have TWO distinct jobs:\n\n")
-		b.WriteString("### Phase 1 — Verify prior issues are resolved\n\n")
+		b.WriteString("This droplet was recirculated. You have TWO distinct jobs:\n\n")
+		b.WriteString("### Phase 1 — Verify YOUR prior issues are resolved\n\n")
+		b.WriteString("These are issues YOU flagged previously. Verify each one with evidence.\n")
 		b.WriteString("For EACH issue below, run the exact check (grep, test, cat) and call:\n")
 		b.WriteString("- `ct droplet issue resolve <id> --evidence \"<command + output>\"` — if fixed\n")
 		b.WriteString("- `ct droplet issue reject <id> --evidence \"<command + output>\"` — if still present\n\n")
@@ -239,17 +240,20 @@ func writeContextFile(path string, p ContextParams) error {
 			b.WriteString(iss.Description)
 			b.WriteString("\n\n")
 		}
-		b.WriteString("### Phase 2 — Fresh review of new changes\n\n")
-		b.WriteString("After completing Phase 1, do a full adversarial review of the diff for NEW issues.\n")
+		b.WriteString("### Phase 2 — Fresh review of new changes in YOUR domain\n\n")
+		b.WriteString("After completing Phase 1, do a full review of the diff — but ONLY for issues\n")
+		b.WriteString("that fall within YOUR area of expertise. Do NOT attempt to validate feedback\n")
+		b.WriteString("from other cataractae — each cataractae verifies its own feedback when the\n")
+		b.WriteString("droplet reaches it.\n")
 		b.WriteString("Do NOT re-examine issues from Phase 1 — they are already handled.\n")
-		b.WriteString("For each new finding: `ct droplet issue add " + p.Item.ID + " \"<description>\"`\n")
-		b.WriteString("Treat this as a clean review of a fresh diff.\n\n")
+		b.WriteString("For each new finding: `ct droplet issue add " + p.Item.ID + " \"<description>\"`\n\n")
 		b.WriteString("---\n\n")
 	} else if isReviewer && len(revisionNotes) > 0 {
 		// Fallback: reviewer with free-text notes but no DB issues (legacy path).
 		b.WriteString("## ⚠️ TWO-PHASE REVIEW — Read carefully before doing anything\n\n")
-		b.WriteString("This droplet was recirculated after a prior review. You have TWO distinct jobs:\n\n")
-		b.WriteString("### Phase 1 — Verify prior issues are resolved\n\n")
+		b.WriteString("This droplet was recirculated. You have TWO distinct jobs:\n\n")
+		b.WriteString("### Phase 1 — Verify YOUR prior issues are resolved\n\n")
+		b.WriteString("These are issues YOU flagged previously. Verify each one with evidence.\n")
 		b.WriteString("For EACH issue below, run the exact check (grep, test, cat) and output:\n")
 		b.WriteString("- `RESOLVED: <evidence>` — paste the command and output proving it is fixed\n")
 		b.WriteString("- `UNRESOLVED: <evidence>` — paste the command and output proving it is still present\n\n")
@@ -260,13 +264,23 @@ func writeContextFile(path string, p ContextParams) error {
 			b.WriteString(n.Content)
 			b.WriteString("\n\n")
 		}
-		b.WriteString("### Phase 2 — Fresh review of new changes\n\n")
-		b.WriteString("After completing Phase 1, do a full adversarial review of the diff for NEW issues.\n")
-		b.WriteString("Do NOT re-examine issues from Phase 1 — they are already handled.\n")
-		b.WriteString("Treat this as a clean review of a fresh diff.\n\n")
+		b.WriteString("### Phase 2 — Fresh review of new changes in YOUR domain\n\n")
+		b.WriteString("After completing Phase 1, do a full review of the diff — but ONLY for issues\n")
+		b.WriteString("that fall within YOUR area of expertise. Do NOT attempt to validate feedback\n")
+		b.WriteString("from other cataractae — each cataractae verifies its own feedback when the\n")
+		b.WriteString("droplet reaches it.\n")
+		b.WriteString("Do NOT re-examine issues from Phase 1 — they are already handled.\n\n")
+		b.WriteString("---\n\n")
+	} else if isReviewer && len(otherIssues) > 0 {
+		// Reviewer with no own issues but other cataractae recirculated the droplet.
+		// Tell them what happened so they know to do a fresh domain-specific review.
+		b.WriteString("## Recirculation Context\n\n")
+		b.WriteString("This droplet was recirculated by another cataractae (not you). Your job is to do a\n")
+		b.WriteString("fresh review in YOUR domain only. Do NOT try to validate the other cataractae's\n")
+		b.WriteString("feedback — they will verify their own feedback when the droplet reaches them.\n\n")
 		b.WriteString("---\n\n")
 	} else if !isReviewer && len(revisionNotes) > 0 {
-		// Implementer/QA with prior issues: surface fixes at the top.
+		// Implementer with prior reviewer feedback: surface fixes at the top.
 		// Filter out non-actionable "no findings" notes to reduce noise.
 		actionableNotes := filterActionableRevisionNotes(revisionNotes)
 		if len(actionableNotes) > 0 {
@@ -283,18 +297,25 @@ func writeContextFile(path string, p ContextParams) error {
 	}
 
 	// Background section: open issues from other cataractae — for reviewer steps only.
-	// These are shown for context; the current reviewer must NOT resolve or reject them.
 	// Fix ci-0y5ha: foreign issues are never mixed into Phase 1.
+	// Show only a summary (who + count), not full descriptions. Full descriptions
+	// let non-expert cataractae try to validate domain-specific feedback they
+	// are not qualified to assess (e.g., QA trying to validate security findings).
+	// The originating cataractae will verify its own feedback when the droplet
+	// reaches it again.
 	if isReviewer && len(otherIssues) > 0 {
-		b.WriteString("## Background — Open Issues from Other Cataractae (read-only)\n\n")
-		b.WriteString("These issues were flagged by other cataractae. Do NOT resolve or reject them —\n")
-		b.WriteString("they are provided for context only. Only the cataractae that flagged them can verify them.\n\n")
-		for i, iss := range otherIssues {
-			b.WriteString(fmt.Sprintf("### [Background] Issue %d — %s (flagged by: %s)\n\n", i+1, iss.ID, iss.FlaggedBy))
-			b.WriteString(iss.Description)
-			b.WriteString("\n\n")
+		bySource := make(map[string]int)
+		for _, iss := range otherIssues {
+			bySource[iss.FlaggedBy]++
 		}
-		b.WriteString("---\n\n")
+		b.WriteString("## Background — Open Issues from Other Cataractae\n\n")
+		b.WriteString("Other cataractae have unresolved issues with this droplet. You must NOT try to\n")
+		b.WriteString("validate or assess these — each cataractae verifies its own feedback when the\n")
+		b.WriteString("droplet reaches it. Your job is to check for issues in YOUR domain only.\n\n")
+		for source, count := range bySource {
+			b.WriteString(fmt.Sprintf("- **%s**: %d open issue(s)\n", source, count))
+		}
+		b.WriteString("\n---\n\n")
 	}
 
 	// Partition notes in one pass:

--- a/internal/cataractae/context_test.go
+++ b/internal/cataractae/context_test.go
@@ -427,13 +427,14 @@ func TestWriteContextFile_Phase1OnlyContainsOwnIssues(t *testing.T) {
 		t.Error("qa issue must NOT appear in Phase 1 of security's context (cross-contamination: ci-0y5ha)")
 	}
 
-	// qa issue must appear in a read-only background section, not silently dropped.
-	if !strings.Contains(got, "Missing unit tests for auth module") {
-		t.Error("qa issue must appear in a read-only background section")
+	// qa issue must appear as a summary in the background section (who + count, not full description).
+	if !strings.Contains(got, "**qa**: 1 open issue(s)") {
+		t.Error("qa issue must appear as a summary line in the background section")
 	}
-	// The background section must include the qa issue ID.
-	if !strings.Contains(got, "qa-abc02") {
-		t.Error("qa issue ID must appear in the background section")
+	// The background section must NOT include the full issue description —
+	// that would let non-expert cataractae try to validate domain-specific feedback.
+	if strings.Contains(got, "Missing unit tests for auth module") {
+		t.Error("qa issue description must NOT appear in the background section (summary only)")
 	}
 }
 
@@ -582,9 +583,17 @@ func TestWriteContextFile_NoTwoPhaseWhenOnlyForeignIssues(t *testing.T) {
 		t.Error("security must NOT be instructed to reject qa's issues")
 	}
 
-	// qa issue must still be visible as background context.
-	if !strings.Contains(got, "Test coverage below threshold") {
-		t.Error("qa issue must appear in read-only background section even when security has no own issues")
+	// qa issue must appear as a summary in the background section (who + count, not full description).
+	if !strings.Contains(got, "**qa**: 1 open issue(s)") {
+		t.Error("qa issue must appear as a summary line in the background section even when security has no own issues")
+	}
+	// The full description must NOT appear — summary only prevents cross-domain validation.
+	if strings.Contains(got, "Test coverage below threshold") {
+		t.Error("qa issue description must NOT appear in the background section (summary only)")
+	}
+	// The recirculation context header must appear since security has no own issues but other cataractae recirculated.
+	if !strings.Contains(got, "Recirculation Context") {
+		t.Error("security must get recirculation context when it has no own issues but other cataractae recirculated")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **CONTEXT.md Background section** now shows summary-only (who + count) instead of full issue descriptions, preventing non-expert cataractae (e.g., QA) from trying to validate domain-specific feedback (e.g., Security findings) they can't properly assess
- **New recirculation context branch** for reviewers with no own issues but other cataractae recirculated — tells them to do a fresh domain-specific review rather than wandering into another cataractae's domain
- **Phase 2 descriptions** explicitly scope review to YOUR domain only and state not to validate other cataractae's feedback
- **All 5 cataractae INSTRUCTIONS.md** updated with Recirculation Ownership sections defining domain boundaries
- Updated tests to match new Background summary format

The core problem: QA was wasting time trying to validate Security's feedback notes. Each cataractae should verify its own feedback, and downstream stages should only check for newly introduced issues in their domain.

**Before:** QA sees Security's full issue description → tries to assess whether the SSRF vulnerability was fixed
**After:** QA sees `**security-review**: 1 open issue(s)` → knows Security will verify its own feedback → focuses on QA-domain issues only