### PR TITLE
Handle empty repos in worktree creation with --orphan flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Handle empty repos in worktree creation with --orphan flag (ci-adwp9)
+
+When a repo has no commits (empty/unborn branch), `git worktree add --detach` and `git worktree add -b feat/<id> <path> origin/main` both fail with `fatal: invalid reference: HEAD`. This crashed the Castellarius in a restart loop. The fix detects empty repos (no commits on `origin/main` or `HEAD`) and uses `git worktree add --orphan` instead, which creates an unborn branch with no parent commit. Once an initial commit exists, subsequent worktrees use the normal path.
+
+**Key changes:**
+- `prepareDropletWorktree`: skips `git fetch` on empty repos (nothing to fetch), uses `--orphan -b` flag for worktree creation, skips `git reset --hard origin/main` on orphan branches
+- `EnsureWorktree`: detects empty repos and uses `--orphan -b _worker_<name>` instead of `--detach`
+- `prepareBranchInSandbox`: detects empty repos and uses `git checkout --orphan` instead of fetch/checkout from `origin/main`
+- `hookGitSync`: skips `git reset --hard origin/main` on the `_primary` clone when the repo has no commits on `origin/main`
+- New `repoHasCommits(dir, ref)` helper (in both `castellarius` and `cataractae` packages) checks whether a ref resolves to a commit using `git rev-parse --verify`
+
+**Testing:** 8 new integration tests covering empty-repo behavior for all four code paths, including orphan branch creation, branch resumption, multiple concurrent droplets, and logging.
+
 ### Fix web SPA crash on empty data — null array regression (ci-1a9sf)
 
 The web SPA crashed on launch when `pooled_items`, `unassigned_items`, or other collection fields were empty. The Go API serialized nil slices as JSON `null` (standard Go behavior), and the React frontend called `.length` on them without null-coalescing.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ repos:
 
 Repo names are validated case-insensitively — `ct droplet add --repo myproject` and `ct droplet add --repo MYPROJECT` both map to the canonical name `myproject` in the config.
 
-Aqueduct names are **concurrency slots** — they control how many droplets run in parallel per repo. Each active droplet gets its own isolated git worktree at `~/.cistern/sandboxes/<repo>/<droplet-id>/` on branch `feat/<droplet-id>`. Worktrees are created when a droplet enters the `implement` step and removed once it reaches a terminal state (`done`, `pooled`, or `human`).
+Aqueduct names are **concurrency slots** — they control how many droplets run in parallel per repo. Each active droplet gets its own isolated git worktree at `~/.cistern/sandboxes/<repo>/<droplet-id>/` on branch `feat/<droplet-id>`. Worktrees are created when a droplet enters the `implement` step and removed once it reaches a terminal state (`done`, `pooled`, or `human`). On empty repos (no commits on `origin/main`), worktrees are created with `--orphan` branches instead of branching from `origin/main`, so brand-new repos work without any initial commit.
 
 All per-droplet worktrees share a single primary clone object store at `~/.cistern/sandboxes/<repo>/_primary/` — objects are shared, only the working tree is per-droplet, keeping disk cost low. Each tmux session is named `<repo>-<aqueduct>`. Every `tmux ls` shows the cistern in motion:
 
@@ -320,7 +320,7 @@ drought_hooks:
 
 | Action | What it does |
 |---|---|
-| `git_sync` | Fetches `origin/main` (with 30s timeout) and deploys `aqueduct.yaml`, `cataractae/<role>/PERSONA.md`, `cataractae/<role>/INSTRUCTIONS.md`, and `skills/` to `~/.cistern/`. Resets the `_primary` clone's working tree to `origin/main` so new worktrees always inherit current files. Safe for agent worktrees (droplet ID directories) — they are never reset and retain in-progress work. Skips files that are already up to date. **Must be the first drought hook** so roles and skills are available to subsequent hooks. |
+| `git_sync` | Fetches `origin/main` (with 30s timeout) and deploys `aqueduct.yaml`, `cataractae/<role>/PERSONA.md`, `cataractae/<role>/INSTRUCTIONS.md`, and `skills/` to `~/.cistern/`. Resets the `_primary` clone's working tree to `origin/main` so new worktrees always inherit current files. Safe for agent worktrees (droplet ID directories) — they are never reset and retain in-progress work. Skips files that are already up to date. On empty repos (no commits on `origin/main`), the reset is skipped since there is nothing to reset to. **Must be the first drought hook** so roles and skills are available to subsequent hooks. |
 | `cataractae_generate` | Regenerates the instructions file (`AGENTS.md`) for each cataractae from its `PERSONA.md` + `INSTRUCTIONS.md`. Run after `git_sync` to pick up new source files. |
 | `worktree_prune` | Runs `git worktree prune` on the repo's primary clone to remove stale worktree registrations. |
 | `db_vacuum` | Flushes the SQLite WAL file back into the main database using `PRAGMA wal_checkpoint(TRUNCATE)`. This reclaims space without requiring an exclusive lock, making it safe to run while agents are active. |

--- a/internal/castellarius/branch_lifecycle_test.go
+++ b/internal/castellarius/branch_lifecycle_test.go
@@ -1,6 +1,7 @@
 package castellarius
 
 import (
+	"bytes"
 	"io"
 	"log/slog"
 	"os"
@@ -699,4 +700,268 @@ func TestPurgeOrphanedWorktrees_NoSandboxRoot_IsNoOp(t *testing.T) {
 		logger:      newBranchLifecycleLogger(io.Discard),
 	}
 	s.purgeOrphanedWorktrees()
+}
+
+// --- empty repo (orphan) tests ---
+
+// makeEmptyBareAndClone creates:
+//
+//	base/remote/ — bare git repo with ZERO commits on main (unborn branch)
+//	base/primary/ — full clone of remote (has origin remote set, but origin/main
+//	                does not exist because there are no commits)
+//
+// Returns the primary directory. Callers will find that origin/main does NOT
+// resolve, simulating a brand-new empty repo.
+func makeEmptyBareAndClone(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	remoteDir := filepath.Join(base, "remote")
+	primaryDir := filepath.Join(base, "primary")
+
+	// Create a bare repo. It has no commits and an unborn default branch.
+	branchMustRun(t, branchGitCmd(".", "init", "--bare", remoteDir))
+
+	// We need to set HEAD in the bare repo to point to main so that clones
+	// get origin/main as the expected default. Since there are no commits,
+	// refs/heads/main won't exist yet — but HEAD will point to it.
+	// Git init --bare defaults HEAD to refs/heads/main, so this should be fine.
+
+	// Clone the bare remote. This creates a primary clone with origin set,
+	// but origin/main is unborn (no commits).
+	branchMustRun(t, branchGitCmd(".", "clone", remoteDir, primaryDir))
+	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.email", "test@test.com"))
+	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.name", "Test"))
+
+	return primaryDir
+}
+
+// TestRepoHasCommits_TrueWhenCommitsExist verifies that repoHasCommits returns
+// true when origin/main has commits.
+func TestRepoHasCommits_TrueWhenCommitsExist(t *testing.T) {
+	dir := makeBareAndClone(t)
+
+	has, err := repoHasCommits(dir, "origin/main")
+	if err != nil {
+		t.Fatalf("repoHasCommits: %v", err)
+	}
+	if !has {
+		t.Error("expected repoHasCommits to return true for repo with commits")
+	}
+}
+
+// TestRepoHasCommits_FalseWhenEmptyRepo verifies that repoHasCommits returns
+// false when the repo has no commits on origin/main (empty/unborn repo).
+func TestRepoHasCommits_FalseWhenEmptyRepo(t *testing.T) {
+	dir := makeEmptyBareAndClone(t)
+
+	has, err := repoHasCommits(dir, "origin/main")
+	if err != nil {
+		t.Fatalf("repoHasCommits: %v", err)
+	}
+	if has {
+		t.Error("expected repoHasCommits to return false for empty repo")
+	}
+}
+
+// TestPrepareDropletWorktree_EmptyRepo_UsesOrphanBranch verifies that on an empty
+// repo (no origin/main commits), prepareDropletWorktree creates an orphan branch
+// worktree instead of failing with "invalid reference: HEAD".
+func TestPrepareDropletWorktree_EmptyRepo_UsesOrphanBranch(t *testing.T) {
+	primaryDir := makeEmptyBareAndClone(t)
+	sandboxRoot := t.TempDir()
+
+	worktreePath, err := prepareDropletWorktreeWithLogger(
+		newBranchLifecycleLogger(io.Discard), primaryDir, sandboxRoot, "myrepo", "drop-orphan",
+	)
+	if err != nil {
+		t.Fatalf("prepareDropletWorktree on empty repo: %v", err)
+	}
+
+	// (a) no error returned (verified above by not fatalf-ing)
+
+	// (b) worktree directory exists
+	if _, statErr := os.Stat(worktreePath); statErr != nil {
+		t.Fatalf("worktree path does not exist: %v", statErr)
+	}
+
+	// (c) git branch --show-current returns feat/<id>
+	// On an orphan branch with no commits, rev-parse HEAD fails, so use
+	// git branch --show-current which correctly reports unborn branch names.
+	branchOut, branchErr := exec.Command("git", "-C", worktreePath, "branch", "--show-current").Output()
+	if branchErr != nil {
+		t.Fatalf("git branch --show-current: %v", branchErr)
+	}
+	if got := strings.TrimSpace(string(branchOut)); got != "feat/drop-orphan" {
+		t.Errorf("current branch = %q, want feat/drop-orphan", got)
+	}
+
+	// (d) worktree has no tracked files (empty initial state — orphan branch)
+	statusOut, statusErr := exec.Command("git", "-C", worktreePath, "status", "--porcelain").Output()
+	if statusErr != nil {
+		t.Fatalf("git status in orphan worktree: %v", statusErr)
+	}
+	if strings.TrimSpace(string(statusOut)) != "" {
+		t.Errorf("orphan worktree has tracked files (should be empty):\n%s", statusOut)
+	}
+}
+
+// TestPrepareDropletWorktree_EmptyRepo_ResumeOrphanBranch verifies that when
+// an orphan worktree already exists (from a prior dispatch), the resume path
+// works correctly — checking out the existing branch with the commit intact.
+func TestPrepareDropletWorktree_EmptyRepo_ResumeOrphanBranch(t *testing.T) {
+	primaryDir := makeEmptyBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	l := newBranchLifecycleLogger(io.Discard)
+
+	// First dispatch: create the orphan worktree and commit a file.
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-orphan")
+	if err != nil {
+		t.Fatalf("first prepareDropletWorktree on empty repo: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreePath, "impl.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	branchMustRun(t, branchGitCmd(worktreePath, "add", "."))
+	branchMustRun(t, branchGitCmd(worktreePath, "commit", "-m", "agent work"))
+
+	beforeSHA, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse before cleanup: %v", err)
+	}
+
+	// Simulate stagnant cleanup: remove worktree but keep branch (keepBranch=true).
+	removeDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-orphan", true)
+
+	if _, statErr := os.Stat(worktreePath); statErr == nil {
+		t.Fatal("worktree directory should be gone after stagnant cleanup")
+	}
+
+	// Second dispatch: resume the orphan branch.
+	newWorktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-orphan")
+	if err != nil {
+		t.Fatalf("second prepareDropletWorktree (resume) on empty repo: %v", err)
+	}
+
+	// Verify the branch is resumed with the commit intact.
+	if got := currentBranch(t, newWorktreePath); got != "feat/drop-resume-orphan" {
+		t.Errorf("HEAD branch after resume = %q, want feat/drop-resume-orphan", got)
+	}
+
+	afterSHA, err := exec.Command("git", "-C", newWorktreePath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse after resume: %v", err)
+	}
+
+	before, after := strings.TrimSpace(string(beforeSHA)), strings.TrimSpace(string(afterSHA))
+	if before != after {
+		t.Errorf("prior commits lost on orphan resume: HEAD before=%s after=%s", before, after)
+	}
+}
+
+// TestPrepareDropletWorktree_EmptyRepo_MultipleDroplets verifies that two
+// droplets can create independent orphan worktrees on an empty repo.
+func TestPrepareDropletWorktree_EmptyRepo_MultipleDroplets(t *testing.T) {
+	primaryDir := makeEmptyBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	l := newBranchLifecycleLogger(io.Discard)
+
+	wt1, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-multi-1")
+	if err != nil {
+		t.Fatalf("prepareDropletWorktree for drop-multi-1: %v", err)
+	}
+	wt2, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-multi-2")
+	if err != nil {
+		t.Fatalf("prepareDropletWorktree for drop-multi-2: %v", err)
+	}
+
+	// Both branches should exist and be independent.
+	// Use git branch --show-current since rev-parse HEAD fails on unborn branches.
+	branch1Out, err := exec.Command("git", "-C", wt1, "branch", "--show-current").Output()
+	if err != nil {
+		t.Fatalf("git branch --show-current in wt1: %v", err)
+	}
+	if got := strings.TrimSpace(string(branch1Out)); got != "feat/drop-multi-1" {
+		t.Errorf("worktree 1 branch = %q, want feat/drop-multi-1", got)
+	}
+
+	branch2Out, err := exec.Command("git", "-C", wt2, "branch", "--show-current").Output()
+	if err != nil {
+		t.Fatalf("git branch --show-current in wt2: %v", err)
+	}
+	if got := strings.TrimSpace(string(branch2Out)); got != "feat/drop-multi-2" {
+		t.Errorf("worktree 2 branch = %q, want feat/drop-multi-2", got)
+	}
+
+	// Commit in wt1 and verify wt2 is unaffected.
+	if err := os.WriteFile(filepath.Join(wt1, "from1.txt"), []byte("1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	branchMustRun(t, branchGitCmd(wt1, "add", "."))
+	branchMustRun(t, branchGitCmd(wt1, "commit", "-m", "commit from droplet 1"))
+
+	// wt2 should still have no tracked files.
+	statusOut, err := exec.Command("git", "-C", wt2, "status", "--porcelain").Output()
+	if err != nil {
+		t.Fatalf("git status in wt2: %v", err)
+	}
+	if strings.TrimSpace(string(statusOut)) != "" {
+		t.Errorf("wt2 should be empty after wt1 commit, but has:\n%s", statusOut)
+	}
+}
+
+// TestPrepareDropletWorktree_EmptyRepo_LogsWorktreeCreated verifies that
+// prepareDropletWorktree emits a log message containing "worktree created (orphan)"
+// when creating a worktree on an empty repo.
+func TestPrepareDropletWorktree_EmptyRepo_LogsWorktreeCreated(t *testing.T) {
+	var buf bytes.Buffer
+	l := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	primaryDir := makeEmptyBareAndClone(t)
+	sandboxRoot := t.TempDir()
+
+	_, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "ci-orphan-log")
+	if err != nil {
+		t.Fatalf("prepareDropletWorktree on empty repo: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "worktree created (orphan)") {
+		t.Errorf("log missing 'worktree created (orphan)'; got: %s", out)
+	}
+	if !strings.Contains(out, "ci-orphan-log") {
+		t.Errorf("log missing droplet ID; got: %s", out)
+	}
+	if !strings.Contains(out, "duration=") {
+		t.Errorf("log missing duration field; got: %s", out)
+	}
+}
+
+// TestPrepareBranchInSandbox_EmptyRepo_CreatesOrphanBranch verifies that on an
+// empty repo (no origin/main commits), prepareBranchInSandbox creates an orphan
+// branch instead of failing with git fetch/reset errors.
+func TestPrepareBranchInSandbox_EmptyRepo_CreatesOrphanBranch(t *testing.T) {
+	primaryDir := makeEmptyBareAndClone(t)
+
+	// First, create a detached worktree on the empty repo using the orphan path
+	// (simulating the worktree EnsureWorktree would create).
+	worktreeDir := filepath.Join(t.TempDir(), "sandbox")
+	branchMustRun(t, branchGitCmd(primaryDir, "worktree", "add", "--orphan", "-b", "_worker_sandbox", worktreeDir))
+	branchMustRun(t, branchGitCmd(worktreeDir, "config", "user.email", "test@test.com"))
+	branchMustRun(t, branchGitCmd(worktreeDir, "config", "user.name", "Test"))
+
+	// Now prepareBranchInSandbox on the orphan worktree.
+	if err := prepareBranchInSandbox(worktreeDir, "drop-empty-branch"); err != nil {
+		t.Fatalf("prepareBranchInSandbox on empty repo: %v", err)
+	}
+
+	// Verify the feature branch was created. On an unborn orphan branch,
+	// rev-parse HEAD fails, so use git branch --show-current.
+	branchOut, branchErr := exec.Command("git", "-C", worktreeDir, "branch", "--show-current").Output()
+	if branchErr != nil {
+		t.Fatalf("git branch --show-current: %v", branchErr)
+	}
+	if got := strings.TrimSpace(string(branchOut)); got != "feat/drop-empty-branch" {
+		t.Errorf("current branch = %q, want feat/drop-empty-branch", got)
+	}
 }

--- a/internal/castellarius/drought_hooks.go
+++ b/internal/castellarius/drought_hooks.go
@@ -251,12 +251,22 @@ func hookGitSync(cfg *aqueduct.AqueductConfig, sandboxRoot string, gitFetchTimeo
 		// this ensures they get the latest AGENTS.md and repo files. Agent
 		// worktrees (non-_primary names) are never reset — they carry
 		// in-progress work on feature branches.
+		// On empty/unborn repos (no commits on origin/main), the reset is
+		// skipped — there's nothing to reset to, and the command would fail.
 		if filepath.Base(cloneDir) == "_primary" {
-			resetOut, resetErr := exec.Command("git", "-C", cloneDir, "reset", "--hard", "origin/main").CombinedOutput()
-			if resetErr != nil {
-				logger.Warn("git_sync: failed to reset _primary to origin/main", "repo", repo.Name, "error", resetErr, "output", string(resetOut))
+			primaryHasCommits, commitsErr := repoHasCommits(cloneDir, "origin/main")
+			if commitsErr != nil {
+				logger.Warn("git_sync: cannot check if origin/main has commits",
+					"repo", repo.Name, "error", commitsErr)
+			} else if primaryHasCommits {
+				resetOut, resetErr := exec.Command("git", "-C", cloneDir, "reset", "--hard", "origin/main").CombinedOutput()
+				if resetErr != nil {
+					logger.Warn("git_sync: failed to reset _primary to origin/main", "repo", repo.Name, "error", resetErr, "output", string(resetOut))
+				} else {
+					logger.Info("git_sync: _primary reset to origin/main", "repo", repo.Name)
+				}
 			} else {
-				logger.Info("git_sync: _primary reset to origin/main", "repo", repo.Name)
+				logger.Info("git_sync: _primary has no origin/main — skipping reset", "repo", repo.Name)
 			}
 		}
 

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -1678,6 +1678,23 @@ func prepareBranchInSandbox(dir, itemID string) error {
 		return nil
 	}
 
+	// Check whether origin/main has commits. On an empty/unborn repo there's
+	// nothing to fetch or reset to — the branch must be created as an orphan.
+	hasCommits, commitsErr := repoHasCommits(dir, "origin/main")
+	if commitsErr != nil {
+		return fmt.Errorf("castellarius: branch check in %s: %w", dir, commitsErr)
+	}
+
+	if !hasCommits {
+		// Empty repo: create an orphan branch (no parent commit).
+		create := exec.Command("git", "checkout", "--orphan", branch)
+		create.Dir = dir
+		if co, err := create.CombinedOutput(); err != nil {
+			return fmt.Errorf("git checkout --orphan %s in %s: %w: %s", branch, dir, err, co)
+		}
+		return nil
+	}
+
 	// New branch — fetch and start from a clean origin/main.
 	fetch := exec.Command("git", "fetch", "origin")
 	fetch.Dir = dir
@@ -1706,6 +1723,27 @@ func prepareBranchInSandbox(dir, itemID string) error {
 	return nil
 }
 
+// repoHasCommits reports whether the given ref resolves to a commit in dir.
+// It runs git rev-parse --verify <ref> in dir. If the ref exists, it returns
+// true, nil. If the ref does not exist (unknown revision), it returns false, nil.
+// For any other error (dir does not exist, permission denied), it returns false, err.
+func repoHasCommits(dir, ref string) (bool, error) {
+	cmd := exec.Command("git", "rev-parse", "--verify", ref)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// git rev-parse --verify exits with code 1 (or 128) and prints
+		// "fatal: Needed a single revision" or "unknown revision" when
+		// the ref does not exist. This is the expected "no commits" case.
+		lower := strings.ToLower(string(out))
+		if strings.Contains(lower, "unknown revision") || strings.Contains(lower, "needed a single revision") {
+			return false, nil
+		}
+		return false, fmt.Errorf("castellarius: repoHasCommits %s in %s: %w: %s", ref, dir, err, out)
+	}
+	return true, nil
+}
+
 // prepareDropletWorktree creates (or resumes) a per-droplet git worktree at
 // sandboxRoot/<repoName>/<dropletID>/ on branch feat/<dropletID>.
 //
@@ -1714,6 +1752,8 @@ func prepareBranchInSandbox(dir, itemID string) error {
 // If new, it first tries `git worktree add <path> feat/<id>` (attach existing branch);
 // if that fails (branch does not exist), falls back to
 // `git worktree add -b feat/<id> <path> origin/main` to create a fresh branch.
+// When origin/main has no commits (empty/unborn repo), uses
+// `git worktree add --orphan -b feat/<id> <path>` instead.
 func prepareDropletWorktree(primaryDir, sandboxRoot, repoName, dropletID string) (string, error) {
 	return prepareDropletWorktreeWithLogger(slog.Default(), primaryDir, sandboxRoot, repoName, dropletID)
 }
@@ -1753,32 +1793,61 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 		return worktreePath, nil
 	}
 
-	// Fetch latest before creating.
-	logger.Info("git fetch", "dir", primaryDir)
-	fetch := exec.Command("git", "fetch", "origin")
-	fetch.Dir = primaryDir
-	if out, err := fetch.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("git fetch in %s: %w: %s", primaryDir, err, out)
+	// Fetch latest before creating — but only if origin/main exists. On an
+	// empty/unborn repo, git fetch origin succeeds but there are no refs to
+	// base a worktree on. The orphan path handles this case.
+	hasCommits, commitsErr := repoHasCommits(primaryDir, "origin/main")
+	if commitsErr != nil {
+		// If we can't check, assume commits exist (conservative fallback)
+		// and let the normal path fail with a descriptive error if wrong.
+		logger.Warn("repoHasCommits check failed, assuming commits exist",
+			"dir", primaryDir, "error", commitsErr)
+		hasCommits = true
+	}
+	if hasCommits {
+		logger.Info("git fetch", "dir", primaryDir)
+		fetch := exec.Command("git", "fetch", "origin")
+		fetch.Dir = primaryDir
+		if out, err := fetch.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("git fetch in %s: %w: %s", primaryDir, err, out)
+		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
 		return "", fmt.Errorf("mkdir for worktree %s: %w", worktreePath, err)
 	}
 
+	freshBranch := false
+	orphanBranch := false
+
 	// First try attaching to an existing branch (handles crash-between-branch-create-and-worktree-add,
 	// and resumes stagnant droplets whose worktree was removed but branch preserved).
+	// This must be attempted before the orphan path because --orphan -b fails when
+	// the branch already exists.
 	addExisting := exec.Command("git", "worktree", "add", worktreePath, branch)
 	addExisting.Dir = primaryDir
-	freshBranch := false
 	if out, err := addExisting.CombinedOutput(); err != nil {
-		// Branch doesn't exist yet — create it fresh from origin/main.
-		addNew := exec.Command("git", "worktree", "add", "-b", branch, worktreePath, "origin/main")
-		addNew.Dir = primaryDir
-		if out2, err2 := addNew.CombinedOutput(); err2 != nil {
-			return "", fmt.Errorf("git worktree add %s in %s: %w: %s", worktreePath, primaryDir, err2, out2)
+		_ = out // Branch doesn't exist or other issue — try creating fresh.
+		if !hasCommits {
+			// Empty/unborn repo: origin/main has no commits. Use --orphan to create
+			// an unborn branch (no parent commit). The agent's first commit will
+			// create the root commit for this branch.
+			addOrphan := exec.Command("git", "worktree", "add", "--orphan", "-b", branch, worktreePath)
+			addOrphan.Dir = primaryDir
+			if orphanOut, orphanErr := addOrphan.CombinedOutput(); orphanErr != nil {
+				return "", fmt.Errorf("git worktree add --orphan %s in %s: %w: %s", worktreePath, primaryDir, orphanErr, orphanOut)
+			}
+			freshBranch = true
+			orphanBranch = true
+		} else {
+			// Branch doesn't exist yet — create it fresh from origin/main.
+			addNew := exec.Command("git", "worktree", "add", "-b", branch, worktreePath, "origin/main")
+			addNew.Dir = primaryDir
+			if out2, err2 := addNew.CombinedOutput(); err2 != nil {
+				return "", fmt.Errorf("git worktree add %s in %s: %w: %s", worktreePath, primaryDir, err2, out2)
+			}
+			freshBranch = true
 		}
-		_ = out // first attempt output discarded; only the second failure matters
-		freshBranch = true
 	}
 
 	for _, args := range [][]string{
@@ -1792,9 +1861,11 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 		}
 	}
 
-	if freshBranch {
+	if freshBranch && !orphanBranch {
 		// Hard-reset to origin/main to guarantee a clean baseline — the worktree
 		// may inherit local modifications from the primary clone.
+		// This is skipped for orphan branches (empty repo) since origin/main
+		// doesn't exist — there's nothing to reset to.
 		reset := exec.Command("git", "reset", "--hard", "origin/main")
 		reset.Dir = worktreePath
 		if out, err := reset.CombinedOutput(); err != nil {
@@ -1805,9 +1876,15 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 		_ = clean.Run()
 	}
 
-	logger.Info("worktree created",
-		"droplet", dropletID, "path", worktreePath,
-		"duration", time.Since(t0).Round(time.Millisecond).String())
+	if orphanBranch {
+		logger.Info("worktree created (orphan)",
+			"droplet", dropletID, "path", worktreePath,
+			"duration", time.Since(t0).Round(time.Millisecond).String())
+	} else {
+		logger.Info("worktree created",
+			"droplet", dropletID, "path", worktreePath,
+			"duration", time.Since(t0).Round(time.Millisecond).String())
+	}
 	return worktreePath, nil
 }
 

--- a/internal/cataractae/sandbox.go
+++ b/internal/cataractae/sandbox.go
@@ -46,6 +46,8 @@ func EnsurePrimaryClone(primaryDir, repoURL string) error {
 // It prunes stale worktree registrations first to prevent "already in use" errors.
 // If worktreeDir exists as a legacy dedicated clone (not a registered worktree), it
 // is removed so a fresh worktree can be created.
+// On an empty/unborn repo (no commits on HEAD), it uses --orphan to create
+// an orphan worktree because --detach would fail with "fatal: invalid reference: HEAD".
 func EnsureWorktree(primaryDir, worktreeDir string) error {
 	// Prune stale registrations so dead paths don't block re-registration.
 	prune := exec.Command("git", "worktree", "prune", "--expire=0")
@@ -80,17 +82,65 @@ func EnsureWorktree(primaryDir, worktreeDir string) error {
 		}
 	}
 
-	t0 := time.Now()
-	add := exec.Command("git", "worktree", "add", "--detach", worktreeDir)
-	add.Dir = primaryDir
-	if addOut, err := add.CombinedOutput(); err != nil {
-		slog.Default().Error("git worktree add failed",
-			"dir", worktreeDir, "duration", time.Since(t0).Round(time.Millisecond).String(), "error", err)
-		return fmt.Errorf("git worktree add --detach %s: %w: %s", worktreeDir, err, addOut)
+	// Check whether HEAD has commits. On an empty/unborn repo, --detach fails
+	// with "fatal: invalid reference: HEAD". Use --orphan in that case.
+	hasCommits, commitsErr := repoHasCommits(primaryDir, "HEAD")
+	if commitsErr != nil {
+		// If we can't check, assume commits exist (conservative fallback) and
+		// let the normal path fail with a descriptive error if wrong.
+		slog.Default().Warn("repoHasCommits check failed, assuming commits exist",
+			"dir", primaryDir, "error", commitsErr)
+		hasCommits = true
 	}
-	slog.Default().Info("git worktree created",
-		"dir", worktreeDir, "duration", time.Since(t0).Round(time.Millisecond).String())
+
+	t0 := time.Now()
+	if !hasCommits {
+		// Empty repo: create an orphan worktree. --orphan requires -b, so use
+		// a named branch for the worker. The _worker_ prefix makes it distinct
+		// from feature branches.
+		branchName := "_worker_" + filepath.Base(worktreeDir)
+		add := exec.Command("git", "worktree", "add", "--orphan", "-b", branchName, worktreeDir)
+		add.Dir = primaryDir
+		if addOut, err := add.CombinedOutput(); err != nil {
+			slog.Default().Error("git worktree add --orphan failed",
+				"dir", worktreeDir, "duration", time.Since(t0).Round(time.Millisecond).String(), "error", err)
+			return fmt.Errorf("git worktree add --orphan -b %s %s: %w: %s", branchName, worktreeDir, err, addOut)
+		}
+		slog.Default().Info("git worktree created (orphan)",
+			"dir", worktreeDir, "duration", time.Since(t0).Round(time.Millisecond).String())
+	} else {
+		add := exec.Command("git", "worktree", "add", "--detach", worktreeDir)
+		add.Dir = primaryDir
+		if addOut, err := add.CombinedOutput(); err != nil {
+			slog.Default().Error("git worktree add failed",
+				"dir", worktreeDir, "duration", time.Since(t0).Round(time.Millisecond).String(), "error", err)
+			return fmt.Errorf("git worktree add --detach %s: %w: %s", worktreeDir, err, addOut)
+		}
+		slog.Default().Info("git worktree created",
+			"dir", worktreeDir, "duration", time.Since(t0).Round(time.Millisecond).String())
+	}
 	return nil
+}
+
+// repoHasCommits reports whether the given ref resolves to a commit in dir.
+// It runs git rev-parse --verify <ref> in dir. If the ref exists, it returns
+// true, nil. If the ref does not exist (unknown revision), it returns false, nil.
+// For any other error (dir does not exist, permission denied), it returns false, err.
+func repoHasCommits(dir, ref string) (bool, error) {
+	cmd := exec.Command("git", "rev-parse", "--verify", ref)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// git rev-parse --verify exits with code 1 (or 128) and prints
+		// "fatal: Needed a single revision" or "unknown revision" when
+		// the ref does not exist. This is the expected "no commits" case.
+		lower := strings.ToLower(string(out))
+		if strings.Contains(lower, "unknown revision") || strings.Contains(lower, "needed a single revision") {
+			return false, nil
+		}
+		return false, fmt.Errorf("cataractae: repoHasCommits %s in %s: %w: %s", ref, dir, err, out)
+	}
+	return true, nil
 }
 
 // cloneSandbox performs a fresh git clone into dir.

--- a/internal/cataractae/sandbox_test.go
+++ b/internal/cataractae/sandbox_test.go
@@ -148,3 +148,65 @@ func TestEnsureWorktree_PrunesStaleRegistrations(t *testing.T) {
 		t.Error("worktree not registered after prune+re-add")
 	}
 }
+
+// makeEmptyGitRepo creates a git repo with ZERO commits on main (unborn branch).
+// This simulates a brand-new empty repo where HEAD points to refs/heads/main
+// but no commit exists.
+func makeEmptyGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Init creates a repo with an unborn default branch (no commits).
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git config user.email: %v\n%s", err, out)
+	}
+
+	cmd = exec.Command("git", "config", "user.name", "Test")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git config user.name: %v\n%s", err, out)
+	}
+
+	// Rename branch to main for consistency.
+	cmd = exec.Command("git", "branch", "-M", "main")
+	cmd.Dir = dir
+	// This will fail on an empty repo with no commits — that's expected.
+	// The branch doesn't exist yet, so -M can't rename it. That's fine;
+	// we just need the .git directory to exist for worktree operations.
+	_ = cmd.Run()
+
+	return dir
+}
+
+// TestEnsureWorktree_EmptyRepo_UsesOrphanBranch verifies that on an empty repo
+// (no commits), EnsureWorktree uses --orphan to create a worktree instead of
+// --detach which would fail with "fatal: invalid reference: HEAD".
+func TestEnsureWorktree_EmptyRepo_UsesOrphanBranch(t *testing.T) {
+	primary := makeEmptyGitRepo(t)
+	worktreeDir := filepath.Join(t.TempDir(), "wt")
+
+	if err := EnsureWorktree(primary, worktreeDir); err != nil {
+		t.Fatalf("EnsureWorktree on empty repo: %v", err)
+	}
+
+	// (a) no error returned (verified above)
+
+	// (b) worktree directory exists
+	if _, err := os.Stat(worktreeDir); err != nil {
+		t.Fatalf("worktree dir not created: %v", err)
+	}
+
+	// (c) worktree is registered in git worktree list
+	abs, _ := filepath.Abs(worktreeDir)
+	if !isWorktreeRegistered(t, primary, abs) {
+		t.Error("worktree not registered in primary clone")
+	}
+}

--- a/skills/cistern/references/troubleshooting.md
+++ b/skills/cistern/references/troubleshooting.md
@@ -381,6 +381,27 @@ git status                           # Assess damage
 git checkout -B lobsterdog-work origin/main  # Nuke and re-sync (loses local changes)
 ```
 
+## Empty Repos (No Commits)
+
+Cistern supports repos that have zero commits on `origin/main` (brand-new empty repos with an unborn default branch). Previously, empty repos caused the Castellarius to crash in a restart loop with `fatal: invalid reference: HEAD` because `git worktree add --detach` and `git worktree add -b feat/<id> <path> origin/main` both require an existing commit.
+
+**How it works now:**
+- `prepareDropletWorktree` detects empty repos and uses `git worktree add --orphan -b feat/<id> <path>` instead, creating an unborn branch with no parent commit
+- `EnsureWorktree` detects empty repos and uses `--orphan -b _worker_<name>` instead of `--detach`
+- `prepareBranchInSandbox` uses `git checkout --orphan` on empty repos instead of fetching and resetting from `origin/main`
+- The `git_sync` drought hook skips `git reset --hard origin/main` on the `_primary` clone when the repo has no commits — it logs `_primary has no origin/main — skipping reset`
+- Once any droplet creates the first commit on its orphan branch, subsequent worktrees for that repo use the normal path (branching from `origin/main`)
+
+**What to expect with a brand-new repo:**
+1. Add the repo to `cistern.yaml` as usual
+2. Add droplets — the first droplet will create an orphan branch and make the initial commit
+3. After the first commit lands on `origin/main` (via delivery/merge), all subsequent droplets branch normally from `origin/main`
+
+**Troubleshooting:**
+- If you see `worktree created (orphan)` in the Castellarius logs, this is expected — it means the repo has no commits yet
+- If a droplet on an orphan branch is recirculated, the existing branch is reattached and prior commits are preserved
+- If you see `_primary has no origin/main — skipping reset` in drought logs, this is expected for empty repos — the reset will resume once the first commit exists
+
 ## Drought Protocol Not Running
 
 Drought hooks run during idle periods. If they're not firing:


### PR DESCRIPTION
Closes droplet ci-adwp9.