### PR TITLE
fix: accept 'next' as valid terminal in aqueduct on_pass validation

### DIFF
--- a/internal/aqueduct/validate.go
+++ b/internal/aqueduct/validate.go
@@ -99,7 +99,7 @@ func cataractaeRefs(s WorkflowCataractae) []cataractaeRef {
 // isTerminal returns true for built-in terminal states that are not step names.
 func isTerminal(name string) bool {
 	switch strings.ToLower(name) {
-	case "done", "pooled", "human", "pool":
+	case "done", "pooled", "human", "pool", "next":
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
The delivery cataractae conventionally uses `on_pass: next` to indicate advancement to the next cataractae. The new validator rejected this as an unknown cataractae name, causing Castellarius to crash-loop on repos using this convention.

Added `"next"` to the `isTerminal()` list alongside `"done"`, `"pooled"`, `"human"`, `"pool"`.