### PR TITLE
fix: purge orphaned per-droplet worktrees at startup and periodically

### DIFF
--- a/internal/castellarius/aqueduct_pool.go
+++ b/internal/castellarius/aqueduct_pool.go
@@ -136,3 +136,14 @@ func (p *AqueductPool) FindByName(name string) *Aqueduct {
 	}
 	return nil
 }
+
+// Names returns the names of all aqueducts in the pool.
+func (p *AqueductPool) Names() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	names := make([]string, len(p.aqueducts))
+	for i, a := range p.aqueducts {
+		names[i] = a.Name
+	}
+	return names
+}

--- a/internal/castellarius/branch_lifecycle_test.go
+++ b/internal/castellarius/branch_lifecycle_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/MichielDean/cistern/internal/aqueduct"
+	"github.com/MichielDean/cistern/internal/cistern"
 )
 
 // --- git helpers for branch lifecycle tests ---
@@ -426,4 +429,274 @@ func TestPrepareDropletWorktree_ConcurrentSameRepo(t *testing.T) {
 			t.Errorf("goroutine %d: worktree path does not exist: %v", i, statErr)
 		}
 	}
+}
+
+// --- purgeOrphanedWorktrees tests ---
+
+// worktreeExists reports whether the named directory exists under the repo sandbox.
+func worktreeExists(t *testing.T, sandboxRoot, repoName, dropletID string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(sandboxRoot, repoName, dropletID))
+	return err == nil
+}
+
+// TestPurgeOrphanedWorktrees_RemovesDeliveredDropletWorktree verifies that
+// purgeOrphanedWorktrees removes a worktree whose droplet is in "delivered"
+// status, while leaving active droplet worktrees untouched.
+func TestPurgeOrphanedWorktrees_RemovesDeliveredDropletWorktree(t *testing.T) {
+	primaryDir := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	repoName := "test-repo"
+	prefix := "test-"
+
+	if err := os.MkdirAll(filepath.Join(sandboxRoot, repoName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
+	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+
+	_, err := prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"delivered")
+	if err != nil {
+		t.Fatalf("prepare worktree for delivered droplet: %v", err)
+	}
+	_, err = prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"active")
+	if err != nil {
+		t.Fatalf("prepare worktree for active droplet: %v", err)
+	}
+
+	if !worktreeExists(t, sandboxRoot, repoName, prefix+"delivered") {
+		t.Fatal("delivered worktree should exist before purge")
+	}
+	if !worktreeExists(t, sandboxRoot, repoName, prefix+"active") {
+		t.Fatal("active worktree should exist before purge")
+	}
+
+	client := newMockClient()
+	client.items[prefix+"delivered"] = &cistern.Droplet{ID: prefix + "delivered", Status: "delivered"}
+	client.items[prefix+"active"] = &cistern.Droplet{ID: prefix + "active", Status: "in_progress"}
+
+	s := &Castellarius{
+		config: aqueduct.AqueductConfig{
+			Repos: []aqueduct.RepoConfig{
+				{Name: repoName, Prefix: prefix, Names: []string{"alpha", "beta"}},
+			},
+		},
+		clients:     map[string]CisternClient{repoName: client},
+		pools:       map[string]*AqueductPool{repoName: NewAqueductPool(repoName, []string{"alpha", "beta"})},
+		sandboxRoot: sandboxRoot,
+		logger:      newBranchLifecycleLogger(io.Discard),
+	}
+
+	s.purgeOrphanedWorktrees()
+
+	if worktreeExists(t, sandboxRoot, repoName, prefix+"delivered") {
+		t.Error("delivered droplet worktree should have been removed")
+	}
+	if !worktreeExists(t, sandboxRoot, repoName, prefix+"active") {
+		t.Error("active droplet worktree should NOT have been removed")
+	}
+}
+
+// TestPurgeOrphanedWorktrees_RemovesDeletedDropletWorktree verifies that
+// purgeOrphanedWorktrees removes a worktree whose droplet has been purged
+// from the database entirely (Get returns not-found error).
+func TestPurgeOrphanedWorktrees_RemovesDeletedDropletWorktree(t *testing.T) {
+	primaryDir := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	repoName := "test-repo"
+	prefix := "test-"
+
+	if err := os.MkdirAll(filepath.Join(sandboxRoot, repoName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
+	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+
+	_, err := prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"purged")
+	if err != nil {
+		t.Fatalf("prepare worktree: %v", err)
+	}
+
+	if !worktreeExists(t, sandboxRoot, repoName, prefix+"purged") {
+		t.Fatal("worktree should exist before purge")
+	}
+
+	client := newMockClient()
+
+	s := &Castellarius{
+		config: aqueduct.AqueductConfig{
+			Repos: []aqueduct.RepoConfig{
+				{Name: repoName, Prefix: prefix, Names: []string{"alpha", "beta"}},
+			},
+		},
+		clients:     map[string]CisternClient{repoName: client},
+		pools:       map[string]*AqueductPool{repoName: NewAqueductPool(repoName, []string{"alpha", "beta"})},
+		sandboxRoot: sandboxRoot,
+		logger:      newBranchLifecycleLogger(io.Discard),
+	}
+
+	s.purgeOrphanedWorktrees()
+
+	if worktreeExists(t, sandboxRoot, repoName, prefix+"purged") {
+		t.Error("purged droplet worktree should have been removed")
+	}
+	if branchExists(t, dstPrimary, "feat/"+prefix+"purged") {
+		t.Error("feature branch for purged droplet should have been deleted")
+	}
+}
+
+// TestPurgeOrphanedWorktrees_SkipsAqueductWorkerDirs verifies that directories
+// matching aqueduct worker names (alpha, beta, etc.) are never removed even
+// though they don't match the droplet prefix.
+func TestPurgeOrphanedWorktrees_SkipsAqueductWorkerDirs(t *testing.T) {
+	primaryDir := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	repoName := "test-repo"
+	prefix := "test-"
+
+	if err := os.MkdirAll(filepath.Join(sandboxRoot, repoName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
+	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+
+	branchMustRun(t, branchGitCmd(dstPrimary, "worktree", "add", filepath.Join(sandboxRoot, repoName, "alpha"), "HEAD"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "worktree", "add", filepath.Join(sandboxRoot, repoName, "beta"), "HEAD"))
+
+	client := newMockClient()
+
+	s := &Castellarius{
+		config: aqueduct.AqueductConfig{
+			Repos: []aqueduct.RepoConfig{
+				{Name: repoName, Prefix: prefix, Names: []string{"alpha", "beta"}},
+			},
+		},
+		clients:     map[string]CisternClient{repoName: client},
+		pools:       map[string]*AqueductPool{repoName: NewAqueductPool(repoName, []string{"alpha", "beta"})},
+		sandboxRoot: sandboxRoot,
+		logger:      newBranchLifecycleLogger(io.Discard),
+	}
+
+	s.purgeOrphanedWorktrees()
+
+	if !worktreeExists(t, sandboxRoot, repoName, "alpha") {
+		t.Error("alpha aqueduct worktree should NOT be removed")
+	}
+	if !worktreeExists(t, sandboxRoot, repoName, "beta") {
+		t.Error("beta aqueduct worktree should NOT be removed")
+	}
+}
+
+// TestPurgeOrphanedWorktrees_SkipsNonPrefixDirs verifies that directories
+// that don't match the droplet prefix (e.g. random dirs) are skipped.
+func TestPurgeOrphanedWorktrees_SkipsNonPrefixDirs(t *testing.T) {
+	primaryDir := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	repoName := "test-repo"
+	prefix := "test-"
+
+	if err := os.MkdirAll(filepath.Join(sandboxRoot, repoName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
+	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+
+	if err := os.MkdirAll(filepath.Join(sandboxRoot, repoName, "other-dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+
+	s := &Castellarius{
+		config: aqueduct.AqueductConfig{
+			Repos: []aqueduct.RepoConfig{
+				{Name: repoName, Prefix: prefix, Names: []string{"alpha"}},
+			},
+		},
+		clients:     map[string]CisternClient{repoName: client},
+		pools:       map[string]*AqueductPool{repoName: NewAqueductPool(repoName, []string{"alpha"})},
+		sandboxRoot: sandboxRoot,
+		logger:      newBranchLifecycleLogger(io.Discard),
+	}
+
+	s.purgeOrphanedWorktrees()
+
+	if _, err := os.Stat(filepath.Join(sandboxRoot, repoName, "other-dir")); err != nil {
+		t.Error("non-prefix directory should NOT be removed")
+	}
+}
+
+// TestPurgeOrphanedWorktrees_RemovesCancelledAndPooled verifies that
+// worktrees for cancelled and pooled droplets are also removed.
+func TestPurgeOrphanedWorktrees_RemovesCancelledAndPooled(t *testing.T) {
+	primaryDir := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	repoName := "test-repo"
+	prefix := "test-"
+
+	if err := os.MkdirAll(filepath.Join(sandboxRoot, repoName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
+	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+
+	_, err := prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"cancelled")
+	if err != nil {
+		t.Fatalf("prepare worktree: %v", err)
+	}
+	_, err = prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"pooled")
+	if err != nil {
+		t.Fatalf("prepare worktree: %v", err)
+	}
+
+	client := newMockClient()
+	client.items[prefix+"cancelled"] = &cistern.Droplet{ID: prefix + "cancelled", Status: "cancelled"}
+	client.items[prefix+"pooled"] = &cistern.Droplet{ID: prefix + "pooled", Status: "pooled"}
+
+	s := &Castellarius{
+		config: aqueduct.AqueductConfig{
+			Repos: []aqueduct.RepoConfig{
+				{Name: repoName, Prefix: prefix, Names: []string{"alpha"}},
+			},
+		},
+		clients:     map[string]CisternClient{repoName: client},
+		pools:       map[string]*AqueductPool{repoName: NewAqueductPool(repoName, []string{"alpha"})},
+		sandboxRoot: sandboxRoot,
+		logger:      newBranchLifecycleLogger(io.Discard),
+	}
+
+	s.purgeOrphanedWorktrees()
+
+	if worktreeExists(t, sandboxRoot, repoName, prefix+"cancelled") {
+		t.Error("cancelled droplet worktree should have been removed")
+	}
+	if worktreeExists(t, sandboxRoot, repoName, prefix+"pooled") {
+		t.Error("pooled droplet worktree should have been removed")
+	}
+}
+
+// TestPurgeOrphanedWorktrees_NoSandboxRoot_IsNoOp verifies that when
+// sandboxRoot is empty (e.g. test environments), the function returns
+// immediately without error.
+func TestPurgeOrphanedWorktrees_NoSandboxRoot_IsNoOp(t *testing.T) {
+	s := &Castellarius{
+		sandboxRoot: "",
+		logger:      newBranchLifecycleLogger(io.Discard),
+	}
+	s.purgeOrphanedWorktrees()
 }

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -613,6 +613,92 @@ func (s *Castellarius) purgeOldItems() {
 		total += n
 	}
 	s.logger.Info("purge complete", "total", total)
+
+	s.purgeOrphanedWorktrees()
+}
+
+// purgeOrphanedWorktrees removes per-droplet worktrees whose droplets are no
+// longer active (delivered, cancelled, pooled, or deleted from DB). This catches
+// worktrees that escaped the normal observe-path cleanup due to Castellarius
+// crashes, failed git worktree remove, or race conditions.
+//
+// Safe guards:
+//   - Skips _primary (shared object store for the repo)
+//   - Skips named aqueduct worker directories (alpha, virgo, etc.)
+//   - Skips directories that don't match the repo's droplet prefix
+//   - Only removes worktrees whose droplet is delivered/cancelled/pooled
+//     or entirely absent from the database
+func (s *Castellarius) purgeOrphanedWorktrees() {
+	if s.sandboxRoot == "" {
+		return
+	}
+
+	for _, repo := range s.config.Repos {
+		repoDir := filepath.Join(s.sandboxRoot, repo.Name)
+		entries, err := os.ReadDir(repoDir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				s.logger.Warn("orphan scan: read dir failed", "repo", repo.Name, "error", err)
+			}
+			continue
+		}
+
+		primaryDir := filepath.Join(repoDir, "_primary")
+		if _, err := os.Stat(filepath.Join(primaryDir, ".git")); err != nil {
+			continue
+		}
+
+		pool := s.pools[repo.Name]
+		knownDirs := map[string]bool{
+			"_primary": true,
+		}
+		for _, name := range pool.Names() {
+			knownDirs[name] = true
+		}
+
+		client := s.clients[repo.Name]
+		prefix := repo.Prefix
+		removed := 0
+
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if knownDirs[name] {
+				continue
+			}
+			if !strings.HasPrefix(name, prefix) {
+				continue
+			}
+
+			remove := false
+			dropletStatus := "unknown"
+			droplet, err := client.Get(name)
+			if err != nil {
+				remove = true
+			} else {
+				dropletStatus = droplet.Status
+				switch droplet.Status {
+				case "delivered", "cancelled", "pooled":
+					remove = true
+				}
+			}
+
+			if remove {
+				removeDropletWorktree(primaryDir, s.sandboxRoot, repo.Name, name, false)
+				removed++
+				s.logger.Info("orphaned worktree removed",
+					"repo", repo.Name, "droplet", name,
+					"droplet_status", dropletStatus)
+			}
+		}
+
+		if removed > 0 {
+			s.logger.Info("orphaned worktree purge complete",
+				"repo", repo.Name, "removed", removed)
+		}
+	}
 }
 
 // Tick runs a single poll cycle across all repos. Exported for testing.


### PR DESCRIPTION
## Summary

- Add `purgeOrphanedWorktrees` that scans each repo's sandbox directory for per-droplet worktrees whose droplets are in a terminal state (delivered/cancelled/pooled) or absent from the DB, and removes them
- Called at startup after `recoverInProgress()` and periodically during `purgeOldItems()`
- Add `AqueductPool.Names()` method for iterating pool worker names
- 6 new tests covering delivered, DB-purged, aqueduct worker skip, non-prefix skip, cancelled/pooled, and no-sandbox-root cases

## Why

Per-droplet worktrees were not cleaned up when the Castellarius crashed during delivery, when `git worktree remove` failed, or due to race conditions. Stale worktrees accumulated in the sandbox with old code baked in, causing new agents assigned to those worktrees to see and regurgitate stale content (the "farm_running" contamination issue).

Safe guards:
- Skips `_primary` (shared object store)
- Skips named aqueduct worker directories (alpha, virgo, etc.) via `pool.Names()`
- Skips directories that don't match the repo's droplet prefix
- Only removes worktrees whose droplet is delivered/cancelled/pooled or entirely absent from the database