### PR TITLE
fix: prevent orphan worktree accumulation from prefix mismatches

### DIFF
--- a/internal/castellarius/branch_lifecycle_test.go
+++ b/internal/castellarius/branch_lifecycle_test.go
@@ -47,8 +47,8 @@ func makeBareAndClone(t *testing.T) string {
 
 	branchMustRun(t, branchGitCmd(".", "init", "--bare", remoteDir))
 	branchMustRun(t, branchGitCmd(".", "init", initDir))
-	branchMustRun(t, branchGitCmd(initDir, "config", "user.email", "test@test.com"))
-	branchMustRun(t, branchGitCmd(initDir, "config", "user.name", "Test"))
+	branchMustRun(t, branchGitCmd(initDir, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(initDir, "config", "user.name", "Lobsterdog Contributors"))
 
 	if err := os.WriteFile(filepath.Join(initDir, "README.md"), []byte("init\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -61,8 +61,8 @@ func makeBareAndClone(t *testing.T) string {
 
 	// Clone the bare remote to create the primary (inherits origin remote).
 	branchMustRun(t, branchGitCmd(".", "clone", remoteDir, primaryDir))
-	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.email", "test@test.com"))
-	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.name", "Test"))
+	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.name", "Lobsterdog Contributors"))
 
 	return primaryDir
 }
@@ -116,16 +116,16 @@ func TestPrepareBranchInSandbox_NewBranch_ConfiguresGitIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("git config user.name: %v", err)
 	}
-	if got := strings.TrimSpace(string(nameOut)); got != "Cistern Agent" {
-		t.Errorf("user.name = %q, want %q", got, "Cistern Agent")
+	if got := strings.TrimSpace(string(nameOut)); got != "Lobsterdog Contributors" {
+		t.Errorf("user.name = %q, want %q", got, "Lobsterdog Contributors")
 	}
 
 	emailOut, err := exec.Command("git", "-C", dir, "config", "user.email").Output()
 	if err != nil {
 		t.Fatalf("git config user.email: %v", err)
 	}
-	if got := strings.TrimSpace(string(emailOut)); got != "agent@cistern.local" {
-		t.Errorf("user.email = %q, want %q", got, "agent@cistern.local")
+	if got := strings.TrimSpace(string(emailOut)); got != "noreply@lobsterdog.dev" {
+		t.Errorf("user.email = %q, want %q", got, "noreply@lobsterdog.dev")
 	}
 }
 
@@ -456,8 +456,8 @@ func TestPurgeOrphanedWorktrees_RemovesDeliveredDropletWorktree(t *testing.T) {
 
 	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
 	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Lobsterdog Contributors"))
 
 	_, err := prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"delivered")
 	if err != nil {
@@ -516,8 +516,8 @@ func TestPurgeOrphanedWorktrees_RemovesDeletedDropletWorktree(t *testing.T) {
 
 	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
 	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Lobsterdog Contributors"))
 
 	_, err := prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"purged")
 	if err != nil {
@@ -567,8 +567,8 @@ func TestPurgeOrphanedWorktrees_SkipsAqueductWorkerDirs(t *testing.T) {
 
 	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
 	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Lobsterdog Contributors"))
 
 	branchMustRun(t, branchGitCmd(dstPrimary, "worktree", "add", filepath.Join(sandboxRoot, repoName, "alpha"), "HEAD"))
 	branchMustRun(t, branchGitCmd(dstPrimary, "worktree", "add", filepath.Join(sandboxRoot, repoName, "beta"), "HEAD"))
@@ -611,8 +611,8 @@ func TestPurgeOrphanedWorktrees_SkipsNonPrefixDirs(t *testing.T) {
 
 	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
 	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Lobsterdog Contributors"))
 
 	if err := os.MkdirAll(filepath.Join(sandboxRoot, repoName, "other-dir"), 0o755); err != nil {
 		t.Fatal(err)
@@ -653,8 +653,8 @@ func TestPurgeOrphanedWorktrees_RemovesCancelledAndPooled(t *testing.T) {
 
 	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
 	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "test@test.com"))
-	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Test"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Lobsterdog Contributors"))
 
 	_, err := prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"cancelled")
 	if err != nil {
@@ -688,6 +688,59 @@ func TestPurgeOrphanedWorktrees_RemovesCancelledAndPooled(t *testing.T) {
 	}
 	if worktreeExists(t, sandboxRoot, repoName, prefix+"pooled") {
 		t.Error("pooled droplet worktree should have been removed")
+	}
+}
+
+// TestPurgeOrphanedWorktrees_PrefixMismatch_StillPurgesOrphans verifies that
+// when the configured prefix doesn't match actual droplet IDs (e.g. config says
+// "lm" but droplets use "ll"), the regex fallback still catches orphaned
+// worktrees via the DB lookup.
+func TestPurgeOrphanedWorktrees_PrefixMismatch_StillPurgesOrphans(t *testing.T) {
+	primaryDir := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	repoName := "test-repo"
+	configPrefix := "lm-"
+
+	if err := os.MkdirAll(filepath.Join(sandboxRoot, repoName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
+	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Lobsterdog Contributors"))
+
+	_, err := prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, "ll-abcde")
+	if err != nil {
+		t.Fatalf("prepare worktree: %v", err)
+	}
+
+	if !worktreeExists(t, sandboxRoot, repoName, "ll-abcde") {
+		t.Fatal("worktree should exist before purge")
+	}
+
+	client := newMockClient()
+	client.items["ll-abcde"] = &cistern.Droplet{ID: "ll-abcde", Status: "cancelled"}
+
+	s := &Castellarius{
+		config: aqueduct.AqueductConfig{
+			Repos: []aqueduct.RepoConfig{
+				{Name: repoName, Prefix: configPrefix, Names: []string{"alpha"}},
+			},
+		},
+		clients:     map[string]CisternClient{repoName: client},
+		pools:       map[string]*AqueductPool{repoName: NewAqueductPool(repoName, []string{"alpha"})},
+		sandboxRoot: sandboxRoot,
+		logger:      newBranchLifecycleLogger(io.Discard),
+	}
+
+	s.purgeOrphanedWorktrees()
+
+	if worktreeExists(t, sandboxRoot, repoName, "ll-abcde") {
+		t.Error("prefix-mismatched cancelled droplet worktree should have been removed via regex fallback")
+	}
+	if branchExists(t, dstPrimary, "feat/ll-abcde") {
+		t.Error("feature branch for prefix-mismatched cancelled droplet should have been deleted")
 	}
 }
 
@@ -729,8 +782,8 @@ func makeEmptyBareAndClone(t *testing.T) string {
 	// Clone the bare remote. This creates a primary clone with origin set,
 	// but origin/main is unborn (no commits).
 	branchMustRun(t, branchGitCmd(".", "clone", remoteDir, primaryDir))
-	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.email", "test@test.com"))
-	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.name", "Test"))
+	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(primaryDir, "config", "user.name", "Lobsterdog Contributors"))
 
 	return primaryDir
 }
@@ -947,8 +1000,8 @@ func TestPrepareBranchInSandbox_EmptyRepo_CreatesOrphanBranch(t *testing.T) {
 	// (simulating the worktree EnsureWorktree would create).
 	worktreeDir := filepath.Join(t.TempDir(), "sandbox")
 	branchMustRun(t, branchGitCmd(primaryDir, "worktree", "add", "--orphan", "-b", "_worker_sandbox", worktreeDir))
-	branchMustRun(t, branchGitCmd(worktreeDir, "config", "user.email", "test@test.com"))
-	branchMustRun(t, branchGitCmd(worktreeDir, "config", "user.name", "Test"))
+	branchMustRun(t, branchGitCmd(worktreeDir, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(worktreeDir, "config", "user.name", "Lobsterdog Contributors"))
 
 	// Now prepareBranchInSandbox on the orphan worktree.
 	if err := prepareBranchInSandbox(worktreeDir, "drop-empty-branch"); err != nil {
@@ -963,5 +1016,78 @@ func TestPrepareBranchInSandbox_EmptyRepo_CreatesOrphanBranch(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(branchOut)); got != "feat/drop-empty-branch" {
 		t.Errorf("current branch = %q, want feat/drop-empty-branch", got)
+	}
+}
+
+// --- purgeStaleBranches tests ---
+
+// TestPurgeStaleBranches_DeletesTerminalDropletBranches verifies that
+// purgeStaleBranches removes local feat/<id> branches for droplets in
+// delivered/cancelled/pooled status, while preserving branches for active
+// droplets and non-feat branches.
+func TestPurgeStaleBranches_DeletesTerminalDropletBranches(t *testing.T) {
+	primaryDir := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	repoName := "test-repo"
+	prefix := "te-"
+
+	dstPrimary := filepath.Join(sandboxRoot, repoName, "_primary")
+	branchMustRun(t, branchGitCmd(".", "clone", primaryDir, dstPrimary))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(dstPrimary, "config", "user.name", "Lobsterdog Contributors"))
+
+	_, err := prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"deliver")
+	if err != nil {
+		t.Fatalf("prepare worktree: %v", err)
+	}
+	_, err = prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"cancel")
+	if err != nil {
+		t.Fatalf("prepare worktree: %v", err)
+	}
+	_, err = prepareDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"active")
+	if err != nil {
+		t.Fatalf("prepare worktree: %v", err)
+	}
+
+	removeDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"deliver", true)
+	removeDropletWorktree(dstPrimary, sandboxRoot, repoName, prefix+"cancel", true)
+
+	if !branchExists(t, dstPrimary, "feat/"+prefix+"deliver") {
+		t.Fatal("feat/te-deliver branch should exist after keepBranch cleanup")
+	}
+	if !branchExists(t, dstPrimary, "feat/"+prefix+"cancel") {
+		t.Fatal("feat/te-cancel branch should exist before purge")
+	}
+	if !branchExists(t, dstPrimary, "feat/"+prefix+"active") {
+		t.Fatal("feat/te-active branch should exist before purge")
+	}
+
+	client := newMockClient()
+	client.items[prefix+"deliver"] = &cistern.Droplet{ID: prefix + "deliver", Status: "delivered"}
+	client.items[prefix+"cancel"] = &cistern.Droplet{ID: prefix + "cancel", Status: "cancelled"}
+	client.items[prefix+"active"] = &cistern.Droplet{ID: prefix + "active", Status: "in_progress"}
+
+	s := &Castellarius{
+		config: aqueduct.AqueductConfig{
+			Repos: []aqueduct.RepoConfig{
+				{Name: repoName, Prefix: prefix, Names: []string{"alpha"}},
+			},
+		},
+		clients:     map[string]CisternClient{repoName: client},
+		pools:       map[string]*AqueductPool{repoName: NewAqueductPool(repoName, []string{"alpha"})},
+		sandboxRoot: sandboxRoot,
+		logger:      newBranchLifecycleLogger(io.Discard),
+	}
+
+	s.purgeStaleBranches(repoName, dstPrimary, prefix, client)
+
+	if branchExists(t, dstPrimary, "feat/"+prefix+"deliver") {
+		t.Error("feat/te-deliver should be deleted (delivered droplet)")
+	}
+	if branchExists(t, dstPrimary, "feat/"+prefix+"cancel") {
+		t.Error("feat/te-cancel should be deleted (cancelled droplet)")
+	}
+	if !branchExists(t, dstPrimary, "feat/"+prefix+"active") {
+		t.Error("feat/te-active should be preserved (in-progress droplet)")
 	}
 }

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime/debug"
 	"strings"
 	"sync/atomic"
@@ -620,6 +621,13 @@ func (s *Castellarius) purgeOldItems() {
 	s.purgeOrphanedWorktrees()
 }
 
+// dropletIDRe matches the canonical droplet ID format: 1-3 lowercase
+// letters, a dash, then 5 lowercase alphanumeric characters. This is used
+// by purgeOrphanedWorktrees to distinguish per-droplet worktrees from
+// repo source directories, even when the configured prefix doesn't match
+// the actual droplet IDs in the database.
+var dropletIDRe = regexp.MustCompile(`^[a-z]{1,3}-[a-z0-9]{5}$`)
+
 // purgeOrphanedWorktrees removes per-droplet worktrees whose droplets are no
 // longer active (delivered, cancelled, pooled, or deleted from DB). This catches
 // worktrees that escaped the normal observe-path cleanup due to Castellarius
@@ -628,7 +636,8 @@ func (s *Castellarius) purgeOldItems() {
 // Safe guards:
 //   - Skips _primary (shared object store for the repo)
 //   - Skips named aqueduct worker directories (alpha, virgo, etc.)
-//   - Skips directories that don't match the repo's droplet prefix
+//   - Skips directories that don't look like droplet IDs (must match
+//     the configured prefix OR the droplet ID regex pattern)
 //   - Only removes worktrees whose droplet is delivered/cancelled/pooled
 //     or entirely absent from the database
 func (s *Castellarius) purgeOrphanedWorktrees() {
@@ -671,7 +680,10 @@ func (s *Castellarius) purgeOrphanedWorktrees() {
 			if knownDirs[name] {
 				continue
 			}
-			if !strings.HasPrefix(name, prefix) {
+
+			matchesPrefix := strings.HasPrefix(name, prefix)
+			looksLikeDroplet := dropletIDRe.MatchString(name)
+			if !matchesPrefix && !looksLikeDroplet {
 				continue
 			}
 
@@ -679,7 +691,9 @@ func (s *Castellarius) purgeOrphanedWorktrees() {
 			dropletStatus := "unknown"
 			droplet, err := client.Get(name)
 			if err != nil {
-				remove = true
+				if matchesPrefix {
+					remove = true
+				}
 			} else {
 				dropletStatus = droplet.Status
 				switch droplet.Status {
@@ -693,7 +707,8 @@ func (s *Castellarius) purgeOrphanedWorktrees() {
 				removed++
 				s.logger.Info("orphaned worktree removed",
 					"repo", repo.Name, "droplet", name,
-					"droplet_status", dropletStatus)
+					"droplet_status", dropletStatus,
+					"prefix_match", matchesPrefix)
 			}
 		}
 
@@ -701,6 +716,59 @@ func (s *Castellarius) purgeOrphanedWorktrees() {
 			s.logger.Info("orphaned worktree purge complete",
 				"repo", repo.Name, "removed", removed)
 		}
+
+		s.purgeStaleBranches(repo.Name, primaryDir, prefix, client)
+	}
+}
+
+// purgeStaleBranches removes local feature branches whose droplets are in
+// terminal states. This catches branches left behind when the normal
+// observe-path or orphan-purge removed the worktree but the branch deletion
+// failed (e.g., git worktree lock), or when git fetch recreated the local
+// tracking branch.
+func (s *Castellarius) purgeStaleBranches(repoName, primaryDir, prefix string, client CisternClient) {
+	listCmd := exec.Command("git", "branch", "--format", "%(refname:short)")
+	listCmd.Dir = primaryDir
+	out, err := listCmd.Output()
+	if err != nil {
+		s.logger.Warn("stale branch scan: git branch failed", "repo", repoName, "error", err)
+		return
+	}
+
+	branches := strings.Split(strings.TrimSpace(string(out)), "\n")
+	deleted := 0
+	for _, branch := range branches {
+		if !strings.HasPrefix(branch, "feat/") {
+			continue
+		}
+		dropletID := strings.TrimPrefix(branch, "feat/")
+		if dropletID == "" {
+			continue
+		}
+
+		droplet, err := client.Get(dropletID)
+		if err != nil {
+			continue
+		}
+		switch droplet.Status {
+		case "delivered", "cancelled", "pooled":
+			delCmd := exec.Command("git", "branch", "-D", branch)
+			delCmd.Dir = primaryDir
+			if delErr := delCmd.Run(); delErr != nil {
+				s.logger.Warn("stale branch delete failed",
+					"repo", repoName, "branch", branch, "error", delErr)
+			} else {
+				deleted++
+				s.logger.Info("stale branch deleted",
+					"repo", repoName, "branch", branch,
+					"droplet_status", droplet.Status)
+			}
+		}
+	}
+
+	if deleted > 0 {
+		s.logger.Info("stale branch purge complete",
+			"repo", repoName, "deleted", deleted)
 	}
 }
 
@@ -1642,8 +1710,8 @@ func prepareBranchInSandbox(dir, itemID string) error {
 
 	// Configure git identity so commits don't fail.
 	for _, args := range [][]string{
-		{"git", "config", "user.name", "Cistern Agent"},
-		{"git", "config", "user.email", "agent@cistern.local"},
+		{"git", "config", "user.name", "Lobsterdog Contributors"},
+		{"git", "config", "user.email", "noreply@lobsterdog.dev"},
 		{"git", "config", "core.editor", "true"},
 		{"git", "config", "sequence.editor", "true"},
 	} {
@@ -1845,8 +1913,8 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 	}
 
 	for _, args := range [][]string{
-		{"git", "config", "user.name", "Cistern Agent"},
-		{"git", "config", "user.email", "agent@cistern.local"},
+		{"git", "config", "user.name", "Lobsterdog Contributors"},
+		{"git", "config", "user.email", "noreply@lobsterdog.dev"},
 	} {
 		c := exec.Command(args[0], args[1:]...)
 		c.Dir = worktreePath


### PR DESCRIPTION
## Summary
- The `purgeOrphanedWorktrees` function used `HasPrefix(name, prefix)` to filter directories, but the LLMem config had `prefix: lm` while actual droplet IDs use `ll-`. This made ALL LLMem worktrees invisible to auto-cleanup, causing 3+ stale sandboxes to accumulate.
- Added `dropletIDRe` regex (`^[a-z]{1,3}-[a-z0-9]{5}$`) as a fallback — directories matching this pattern also get checked against the DB, even if they don't match the configured prefix.
- For non-prefix-matched directories, only delete if the DB confirms a terminal state (prevents removing repo source dirs like `cmd/`, `internal/`).
- Added `purgeStaleBranches` to clean up `feat/*` branches whose droplets are delivered/cancelled/pooled — these accumulate when the worktree is removed but branch deletion fails.
- Aligned git identity in `prepareDropletWorktree`/`prepareBranchInSandbox` with the global pre-commit hook (`Lobsterdog Contributors` / `noreply@lobsterdog.dev`) to prevent agent commit failures.
- New tests: `TestPurgeOrphanedWorktrees_PrefixMismatch_StillPurgesOrphans`, `TestPurgeStaleBranches_DeletesTerminalDropletBranches`.