### PR TITLE
chore: switch CI from self-hosted to GitHub-hosted runners

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,28 +10,16 @@ on:
 jobs:
   build:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     steps:
-      - name: Check disk space
-        run: |
-          DISK_USED_PCT=$(df --output=pcent "$GITHUB_WORKSPACE" | tail -1 | tr -d ' %')
-          DISK_FREE_PCT=$((100 - DISK_USED_PCT))
-          DISK_FREE_HUMAN=$(df -h "$GITHUB_WORKSPACE" | tail -1 | awk '{print $4}')
-          echo "Disk free: ${DISK_FREE_PCT}% (${DISK_FREE_HUMAN}) on $(df --output=source "$GITHUB_WORKSPACE" | tail -1)"
-          if [ "${DISK_FREE_PCT}" -lt 10 ]; then
-            echo "::error::Disk space critical: only ${DISK_FREE_PCT}% free on runner. Clean up runner disk before retrying."
-            df -h
-            exit 1
-          fi
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: true
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: false
+          cache: true
 
       - name: Install deps
         run: go mod download
@@ -47,36 +35,12 @@ jobs:
       - name: Test
         run: go test ./... -v
 
-      - name: Clean up runner _update and _diag
-        if: always()
-        run: |
-          RUNNER_ROOT="$(realpath "$GITHUB_WORKSPACE/../../..")"
-          for dir in _update _diag; do
-            TARGET="${RUNNER_ROOT}/${dir}"
-            if [ -d "${TARGET}" ]; then
-              echo "Cleaning ${dir} entries older than 1 day from ${TARGET}"
-              find "${TARGET}" -maxdepth 1 -mindepth 1 -mtime +1 -exec rm -rf {} + 2>/dev/null || true
-            fi
-          done
-
   installer-tests:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Check disk space
-        run: |
-          DISK_USED_PCT=$(df --output=pcent "$GITHUB_WORKSPACE" | tail -1 | tr -d ' %')
-          DISK_FREE_PCT=$((100 - DISK_USED_PCT))
-          DISK_FREE_HUMAN=$(df -h "$GITHUB_WORKSPACE" | tail -1 | awk '{print $4}')
-          echo "Disk free: ${DISK_FREE_PCT}% (${DISK_FREE_HUMAN}) on $(df --output=source "$GITHUB_WORKSPACE" | tail -1)"
-          if [ "${DISK_FREE_PCT}" -lt 10 ]; then
-            echo "::error::Disk space critical: only ${DISK_FREE_PCT}% free on runner. Clean up runner disk before retrying."
-            df -h
-            exit 1
-          fi
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: true
@@ -105,11 +69,11 @@ jobs:
             echo "${CHANGED}"
           fi
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@v6
         if: steps.installer_changed.outputs.skip != 'true'
         with:
           go-version-file: go.mod
-          cache: false
+          cache: true
 
       - name: Build Go binaries
         if: steps.installer_changed.outputs.skip != 'true'
@@ -121,28 +85,16 @@ jobs:
 
       - name: Upload container logs
         if: failure() && steps.installer_changed.outputs.skip != 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: installer-test-logs
           path: |
             installer-test-container.log
           retention-days: 7
 
-      - name: Clean up runner _update and _diag
-        if: always()
-        run: |
-          RUNNER_ROOT="$(realpath "$GITHUB_WORKSPACE/../../..")"
-          for dir in _update _diag; do
-            TARGET="${RUNNER_ROOT}/${dir}"
-            if [ -d "${TARGET}" ]; then
-              echo "Cleaning ${dir} entries older than 1 day from ${TARGET}"
-              find "${TARGET}" -maxdepth 1 -mindepth 1 -mtime +1 -exec rm -rf {} + 2>/dev/null || true
-            fi
-          done
-
   installer-integration-tests:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     env:
@@ -150,19 +102,7 @@ jobs:
       IMAGE_TAG: cistern/installer-test:${{ github.run_id }}
 
     steps:
-      - name: Check disk space
-        run: |
-          DISK_USED_PCT=$(df --output=pcent "$GITHUB_WORKSPACE" | tail -1 | tr -d ' %')
-          DISK_FREE_PCT=$((100 - DISK_USED_PCT))
-          DISK_FREE_HUMAN=$(df -h "$GITHUB_WORKSPACE" | tail -1 | awk '{print $4}')
-          echo "Disk free: ${DISK_FREE_PCT}% (${DISK_FREE_HUMAN}) on $(df --output=source "$GITHUB_WORKSPACE" | tail -1)"
-          if [ "${DISK_FREE_PCT}" -lt 10 ]; then
-            echo "::error::Disk space critical: only ${DISK_FREE_PCT}% free on runner. Clean up runner disk before retrying."
-            df -h
-            exit 1
-          fi
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -194,12 +134,11 @@ jobs:
         if: steps.installer_changed.outputs.skip != 'true'
         run: |
           docker run \
-            --privileged \
-            --cgroupns=host \
-            -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            --security-opt seccomp=unconfined \
+            --security-opt apparmor=unconfined \
             --tmpfs /run \
             --tmpfs /run/lock \
-            --security-opt apparmor=unconfined \
+            --tmpfs /tmp \
             -d \
             --name "${CONTAINER_NAME}" \
             "${IMAGE_TAG}"
@@ -260,15 +199,3 @@ jobs:
           docker rm "${CONTAINER_NAME}" 2>/dev/null || true
           docker rmi "${IMAGE_TAG}" 2>/dev/null || true
           rm -f "/tmp/installer-test-output-${GITHUB_RUN_ID}.txt"
-
-      - name: Clean up runner _update and _diag
-        if: always()
-        run: |
-          RUNNER_ROOT="$(realpath "$GITHUB_WORKSPACE/../../..")"
-          for dir in _update _diag; do
-            TARGET="${RUNNER_ROOT}/${dir}"
-            if [ -d "${TARGET}" ]; then
-              echo "Cleaning ${dir} entries older than 1 day from ${TARGET}"
-              find "${TARGET}" -maxdepth 1 -mindepth 1 -mtime +1 -exec rm -rf {} + 2>/dev/null || true
-            fi
-          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,42 +7,16 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
-      - name: Check disk space
-        run: |
-          DISK_USED_PCT=$(df --output=pcent "$GITHUB_WORKSPACE" | tail -1 | tr -d ' %')
-          DISK_FREE_PCT=$((100 - DISK_USED_PCT))
-          DISK_FREE_HUMAN=$(df -h "$GITHUB_WORKSPACE" | tail -1 | awk '{print $4}')
-          echo "Disk free: ${DISK_FREE_PCT}% (${DISK_FREE_HUMAN}) on $(df --output=source "$GITHUB_WORKSPACE" | tail -1)"
-          if [ "${DISK_FREE_PCT}" -lt 10 ]; then
-            echo "::error::Disk space critical: only ${DISK_FREE_PCT}% free on runner. Clean up runner disk before retrying."
-            df -h
-            exit 1
-          fi
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-
-      - name: Compute cache week
-        id: cache-week
-        run: echo "week=$(date +%Y%U)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Go modules
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-week${{ steps.cache-week.outputs.week }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-week${{ steps.cache-week.outputs.week }}-
-            ${{ runner.os }}-go-
+          cache: true
 
       - name: Install deps
         run: go mod download
@@ -59,39 +33,15 @@ jobs:
       - name: Test
         run: go test ./... -v
 
-      - name: Clean up runner _update and _diag
-        if: always()
-        run: |
-          RUNNER_ROOT="$(realpath "$GITHUB_WORKSPACE/../../..")"
-          for dir in _update _diag; do
-            TARGET="${RUNNER_ROOT}/${dir}"
-            if [ -d "${TARGET}" ]; then
-              echo "Cleaning ${dir} entries older than 1 day from ${TARGET}"
-              find "${TARGET}" -maxdepth 1 -mindepth 1 -mtime +1 -exec rm -rf {} + 2>/dev/null || true
-            fi
-          done
-
   publish:
     needs: test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Check disk space
-        run: |
-          DISK_USED_PCT=$(df --output=pcent "$GITHUB_WORKSPACE" | tail -1 | tr -d ' %')
-          DISK_FREE_PCT=$((100 - DISK_USED_PCT))
-          DISK_FREE_HUMAN=$(df -h "$GITHUB_WORKSPACE" | tail -1 | awk '{print $4}')
-          echo "Disk free: ${DISK_FREE_PCT}% (${DISK_FREE_HUMAN}) on $(df --output=source "$GITHUB_WORKSPACE" | tail -1)"
-          if [ "${DISK_FREE_PCT}" -lt 10 ]; then
-            echo "::error::Disk space critical: only ${DISK_FREE_PCT}% free on runner. Clean up runner disk before retrying."
-            df -h
-            exit 1
-          fi
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -103,13 +53,13 @@ jobs:
           echo "commit=${COMMIT}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -117,7 +67,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -126,7 +76,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -136,15 +86,3 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.tag }}
             COMMIT=${{ steps.version.outputs.commit }}
-
-      - name: Clean up runner _update and _diag
-        if: always()
-        run: |
-          RUNNER_ROOT="$(realpath "$GITHUB_WORKSPACE/../../..")"
-          for dir in _update _diag; do
-            TARGET="${RUNNER_ROOT}/${dir}"
-            if [ -d "${TARGET}" ]; then
-              echo "Cleaning ${dir} entries older than 1 day from ${TARGET}"
-              find "${TARGET}" -maxdepth 1 -mindepth 1 -mtime +1 -exec rm -rf {} + 2>/dev/null || true
-            fi
-          done


### PR DESCRIPTION
## Summary
- Switch all jobs from `[self-hosted, linux, x64]` / `self-hosted` to `ubuntu-latest`
- Remove disk-space checks (not needed on ephemeral GitHub-hosted runners)
- Remove runner `_update`/`_diag` cleanup steps (self-hosted specific maintenance)
- Remove per-week Go cache step — use built-in `actions/setup-go` caching instead
- Unpin action versions (use `@v6` instead of SHA-pinned) for easier maintenance
- For installer-integration-tests: remove `--privileged`, `--cgroupns=host`, and `/sys/fs/cgroup` mount (not available on GitHub-hosted runners). Use `--security-opt seccomp=unconfined` + tmpfs mounts instead. Systemd will run in degraded mode but smoke tests should pass.

## Known limitations
- The systemd integration scenarios in installer-integration-tests may not fully work without `--privileged`. The smoke tests (ct binary, fakeagent, ct init, ct doctor) should work fine. If the full integration suite fails, we can split it into a separate manual job later.