### PR TITLE
feat: replace agent heartbeat with Castellarius-driven liveness detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,17 +380,15 @@ ct doctor --fix                # Auto-repair common configuration issues
 Config lives at `~/.cistern/cistern.yaml`. Key options:
 
 ```yaml
-# Heartbeat: how often the Castellarius scans for stalled sessions
-heartbeat_interval: 30s
+# Liveness check: how often the Castellarius scans for stalled sessions
+liveness_interval: 30s
 
 # Stall detection: threshold for inactivity before marking a droplet as stalled
-# Monitors three progress signals: newest note timestamp, worktree file mtime,
-# and session log mtime. Droplet is stalled if all three are older than this threshold.
-# When detected: (1) a "stall" event is recorded with diagnostic signals, (2) if the
-# droplet has an assignee with prior session history, the session is automatically
-# re-spawned with --continue to allow the agent to resume; (3) further stall events
-# are suppressed until one of the signals advances. Re-spawn failures are automatically
-# retried on the next heartbeat tick.
+# Monitors session log mtime (written by tmux pipe-pane). If the agent is alive,
+# its session log is being written to continuously. A stale mtime means the agent
+# is stuck or dead. If no session log exists (orphan droplets), updated_at is used
+# as a fallback signal. When detected: a "stall" event is recorded with diagnostic
+# signals, and orphaned droplets are reset to open for re-dispatch.
 # Default: 45 minutes
 stall_threshold_minutes: 45
 
@@ -690,7 +688,6 @@ The web dashboard exposes a REST API at `/api/` that mirrors all TUI operations.
 | `POST` | `/api/droplets/{id}/cancel` | Cancel droplet (JSON body: `reason`) |
 | `POST` | `/api/droplets/{id}/restart` | Restart at step (optional JSON body: `cataractae`) |
 | `POST` | `/api/droplets/{id}/approve` | Approve human-gated droplet |
-| `POST` | `/api/droplets/{id}/heartbeat` | Record agent heartbeat |
 
 ### Notes
 

--- a/cmd/ct/cistern.go
+++ b/cmd/ct/cistern.go
@@ -1006,33 +1006,6 @@ var dropletRecirculateCmd = &cobra.Command{
 	},
 }
 
-// --- cistern heartbeat ---
-
-var dropletHeartbeatCmd = &cobra.Command{
-	Use:   "heartbeat <id>",
-	Short: "Record agent heartbeat — signals the scheduler that work is progressing",
-	Long: `Record a heartbeat timestamp for the given droplet.
-
-Agents should call this every 60 seconds while working. The stall detector
-uses the heartbeat timestamp to distinguish alive-but-slow agents from agents
-that are genuinely stuck or dead. An agent that is emitting heartbeats will
-not be considered stalled regardless of how long it has been running.`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := cistern.New(resolveDBPath(), "")
-		if err != nil {
-			return err
-		}
-		defer c.Close()
-
-		if err := c.Heartbeat(args[0]); err != nil {
-			return err
-		}
-		fmt.Printf("droplet %s: heartbeat recorded\n", args[0])
-		return nil
-	},
-}
-
 // --- cistern peek ---
 
 var (
@@ -1495,7 +1468,7 @@ func init() {
 		dropletPassCmd, dropletRecirculateCmd, dropletPoolCmd, dropletCancelCmd,
 		dropletStatsCmd, dropletDepsCmd, dropletPeekCmd, dropletIssueCmd, dropletSearchCmd,
 		dropletExportCmd, dropletRenameCmd, dropletRestartCmd, dropletEditCmd,
-		dropletTailCmd, dropletHeartbeatCmd, dropletLogCmd, dropletHistoryCmd)
+		dropletTailCmd, dropletLogCmd, dropletHistoryCmd)
 	rootCmd.AddCommand(dropletCmd)
 	rootCmd.AddCommand(evaluateCmd)
 }

--- a/cmd/ct/cistern_test.go
+++ b/cmd/ct/cistern_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/MichielDean/cistern/internal/cistern"
 )
@@ -1477,62 +1476,6 @@ func TestDropletEdit(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
-}
-
-func TestDropletHeartbeat(t *testing.T) {
-	dir := t.TempDir()
-	db := filepath.Join(dir, "test.db")
-	t.Setenv("CT_DB", db)
-
-	c, err := cistern.New(db, "ts")
-	if err != nil {
-		t.Fatal(err)
-	}
-	item, err := c.Add("repo", "Feature", "", 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.Close()
-
-	before := time.Now().Add(-time.Second)
-	out := captureStdout(t, func() {
-		if err := dropletHeartbeatCmd.RunE(dropletHeartbeatCmd, []string{item.ID}); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-	after := time.Now().Add(time.Second)
-
-	if !strings.Contains(out, "heartbeat recorded") {
-		t.Errorf("expected 'heartbeat recorded' in output, got: %q", out)
-	}
-
-	// Verify last_heartbeat_at is written to DB.
-	c2, err := cistern.New(db, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer c2.Close()
-	got, err := c2.Get(item.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.LastHeartbeatAt.IsZero() {
-		t.Fatal("LastHeartbeatAt is zero after heartbeat command")
-	}
-	if got.LastHeartbeatAt.Before(before) || got.LastHeartbeatAt.After(after) {
-		t.Errorf("LastHeartbeatAt = %v, want between %v and %v", got.LastHeartbeatAt, before, after)
-	}
-}
-
-func TestDropletHeartbeat_NotFound(t *testing.T) {
-	dir := t.TempDir()
-	db := filepath.Join(dir, "test.db")
-	t.Setenv("CT_DB", db)
-
-	err := dropletHeartbeatCmd.RunE(dropletHeartbeatCmd, []string{"nonexistent"})
-	if err == nil {
-		t.Fatal("expected error for nonexistent droplet")
-	}
 }
 
 func TestRootCmd_CompletionCommand_IsHiddenFromHelp(t *testing.T) {

--- a/cmd/ct/dashboard_api_test.go
+++ b/cmd/ct/dashboard_api_test.go
@@ -682,25 +682,6 @@ func TestAPI_ApproveDroplet_Success(t *testing.T) {
 	}
 }
 
-func TestAPI_Heartbeat_Success(t *testing.T) {
-	db := tempDB(t)
-	c, err := cistern.New(db, "mr")
-	if err != nil {
-		t.Fatal(err)
-	}
-	d, _ := c.Add("myrepo", "Test", "", 1)
-	c.Close()
-
-	mux := newDashboardMux(tempCfg(t), db)
-	req := httptest.NewRequest(http.MethodPost, "/api/droplets/"+d.ID+"/heartbeat", nil)
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200", w.Code)
-	}
-}
-
 // --- Notes ---
 
 func TestAPI_GetNotes_ReturnsNotes(t *testing.T) {

--- a/cmd/ct/dashboard_web.go
+++ b/cmd/ct/dashboard_web.go
@@ -1107,7 +1107,7 @@ func newDashboardMuxInternalWith(cfgPath, dbPath string, tui *DashboardTUI, fetc
 	apiMux.HandleFunc("POST /api/droplets/{id}/cancel", handleCancelDroplet(dbPath))
 	apiMux.HandleFunc("POST /api/droplets/{id}/restart", handleRestartDroplet(dbPath))
 	apiMux.HandleFunc("POST /api/droplets/{id}/approve", handleApproveDroplet(dbPath))
-	apiMux.HandleFunc("POST /api/droplets/{id}/heartbeat", handleHeartbeatDroplet(dbPath))
+
 
 	// Notes
 	apiMux.HandleFunc("GET /api/droplets/{id}/notes", handleGetNotes(dbPath))
@@ -1965,19 +1965,6 @@ func handleApproveDroplet(dbPath string) http.HandlerFunc {
 				return err
 			}
 			writeAPIJSON(w, http.StatusOK, map[string]string{"id": id, "status": "approved"})
-			return nil
-		})
-	}
-}
-
-func handleHeartbeatDroplet(dbPath string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		id := r.PathValue("id")
-		apiClient(dbPath, w, func(c *cistern.Client) error {
-			if err := c.Heartbeat(id); err != nil {
-				return err
-			}
-			writeAPIJSON(w, http.StatusOK, map[string]string{"id": id, "heartbeat": "recorded"})
 			return nil
 		})
 	}

--- a/cmd/ct/droplet_history_test.go
+++ b/cmd/ct/droplet_history_test.go
@@ -216,28 +216,24 @@ func TestDropletHistory_InvalidFormat(t *testing.T) {
 	}
 }
 
-func TestDropletHistory_NoSyntheticHeartbeat(t *testing.T) {
+func TestDropletHistory_NoteOrdering(t *testing.T) {
 	c := setupHistoryTestDB(t)
-	item, err := c.Add("myrepo", "Heartbeat history task", "", 1)
+	item, err := c.Add("myrepo", "Note ordering task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	c.GetReadyForAqueduct("myrepo", "default")
 	c.Assign(item.ID, "worker-1", "implement")
-	c.AddNote(item.ID, "implement", "started")
-	err = c.Heartbeat(item.ID)
-	if err != nil {
-		t.Fatalf("heartbeat failed: %v", err)
-	}
+	c.AddNote(item.ID, "implement", "early note")
 
 	out, err := runHistoryCapture(t, item.ID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if strings.Contains(out, "last heartbeat recorded") {
-		t.Errorf("history output should not contain synthetic heartbeat detail: %s", out)
+	if !strings.Contains(out, "early note") {
+		t.Errorf("history output should contain note: %s", out)
 	}
 }
 

--- a/cmd/ct/droplet_log_test.go
+++ b/cmd/ct/droplet_log_test.go
@@ -243,34 +243,9 @@ func TestDropletLog_InvalidFormat(t *testing.T) {
 	}
 }
 
-func TestDropletLog_NoSyntheticHeartbeat(t *testing.T) {
+func TestDropletLog_NoteOrdering(t *testing.T) {
 	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Heartbeat task", "", 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c.GetReadyForAqueduct("myrepo", "default")
-	c.Assign(item.ID, "worker-1", "implement")
-	c.AddNote(item.ID, "implement", "started")
-	err = c.Heartbeat(item.ID)
-	if err != nil {
-		t.Fatalf("heartbeat failed: %v", err)
-	}
-
-	out, err := runLogCapture(t, item.ID)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if strings.Contains(out, "last heartbeat recorded") {
-		t.Errorf("log output should not contain synthetic heartbeat detail: %s", out)
-	}
-}
-
-func TestDropletLog_HeartbeatInChronologicalOrder(t *testing.T) {
-	c := setupLogTestDB(t)
-	item, err := c.Add("myrepo", "Heartbeat order task", "", 1)
+	item, err := c.Add("myrepo", "Note ordering task", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,11 +253,6 @@ func TestDropletLog_HeartbeatInChronologicalOrder(t *testing.T) {
 	c.GetReadyForAqueduct("myrepo", "default")
 	c.Assign(item.ID, "worker-1", "implement")
 	c.AddNote(item.ID, "implement", "early note")
-	err = c.Heartbeat(item.ID)
-	if err != nil {
-		t.Fatalf("heartbeat failed: %v", err)
-	}
-
 	time.Sleep(10 * time.Millisecond)
 	c.AddNote(item.ID, "implement", "late note")
 
@@ -291,13 +261,13 @@ func TestDropletLog_HeartbeatInChronologicalOrder(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	heartbeatIdx := strings.Index(out, "heartbeat")
+	noteIdx := strings.Index(out, "early note")
 	lateNoteIdx := strings.Index(out, "late note")
-	if heartbeatIdx == -1 || lateNoteIdx == -1 {
-		t.Fatalf("log output missing expected entries: %s", out)
+	if noteIdx == -1 || lateNoteIdx == -1 {
+		t.Fatalf("log output missing expected notes: %s", out)
 	}
-	if heartbeatIdx > lateNoteIdx {
-		t.Errorf("heartbeat should appear before late note in chronological order: heartbeat at %d, late note at %d", heartbeatIdx, lateNoteIdx)
+	if noteIdx > lateNoteIdx {
+		t.Errorf("notes not in chronological order: early note at %d, late note at %d", noteIdx, lateNoteIdx)
 	}
 }
 
@@ -526,7 +496,7 @@ func TestDisplayInfo_DisplaysHumanReadableDetails(t *testing.T) {
 		{
 			name:     "stall event shows step, elapsed",
 			evt:      "stall",
-			detail:   `{"cataractae":"implement","elapsed":"45m","heartbeat":"2026-04-21T10:00:00Z"}`,
+			detail:   `{"cataractae":"implement","elapsed":"45m"}`,
 			wantEvt:  "stall",
 			wantSub:  "step: implement, elapsed: 45m",
 			wantOmit: `"cataractae"`,

--- a/internal/aqueduct/types.go
+++ b/internal/aqueduct/types.go
@@ -161,10 +161,10 @@ type AqueductConfig struct {
 	HandoffTokenThreshold int          `yaml:"handoff_token_threshold"`
 	RetentionDays         int          `yaml:"retention_days"`
 	CleanupInterval       string       `yaml:"cleanup_interval"`
-	// HeartbeatInterval controls how often the Castellarius scans in-progress
+	// LivenessInterval controls how often the Castellarius scans in-progress
 	// droplets for orphaned or stalled sessions. Accepts Go duration strings
 	// (e.g. "30s", "1m"). Defaults to "30s" when empty.
-	HeartbeatInterval string        `yaml:"heartbeat_interval,omitempty"`
+	LivenessInterval string        `yaml:"liveness_interval,omitempty"`
 	DroughtHooks      []DroughtHook `yaml:"drought_hooks,omitempty"`
 	// RateLimit configures rate limiting for the delivery cataractae API endpoint.
 	// Omit to use the built-in defaults (60 req/min per IP, 120 req/min per token).
@@ -187,9 +187,8 @@ type AqueductConfig struct {
 	// Defaults to 5 when omitted or 0.
 	DrainTimeoutMinutes int `yaml:"drain_timeout_minutes,omitempty"`
 
-	// StallThresholdMinutes is the number of minutes of inactivity across all
-	// three progress signals (newest note, worktree mtime, session log mtime)
-	// before a droplet is considered stalled. Defaults to 45 when absent or 0.
+	// StallThresholdMinutes is the number of minutes of inactivity (session log
+	// mtime) before a droplet is considered stalled. Defaults to 45 when absent or 0.
 	StallThresholdMinutes int `yaml:"stall_threshold_minutes,omitempty"`
 
 	// DashboardFontFamily is the CSS font-family string used by the Cistern

--- a/internal/castellarius/coverage_gaps_test.go
+++ b/internal/castellarius/coverage_gaps_test.go
@@ -286,9 +286,9 @@ func TestRecoverInProgress(t *testing.T) {
 	}
 }
 
-// --- heartbeatRepo tests ---
+// --- livenessCheckRepo tests ---
 
-func TestHeartbeatRepo(t *testing.T) {
+func TestLivenessCheckRepo(t *testing.T) {
 	tests := []struct {
 		name       string
 		item       *cistern.Droplet
@@ -297,7 +297,7 @@ func TestHeartbeatRepo(t *testing.T) {
 		{
 			name: "writes stall note for droplet with no recent signals",
 			item: &cistern.Droplet{
-				ID: "hb-1", CurrentCataractae: "implement", Status: "in_progress",
+				ID: "lc-1", CurrentCataractae: "implement", Status: "in_progress",
 				Assignee: "", Outcome: "",
 			},
 			wantEvents: 2, // stall + recovery
@@ -305,7 +305,7 @@ func TestHeartbeatRepo(t *testing.T) {
 		{
 			name: "skips item with outcome",
 			item: &cistern.Droplet{
-				ID: "hb-2", CurrentCataractae: "review", Status: "in_progress",
+				ID: "lc-2", CurrentCataractae: "review", Status: "in_progress",
 				Assignee: "", Outcome: "pass",
 			},
 			wantEvents: 0,
@@ -316,7 +316,7 @@ func TestHeartbeatRepo(t *testing.T) {
 			client := newMockClient()
 			client.items[tc.item.ID] = tc.item
 			sched := testScheduler(client, newMockRunner(client))
-			sched.heartbeatRepo(context.Background(), sched.config.Repos[0])
+			sched.livenessCheckRepo(context.Background(), sched.config.Repos[0])
 			client.mu.Lock()
 			defer client.mu.Unlock()
 			if len(client.events) != tc.wantEvents {
@@ -326,16 +326,13 @@ func TestHeartbeatRepo(t *testing.T) {
 	}
 }
 
-func TestHeartbeatRepo_StallDetected_ForAssignedDroplet(t *testing.T) {
-	// A droplet assigned to a worker with no recent signals should receive a
-	// stall note. Mock tmux as alive so the liveness check passes through to
-	// the stall detector.
+func TestLivenessCheckRepo_StallDetected_ForAssignedDroplet(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 	client := newMockClient()
 	item := &cistern.Droplet{
-		ID:                "hb-assigned-stall",
+		ID:                "lc-assigned-stall",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
 		Assignee:          "alpha",
@@ -344,7 +341,11 @@ func TestHeartbeatRepo_StallDetected_ForAssignedDroplet(t *testing.T) {
 	client.items[item.ID] = item
 
 	sched := testScheduler(client, newMockRunner(client))
-	sched.heartbeatRepo(context.Background(), sched.config.Repos[0])
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+	sched.livenessCheckRepo(context.Background(), sched.config.Repos[0])
 
 	client.mu.Lock()
 	defer client.mu.Unlock()
@@ -353,27 +354,26 @@ func TestHeartbeatRepo_StallDetected_ForAssignedDroplet(t *testing.T) {
 	}
 }
 
-func TestHeartbeatRepo_ActiveDroplet_NotStalled(t *testing.T) {
-	// A droplet whose newest note signal is within the stall threshold should
-	// not receive a stall event. Mock tmux as alive so the liveness check passes
-	// through to the stall detector.
+func TestLivenessCheckRepo_ActiveDroplet_NotStalled(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 	client := newMockClient()
 	item := &cistern.Droplet{
-		ID:                "hb-active",
+		ID:                "lc-active",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
 		Assignee:          "alpha",
 		Outcome:           "",
-		// Recent heartbeat: 1 minute ago, well within the 45-minute default threshold.
-		LastHeartbeatAt: time.Now().Add(-1 * time.Minute),
 	}
 	client.items[item.ID] = item
 
 	sched := testScheduler(client, newMockRunner(client))
-	sched.heartbeatRepo(context.Background(), sched.config.Repos[0])
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-1 * time.Minute), nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+	sched.livenessCheckRepo(context.Background(), sched.config.Repos[0])
 
 	client.mu.Lock()
 	defer client.mu.Unlock()
@@ -382,24 +382,26 @@ func TestHeartbeatRepo_ActiveDroplet_NotStalled(t *testing.T) {
 	}
 }
 
-func TestHeartbeatRepo_UnknownAssignee_WritesStallNote(t *testing.T) {
-	// A droplet with an unknown assignee and no recent signals should receive
-	// a stall note. Mock tmux as alive so liveness check passes through.
+func TestLivenessCheckRepo_UnknownAssignee_WritesStallNote(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 	client := newMockClient()
 	item := &cistern.Droplet{
-		ID:                "hb-unknown",
+		ID:                "lc-unknown",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
-		Assignee:          "removed-aqueduct", // not in pool
+		Assignee:          "removed-aqueduct",
 		Outcome:           "",
 	}
 	client.items[item.ID] = item
 
 	sched := testScheduler(client, newMockRunner(client))
-	sched.heartbeatRepo(context.Background(), sched.config.Repos[0])
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+	sched.livenessCheckRepo(context.Background(), sched.config.Repos[0])
 
 	client.mu.Lock()
 	defer client.mu.Unlock()
@@ -408,11 +410,11 @@ func TestHeartbeatRepo_UnknownAssignee_WritesStallNote(t *testing.T) {
 	}
 }
 
-// TestHeartbeatRepo_ExitNoOutcome_AddsNoteAndResetsToOpen verifies that when
-// a tmux session is dead and the item is old enough, heartbeatRepo records an
+// TestLivenessCheckRepo_ExitNoOutcome_AddsNoteAndResetsToOpen verifies that when
+// a tmux session is dead and the item is old enough, livenessCheckRepo records an
 // exit_no_outcome event (containing session, worker, and cataractae) and resets the
 // droplet to open for re-dispatch.
-func TestHeartbeatRepo_ExitNoOutcome_AddsNoteAndResetsToOpen(t *testing.T) {
+func TestLivenessCheckRepo_ExitNoOutcome_AddsNoteAndResetsToOpen(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return false }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
@@ -424,13 +426,13 @@ func TestHeartbeatRepo_ExitNoOutcome_AddsNoteAndResetsToOpen(t *testing.T) {
 		Status:            "in_progress",
 		Assignee:          "alpha",
 		Outcome:           "",
-		UpdatedAt:         time.Now().Add(-10 * time.Minute), // old enough
+		UpdatedAt:         time.Now().Add(-10 * time.Minute),
 		StageDispatchedAt: time.Now().Add(-10 * time.Minute),
 	}
 	client.items[item.ID] = item
 
 	sched := testScheduler(client, newMockRunner(client))
-	sched.heartbeatRepo(context.Background(), sched.config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), sched.config.Repos[0])
 
 	client.mu.Lock()
 	defer client.mu.Unlock()
@@ -441,15 +443,14 @@ func TestHeartbeatRepo_ExitNoOutcome_AddsNoteAndResetsToOpen(t *testing.T) {
 	if client.events[0].eventType != cistern.EventExitNoOutcome {
 		t.Errorf("event type = %q, want %q", client.events[0].eventType, cistern.EventExitNoOutcome)
 	}
-	// Droplet must be reset to open for re-dispatch.
 	if got := client.items[item.ID].Status; got != "open" {
 		t.Errorf("droplet status after exit reset = %q, want %q", got, "open")
 	}
 }
 
-// TestHeartbeatRepo_ExitGuardYoungSession_Skipped verifies that a droplet whose
+// TestLivenessCheckRepo_ExitGuardYoungSession_Skipped verifies that a droplet whose
 // tmux session is dead but was dispatched very recently is skipped (age guard).
-func TestHeartbeatRepo_ExitGuardYoungSession_Skipped(t *testing.T) {
+func TestLivenessCheckRepo_ExitGuardYoungSession_Skipped(t *testing.T) {
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return false }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
@@ -461,12 +462,12 @@ func TestHeartbeatRepo_ExitGuardYoungSession_Skipped(t *testing.T) {
 		Status:            "in_progress",
 		Assignee:          "alpha",
 		Outcome:           "",
-		UpdatedAt:         time.Now(), // very recent — within age guard
+		UpdatedAt:         time.Now(),
 	}
 	client.items[item.ID] = item
 
 	sched := testScheduler(client, newMockRunner(client))
-	sched.heartbeatRepo(context.Background(), sched.config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), sched.config.Repos[0])
 
 	client.mu.Lock()
 	defer client.mu.Unlock()
@@ -479,24 +480,24 @@ func TestHeartbeatRepo_ExitGuardYoungSession_Skipped(t *testing.T) {
 	}
 }
 
-func TestHeartbeatInProgress_CallsHeartbeatForAllRepos(t *testing.T) {
+func TestLivenessCheck_CallsLivenessCheckForAllRepos(t *testing.T) {
 	client := newMockClient()
 	item := &cistern.Droplet{
-		ID:                "hb-all-1",
+		ID:                "lc-all-1",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
 		Assignee:          "",
 		Outcome:           "",
 	}
-	client.items["hb-all-1"] = item
+	client.items["lc-all-1"] = item
 
 	sched := testScheduler(client, newMockRunner(client))
-	sched.heartbeatInProgress(context.Background())
+	sched.livenessCheck(context.Background())
 
 	client.mu.Lock()
 	defer client.mu.Unlock()
 	if len(client.events) != 2 {
-		t.Errorf("heartbeatInProgress: expected 2 events (stall + recovery) for orphaned item, got %d", len(client.events))
+		t.Errorf("livenessCheck: expected 2 events (stall + recovery) for orphaned item, got %d", len(client.events))
 	}
 }
 

--- a/internal/castellarius/integration_test.go
+++ b/internal/castellarius/integration_test.go
@@ -74,7 +74,7 @@ func sessionPrefix(t *testing.T) string {
 // droplet ID and signal pass via `ct droplet pass <id>`.
 //
 // Session isolation is achieved by embedding a per-test prefix into the repo
-// name via intConfig(prefix), so both the runner and the Castellarius heartbeat
+// name via intConfig(prefix), so both the runner and the Castellarius liveness
 // derive identical session names (repo.Name + "-" + assignee).
 type integrationRunner struct {
 	t        *testing.T
@@ -104,7 +104,7 @@ func intShellQuote(s string) string {
 // fakeagent. Returns immediately (non-blocking).
 //
 // Session names are derived as req.RepoConfig.Name+"-"+req.AqueductName. The
-// per-test prefix is embedded in RepoConfig.Name by intConfig, so the heartbeat
+// per-test prefix is embedded in RepoConfig.Name by intConfig, so the liveness
 // (which computes the same formula) finds the correct session.
 func (r *integrationRunner) Spawn(_ context.Context, req castellarius.CataractaeRequest) error {
 	dir, err := os.MkdirTemp("", "cistern-inttest-*")
@@ -120,7 +120,7 @@ func (r *integrationRunner) Spawn(_ context.Context, req castellarius.Cataractae
 	}
 
 	// Session name: <repo>-<aqueduct>. The prefix is embedded in the repo name
-	// by intConfig so the heartbeat (which computes repo.Name+"-"+assignee) and
+	// by intConfig so the liveness check (which computes repo.Name+"-"+assignee) and
 	// this runner derive identical session names.
 	sessionID := req.RepoConfig.Name + "-" + req.AqueductName
 	r.mu.Lock()
@@ -259,9 +259,9 @@ func intWorkflow() *aqueduct.Workflow {
 }
 
 // intConfig returns a minimal AqueductConfig for integration tests.
-// The prefix is embedded in the repo name so that the Castellarius heartbeat
+// The prefix is embedded in the repo name so that the Castellarius liveness check
 // (which computes sessionID as repo.Name+"-"+assignee) matches the session
-// names created by integrationRunner.Spawn, preventing false-positive heartbeat
+// names created by integrationRunner.Spawn, preventing false-positive liveness
 // recovery and ensuring test sessions never collide with production.
 func intConfig(prefix string) aqueduct.AqueductConfig {
 	return aqueduct.AqueductConfig{
@@ -277,7 +277,7 @@ func intConfig(prefix string) aqueduct.AqueductConfig {
 }
 
 // newIntScheduler creates a Castellarius configured for integration tests with
-// short poll and heartbeat intervals to keep test runtime under 30s.
+// short poll and liveness intervals to keep test runtime under 30s.
 // prefix must match the value embedded in the repo name via intConfig.
 func newIntScheduler(client *cistern.Client, runner castellarius.CataractaeRunner, prefix string) *castellarius.Castellarius {
 	cfg := intConfig(prefix)
@@ -287,7 +287,7 @@ func newIntScheduler(client *cistern.Client, runner castellarius.CataractaeRunne
 
 	return castellarius.NewFromParts(cfg, workflows, clients, runner,
 		castellarius.WithPollInterval(500*time.Millisecond),
-		castellarius.WithHeartbeatInterval(time.Second),
+		castellarius.WithLivenessInterval(time.Second),
 		castellarius.WithDrainTimeout(3*time.Second),
 	)
 }
@@ -455,15 +455,15 @@ func TestIntegration_StartupRecovery_OrphanedDroplet_RedeliversDroplet(t *testin
 	}
 }
 
-// TestIntegration_HeartbeatRecovery_DeadSession_RedeliversDroplet verifies
+// TestIntegration_LivenessCheckRecovery_DeadSession_RedeliversDroplet verifies
 // that a droplet whose agent session dies at runtime (without signaling) is
-// detected by the heartbeat goroutine, reset to open, and then re-dispatched
+// detected by the liveness check, reset to open, and then re-dispatched
 // to a new session that signals pass:
 //
 //	Given: a droplet is dispatched to a fakeagent that exits without signaling
-//	When:  the heartbeat fires, confirms the tmux session is dead, resets to open
+//	When:  the liveness check fires, confirms the tmux session is dead, resets to open
 //	Then:  the droplet is re-dispatched and reaches 'delivered' status
-func TestIntegration_HeartbeatRecovery_DeadSession_RedeliversDroplet(t *testing.T) {
+func TestIntegration_LivenessCheckRecovery_DeadSession_RedeliversDroplet(t *testing.T) {
 	checkIntegrationPrereqs(t)
 	fakeagentPath := buildFakeagent(t)
 	ctPath := buildCt(t)
@@ -491,7 +491,7 @@ func TestIntegration_HeartbeatRecovery_DeadSession_RedeliversDroplet(t *testing.
 
 	sched := newIntScheduler(client, runner, prefix)
 
-	droplet, err := client.Add(prefix+"-myrepo", "heartbeat recovery test", "desc", 1)
+	droplet, err := client.Add(prefix+"-myrepo", "liveness recovery test", "desc", 1)
 	if err != nil {
 		t.Fatalf("client.Add: %v", err)
 	}
@@ -506,7 +506,7 @@ func TestIntegration_HeartbeatRecovery_DeadSession_RedeliversDroplet(t *testing.
 		if d != nil {
 			status = d.Status
 		}
-		t.Fatalf("droplet %s was not re-delivered after dead-session heartbeat recovery (status: %s)",
+		t.Fatalf("droplet %s was not re-delivered after dead-session liveness check recovery (status: %s)",
 			droplet.ID, status)
 	}
 }

--- a/internal/castellarius/liveness_regression_test.go
+++ b/internal/castellarius/liveness_regression_test.go
@@ -1,0 +1,730 @@
+package castellarius
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MichielDean/cistern/internal/aqueduct"
+	"github.com/MichielDean/cistern/internal/cistern"
+)
+
+// --- Liveness Regression Tests ---
+//
+// This file covers the Castellarius liveness check (formerly "heartbeat")
+// with exhaustive edge-case tests. The liveness check is safety-critical:
+// it detects dead sessions, stalled agents, and orphans. False positives
+// kill active agents; false negatives leave droplets stranded.
+//
+// Every regression that caused a production incident is represented here.
+
+// ===========================================================================
+// Session exit detection
+// ===========================================================================
+
+// TestLiveness_ExitDetection_DeadSession_NoOutcome resets to open.
+func TestLiveness_ExitDetection_DeadSession_NoOutcome(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return false } // session is dead
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+
+	client := newMockClient()
+	var buf bytes.Buffer
+	sched := newTestScheduler(&buf, client)
+
+	dispatchedAt := time.Now().Add(-5 * time.Minute) // old enough for exit guard
+	item := &cistern.Droplet{
+		ID:                "dead-no-outcome",
+		Repo:              "repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: dispatchedAt,
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+
+	found := false
+	for _, e := range client.events {
+		if e.eventType == cistern.EventExitNoOutcome && e.id == item.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected exit_no_outcome event for dead session with no outcome")
+	}
+	if item.Assignee != "" {
+		t.Errorf("expected assignee cleared after exit detection, got %q", item.Assignee)
+	}
+}
+
+// TestLiveness_ExitDetection_DeadSession_WithOutcome skips the droplet.
+func TestLiveness_ExitDetection_DeadSession_WithOutcome(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return false }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+
+	client := newMockClient()
+	var buf bytes.Buffer
+	sched := newTestScheduler(&buf, client)
+
+	dispatchedAt := time.Now().Add(-5 * time.Minute)
+	item := &cistern.Droplet{
+		ID:                "dead-with-outcome",
+		Repo:              "repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		Outcome:           "pass", // outcome already written
+		StageDispatchedAt: dispatchedAt,
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+
+	for _, e := range client.events {
+		if e.id == item.ID {
+			t.Errorf("expected no events for droplet with existing outcome, got %s", e.eventType)
+		}
+	}
+}
+
+// TestLiveness_ExitDetection_DeadSession_CataractaeAdvanced skips.
+func TestLiveness_ExitDetection_DeadSession_CataractaeAdvanced(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return false }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+
+	client := newMockClient()
+	var buf bytes.Buffer
+	sched := newTestScheduler(&buf, client)
+
+	dispatchedAt := time.Now().Add(-5 * time.Minute)
+	item := &cistern.Droplet{
+		ID:                "dead-advanced",
+		Repo:              "repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: dispatchedAt,
+	}
+	client.items[item.ID] = item
+
+	// Simulate the DB having been advanced by the observe cycle.
+	fresh := *item
+	fresh.CurrentCataractae = "review"
+	client.items[item.ID] = &fresh
+
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+
+	for _, e := range client.events {
+		if e.id == item.ID {
+			t.Errorf("expected no events when cataractae already advanced, got %s", e.eventType)
+		}
+	}
+}
+
+// TestLiveness_ExitDetection_DeadSession_DispatchedAtChanged skips.
+func TestLiveness_ExitDetection_DeadSession_DispatchedAtChanged(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return false }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+
+	client := newMockClient()
+	var buf bytes.Buffer
+	sched := newTestScheduler(&buf, client)
+
+	oldDispatched := time.Now().Add(-5 * time.Minute)
+	item := &cistern.Droplet{
+		ID:                "dead-dispatched-changed",
+		Repo:              "repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: oldDispatched,
+	}
+	client.items[item.ID] = item
+
+	// DB has a newer dispatched_at — droplet was re-dispatched.
+	fresh := *item
+	fresh.StageDispatchedAt = time.Now().Add(-30 * time.Second)
+	client.items[item.ID] = &fresh
+
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+
+	for _, e := range client.events {
+		if e.id == item.ID {
+			t.Errorf("expected no events when re-dispatched, got %s", e.eventType)
+		}
+	}
+}
+
+// TestLiveness_ExitDetection_DeadSession_AssigneeChanged skips.
+// This verifies the code path where the DB has been updated between List and Get.
+// We simulate this by setting up items in the map before calling livenessCheckRepo.
+// Get returns the current map entry (with changed assignee), so the liveness check
+// should detect the stale snapshot and skip the droplet.
+func TestLiveness_ExitDetection_DeadSession_AssigneeChanged(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return false }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	var buf bytes.Buffer
+	client := newMockClient()
+	sched := newTestScheduler(&buf, client)
+
+	dispatchedAt := time.Now().Add(-5 * time.Minute)
+	item := &cistern.Droplet{
+		ID:                "dead-assignee-changed",
+		Repo:              "repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: dispatchedAt,
+	}
+	// Register with the changed assignee (beta, not alpha) so both List and Get
+	// see the same state. The liveness check constructs sessionID from the snapshot's
+	// assignee (alpha), but the DB now has beta — verify this doesn't produce false
+	// exit_no_outcome events. Since List and Get agree, this test instead validates
+	// that dead sessions with a valid assignee get proper exit_no_outcome handling.
+	changedItem := *item
+	changedItem.Assignee = "beta"
+	client.items[item.ID] = &changedItem
+
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+
+	// The session "repo-beta" is dead, no outcome → should get exit_no_outcome
+	found := false
+	for _, e := range client.events {
+		if e.id == item.ID && e.eventType == cistern.EventExitNoOutcome {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("dead session with changed assignee should still detect exit_no_outcome")
+	}
+}
+
+// TestLiveness_ExitGuard_RecentDispatch_Skips skips young sessions even if dead.
+func TestLiveness_ExitGuard_RecentDispatch_Skips(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return false } // dead session
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+
+	client := newMockClient()
+	var buf bytes.Buffer
+	sched := newTestScheduler(&buf, client)
+
+	// Dispatched only 10 seconds ago — well within the 2-min exit guard.
+	dispatchedAt := time.Now().Add(-10 * time.Second)
+	item := &cistern.Droplet{
+		ID:                "young-dead",
+		Repo:              "repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: dispatchedAt,
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+
+	if len(client.events) > 0 {
+		t.Errorf("expected no events for recently-dispatched dead session, got %d", len(client.events))
+	}
+}
+
+// ===========================================================================
+// Stall detection: session log mtime
+// ===========================================================================
+
+// TestLiveness_Stall_RecentSessionLogMtime_NotStalled verifies that an active
+// agent with a recent session log mtime is NOT flagged as stalled.
+func TestLiveness_Stall_RecentSessionLogMtime_NotStalled(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true } // session alive
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(_ string) (time.Time, error) {
+		return time.Now().Add(-30 * time.Second), nil // active agent
+	}
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+
+	client := newMockClient()
+	cfg := testConfig()
+	cfg.StallThresholdMinutes = 5
+	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
+	clients := map[string]CisternClient{"test-repo": client}
+	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
+
+	dispatchedAt := time.Now().Add(-10 * time.Minute)
+	item := &cistern.Droplet{
+		ID:                "active-agent",
+		Repo:              "test-repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: dispatchedAt,
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
+
+	for _, e := range client.events {
+		if e.id == item.ID && e.eventType == cistern.EventStall {
+			t.Error("active agent with recent session log should NOT be stalled")
+		}
+	}
+}
+
+// TestLiveness_Stall_OldSessionLogMtime_IsStalled verifies that an agent
+// whose session log mtime is older than the stall threshold IS flagged.
+func TestLiveness_Stall_OldSessionLogMtime_IsStalled(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(_ string) (time.Time, error) {
+		return time.Now().Add(-60 * time.Minute), nil // stale
+	}
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+
+	client := newMockClient()
+	cfg := testConfig()
+	cfg.StallThresholdMinutes = 5
+	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
+	clients := map[string]CisternClient{"test-repo": client}
+	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
+
+	dispatchedAt := time.Now().Add(-10 * time.Minute)
+	item := &cistern.Droplet{
+		ID:                "stalled-agent",
+		Repo:              "test-repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: dispatchedAt,
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
+
+	found := false
+	for _, e := range client.events {
+		if e.id == item.ID && e.eventType == cistern.EventStall {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("stale agent with old session log should be stalled")
+	}
+}
+
+// TestLiveness_Stall_NoSessionLog_FallsBackToUpdatedAt verifies that when
+// there's no session log (mtime returns zero), the stall detector falls
+// back to UpdatedAt.
+func TestLiveness_Stall_NoSessionLog_FallsBackToUpdatedAt(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil } // no log
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+
+	client := newMockClient()
+	cfg := testConfig()
+	cfg.StallThresholdMinutes = 5
+	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
+	clients := map[string]CisternClient{"test-repo": client}
+	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
+
+	dispatchedAt := time.Now().Add(-10 * time.Minute)
+	item := &cistern.Droplet{
+		ID:                "no-log-stale",
+		Repo:              "test-repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: dispatchedAt,
+		UpdatedAt:          time.Now().Add(-60 * time.Minute), // old updated_at
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
+
+	found := false
+	for _, e := range client.events {
+		if e.id == item.ID && e.eventType == cistern.EventStall {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no session log + old UpdatedAt should trigger stall detection via fallback")
+	}
+}
+
+// TestLiveness_Stall_NoSessionLog_RecentUpdatedAt_NotStalled verifies that
+// when there's no session log but UpdatedAt is recent, no stall is detected.
+func TestLiveness_Stall_NoSessionLog_RecentUpdatedAt_NotStalled(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil } // no log
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+
+	client := newMockClient()
+	cfg := testConfig()
+	cfg.StallThresholdMinutes = 5
+	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
+	clients := map[string]CisternClient{"test-repo": client}
+	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
+
+	dispatchedAt := time.Now().Add(-10 * time.Minute)
+	item := &cistern.Droplet{
+		ID:                "no-log-recent",
+		Repo:              "test-repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: dispatchedAt,
+		UpdatedAt:          time.Now().Add(-30 * time.Second), // recent
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
+
+	for _, e := range client.events {
+		if e.id == item.ID && e.eventType == cistern.EventStall {
+			t.Error("no session log + recent UpdatedAt should NOT be stalled")
+		}
+	}
+}
+
+// TestLiveness_Stall_NoAssignee_OrphanRecovery verifies that a stalled
+// droplet with no assignee is detected as an orphan and reset to open.
+func TestLiveness_Stall_NoAssignee_OrphanRecovery(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+
+	client := newMockClient()
+	cfg := testConfig()
+	cfg.StallThresholdMinutes = 1
+	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
+	clients := map[string]CisternClient{"test-repo": client}
+	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
+
+	item := &cistern.Droplet{
+		ID:                "orphan",
+		Repo:              "test-repo",
+		Status:            "in_progress",
+		Assignee:          "", // orphan
+		CurrentCataractae: "implement",
+		UpdatedAt:          time.Now().Add(-2 * time.Hour), // old
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
+
+	stallFound := false
+	recoveryFound := false
+	for _, e := range client.events {
+		if e.id == item.ID && e.eventType == cistern.EventStall {
+			stallFound = true
+		}
+		if e.id == item.ID && e.eventType == cistern.EventRecovery {
+			recoveryFound = true
+		}
+	}
+	if !stallFound {
+		t.Error("orphan droplet should trigger stall event")
+	}
+	if !recoveryFound {
+		t.Error("orphan droplet should trigger recovery event")
+	}
+	if item.Status != "open" {
+		t.Errorf("orphan should be reset to open, got %q", item.Status)
+	}
+}
+
+// TestLiveness_Stall_WithOutcome_Skips verifies that items with an outcome
+// are never processed by stall detection.
+func TestLiveness_Stall_WithOutcome_Skips(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+
+	client := newMockClient()
+	var buf bytes.Buffer
+	sched := newTestScheduler(&buf, client)
+
+	dispatchedAt := time.Now().Add(-2 * time.Hour)
+	item := &cistern.Droplet{
+		ID:                "has-outcome",
+		Repo:              "repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		Outcome:           "pass", // has outcome
+		StageDispatchedAt: dispatchedAt,
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+
+	if len(client.events) > 0 {
+		t.Errorf("expected no events for droplet with existing outcome, got %d", len(client.events))
+	}
+}
+
+// ===========================================================================
+// DB integration tests
+// ===========================================================================
+
+// TestLiveness_DB_StallWithOrphanRecovery uses a real DB to verify that an
+// orphaned droplet (no assignee, no session log) is detected as stalled
+// and recovered to open.
+func TestLiveness_DB_StallWithOrphanRecovery(t *testing.T) {
+	origTmux := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = origTmux })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	c, err := cistern.New(dbPath, "ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	item, err := c.Add("test-repo", "DB orphan task", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.UpdateStatus(item.ID, "in_progress"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Age updated_at so the stall threshold is exceeded.
+	rawDB, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().UTC().Add(-2 * time.Hour)
+	if _, err := rawDB.Exec(`UPDATE droplets SET updated_at = ? WHERE id = ?`, past, item.ID); err != nil {
+		rawDB.Close()
+		t.Fatal(err)
+	}
+	rawDB.Close()
+
+	cfg := testConfig()
+	cfg.StallThresholdMinutes = 1
+	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
+	clients := map[string]CisternClient{"test-repo": c}
+	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
+
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
+
+	recoveryCount, err := c.CountEventsByType(item.ID, cistern.EventRecovery, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recoveryCount == 0 {
+		t.Error("expected recovery event for orphaned droplet")
+	}
+
+	// Verify the droplet was reset to open.
+	fresh, err := c.Get(item.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.Status != "open" {
+		t.Errorf("expected droplet reset to open, got %q", fresh.Status)
+	}
+}
+
+// TestLiveness_DB_ExitNoOutcome uses a real DB to verify that a dead session
+// with no outcome resets the droplet for re-dispatch.
+func TestLiveness_DB_ExitNoOutcome(t *testing.T) {
+	origTmux := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return false } // dead session
+	t.Cleanup(func() { isTmuxAliveFn = origTmux })
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	c, err := cistern.New(dbPath, "ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	item, err := c.Add("test-repo", "DB exit task", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.UpdateStatus(item.ID, "in_progress"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Assign(item.ID, "alpha", "implement"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Age stage_dispatched_at past the exit guard.
+	rawDB, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().UTC().Add(-5 * time.Minute)
+	if _, err := rawDB.Exec(`UPDATE droplets SET stage_dispatched_at = ?, updated_at = ? WHERE id = ?`, past, past, item.ID); err != nil {
+		rawDB.Close()
+		t.Fatal(err)
+	}
+	rawDB.Close()
+
+	cfg := testConfig()
+	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
+	clients := map[string]CisternClient{"test-repo": c}
+	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
+
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
+
+	exitCount, err := c.CountEventsByType(item.ID, cistern.EventExitNoOutcome, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCount == 0 {
+		t.Error("expected exit_no_outcome event for dead session with no outcome")
+	}
+
+	// Verify the droplet was reset to open.
+	fresh, err := c.Get(item.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.Status != "open" {
+		t.Errorf("expected droplet reset to open, got %q", fresh.Status)
+	}
+	if fresh.Assignee != "" {
+		t.Errorf("expected assignee cleared, got %q", fresh.Assignee)
+	}
+}
+
+// TestLiveness_Stall_SessionLogReadError_FallsBackToUpdatedAt verifies that
+// if the session log mtime check returns an error, the liveness check
+// gracefully falls back to UpdatedAt.
+func TestLiveness_Stall_SessionLogReadError_FallsBackToUpdatedAt(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, sql.ErrConnDone } // read error
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+
+	client := newMockClient()
+	cfg := testConfig()
+	cfg.StallThresholdMinutes = 1
+	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
+	clients := map[string]CisternClient{"test-repo": client}
+	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
+
+	dispatchedAt := time.Now().Add(-5 * time.Minute)
+	item := &cistern.Droplet{
+		ID:                "log-read-error",
+		Repo:              "test-repo",
+		Status:            "in_progress",
+		Assignee:          "alpha",
+		CurrentCataractae: "implement",
+		StageDispatchedAt: dispatchedAt,
+		UpdatedAt:          time.Now().Add(-2 * time.Hour), // old → stall via fallback
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
+
+	found := false
+	for _, e := range client.events {
+		if e.id == item.ID && e.eventType == cistern.EventStall {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("session log read error should fall back to UpdatedAt and detect stall")
+	}
+}
+
+// TestLiveness_Stall_NoAssignee_NoSessionLog_UsesUpdatedAt verifies that
+// an orphan (no assignee) falls through to UpdatedAt for stall detection.
+func TestLiveness_Stall_NoAssignee_NoSessionLog_UsesUpdatedAt(t *testing.T) {
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+
+	client := newMockClient()
+	cfg := testConfig()
+	cfg.StallThresholdMinutes = 1
+	workflows := map[string]*aqueduct.Workflow{"test-repo": testWorkflow()}
+	clients := map[string]CisternClient{"test-repo": client}
+	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
+
+	item := &cistern.Droplet{
+		ID:                "orphan-no-log",
+		Repo:              "test-repo",
+		Status:            "in_progress",
+		Assignee:          "", // no assignee
+		CurrentCataractae: "implement",
+		UpdatedAt:          time.Now().Add(-2 * time.Hour),
+	}
+	client.items[item.ID] = item
+
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
+
+	stallFound := false
+	recoveryFound := false
+	for _, e := range client.events {
+		if e.id == item.ID && e.eventType == cistern.EventStall {
+			stallFound = true
+		}
+		if e.id == item.ID && e.eventType == cistern.EventRecovery {
+			recoveryFound = true
+		}
+	}
+	if !stallFound {
+		t.Error("orphan with old UpdatedAt should trigger stall event")
+	}
+	if !recoveryFound {
+		t.Error("orphan with no assignee should trigger recovery event")
+	}
+}

--- a/internal/castellarius/production_gaps_test.go
+++ b/internal/castellarius/production_gaps_test.go
@@ -3,8 +3,8 @@ package castellarius
 // production_gaps_test.go — tests for failure modes that caused real incidents.
 //
 // These tests cover the interaction paths that were MISSING before 2026-03-25
-// and whose absence allowed the self-kill bug, silent backoff, and heartbeat
-// race to go undetected.
+// and whose absence allowed the self-kill bug, silent backoff, and liveness
+// check race to go undetected.
 
 import (
 	"bytes"
@@ -21,16 +21,20 @@ import (
 	"github.com/MichielDean/cistern/internal/cistern"
 )
 
-// --- Heartbeat progress-monitoring tests ---
+// --- Liveness check progress-monitoring tests ---
 
-// TestHeartbeat_StallDetected_WhenNoSignals verifies that the heartbeat detects
-// a stall and logs "stall detected" when all three progress signals are absent
+// TestLivenessCheck_StallDetected_WhenNoSignals verifies that the liveness check detects
+// a stall and logs "stall detected" when all progress signals are absent
 // (no notes, no worktree files, no session log).
-func TestHeartbeat_StallDetected_WhenNoSignals(t *testing.T) {
+func TestLivenessCheck_StallDetected_WhenNoSignals(t *testing.T) {
 	// Mock tmux as alive so liveness check passes through to stall detector.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
 
 	buf := &bytes.Buffer{}
 	client := newMockClient()
@@ -45,23 +49,27 @@ func TestHeartbeat_StallDetected_WhenNoSignals(t *testing.T) {
 	}
 	client.items["stale-session"] = item
 
-	sched.heartbeatRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
 
 	log := buf.String()
 	if !strings.Contains(log, "stall detected") {
-		t.Errorf("heartbeat should log 'stall detected' when no signals present; log:\n%s", log)
+		t.Errorf("liveness check should log 'stall detected' when no signals present; log:\n%s", log)
 	}
 }
 
-// TestHeartbeat_NoStallNote_WhenRecentHeartbeat verifies that the heartbeat
-// does not write a stall note when the agent's LastHeartbeatAt is within the
-// 45-minute default threshold.
-func TestHeartbeat_NoStallNote_WhenRecentHeartbeat(t *testing.T) {
+// TestLivenessCheck_NoStallNote_WhenRecentLogMtime verifies that the liveness check
+// does not write a stall note when the agent's session log mtime is within the
+// stall threshold.
+func TestLivenessCheck_NoStallNote_WhenRecentLogMtime(t *testing.T) {
 	// Mock tmux as alive so exit detection is bypassed and stall
-	// detection runs on the heartbeat timestamp.
+	// detection runs on the session log mtime.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
+
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-5 * time.Second), nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
 
 	buf := &bytes.Buffer{}
 	client := newMockClient()
@@ -73,23 +81,21 @@ func TestHeartbeat_NoStallNote_WhenRecentHeartbeat(t *testing.T) {
 		Status:            "in_progress",
 		Assignee:          "alpha",
 		CurrentCataractae: "implement",
-		// Recent heartbeat: 5 seconds ago — well within the 45-minute default threshold.
-		LastHeartbeatAt: time.Now().Add(-5 * time.Second),
 	}
 	client.items["fresh-dispatch"] = item
 
-	sched.heartbeatRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
 
 	log := buf.String()
 	if strings.Contains(log, "stall detected") {
-		t.Errorf("heartbeat flagged a recently-heartbeating droplet as stalled; log:\n%s", log)
+		t.Errorf("liveness check flagged a recently-active droplet as stalled; log:\n%s", log)
 	}
 }
 
-// TestHeartbeat_SkipsItemsWithOutcome verifies that the heartbeat never writes
+// TestLivenessCheck_SkipsItemsWithOutcome verifies that the liveness check never writes
 // a stall note for a droplet that already has an outcome — the observe loop
 // handles those and must not be interfered with.
-func TestHeartbeat_SkipsItemsWithOutcome(t *testing.T) {
+func TestLivenessCheck_SkipsItemsWithOutcome(t *testing.T) {
 	buf := &bytes.Buffer{}
 	client := newMockClient()
 	sched := newTestScheduler(buf, client)
@@ -104,11 +110,11 @@ func TestHeartbeat_SkipsItemsWithOutcome(t *testing.T) {
 	}
 	client.items["has-outcome"] = item
 
-	sched.heartbeatRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
+	sched.livenessCheckRepo(context.Background(), aqueduct.RepoConfig{Name: "repo"})
 
 	log := buf.String()
 	if strings.Contains(log, "stall detected") {
-		t.Errorf("heartbeat flagged a droplet with an existing outcome; log:\n%s", log)
+		t.Errorf("liveness check flagged a droplet with an existing outcome; log:\n%s", log)
 	}
 }
 
@@ -279,19 +285,19 @@ func init() {
 	var _ CisternClient = (*mockClient)(nil)
 }
 
-// --- Heartbeat DB integration tests ---
+// --- Liveness check DB integration tests ---
 //
 // These tests use a real cistern.Client backed by SQLite to catch column scan
 // ordering bugs that mock-client tests cannot detect. If List() has a bug that
-// leaves LastHeartbeatAt always zero, the stall detector falls back to
+// leaves session log mtime always zero, the stall detector falls back to
 // UpdatedAt. Because UpdatedAt is artificially aged in these tests, such a
-// scan bug would cause a false stall in TestHeartbeat_DB_NotStalled and
+// scan bug would cause a false stall in TestLivenessCheck_DB_NotStalled and
 // the test would fail.
 
-// TestHeartbeat_DB_NotStalled_WhenRecentHeartbeat uses a real DB to verify
-// that the stall detector skips agents whose last_heartbeat_at is recent, even
+// TestLivenessCheck_DB_NotStalled_WhenRecentLogMtime uses a real DB to verify
+// that the stall detector skips agents whose session log mtime is recent, even
 // when updated_at is old. Detects scan ordering bugs in List().
-func TestHeartbeat_DB_NotStalled_WhenRecentHeartbeat(t *testing.T) {
+func TestLivenessCheck_DB_NotStalled_WhenRecentLogMtime(t *testing.T) {
 	origTmux := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = origTmux })
@@ -310,24 +316,27 @@ func TestHeartbeat_DB_NotStalled_WhenRecentHeartbeat(t *testing.T) {
 	if err := c.UpdateStatus(item.ID, "in_progress"); err != nil {
 		t.Fatal(err)
 	}
+	if err := c.Assign(item.ID, "alpha", "implement"); err != nil {
+		t.Fatal(err)
+	}
 
 	// Age updated_at so the stall detector fires on the fallback path if
-	// last_heartbeat_at is not scanned correctly (zero value scan bug).
+	// session_log mtime is not available.
 	rawDB, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
 	if err != nil {
 		t.Fatal(err)
 	}
 	past := time.Now().UTC().Add(-2 * time.Hour)
-	if _, err := rawDB.Exec(`UPDATE droplets SET updated_at = ? WHERE id = ?`, past, item.ID); err != nil {
+	if _, err := rawDB.Exec(`UPDATE droplets SET updated_at = ?, stage_dispatched_at = ? WHERE id = ?`, past, past, item.ID); err != nil {
 		rawDB.Close()
 		t.Fatal(err)
 	}
 	rawDB.Close()
 
-	// Emit a heartbeat — last_heartbeat_at is now current.
-	if err := c.Heartbeat(item.ID); err != nil {
-		t.Fatal(err)
-	}
+	// Mock session log mtime to return a recent time — agent is alive and working.
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-5 * time.Second), nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
 
 	cfg := testConfig()
 	cfg.StallThresholdMinutes = 1
@@ -335,22 +344,22 @@ func TestHeartbeat_DB_NotStalled_WhenRecentHeartbeat(t *testing.T) {
 	clients := map[string]CisternClient{"test-repo": c}
 	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
 
-	sched.heartbeatRepo(context.Background(), cfg.Repos[0])
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
 
-	// Recent heartbeat → no stall event should be recorded.
+	// Recent session log mtime → no stall event should be recorded.
 	stallCount, err := c.CountEventsByType(item.ID, cistern.EventStall, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stallCount != 0 {
-		t.Errorf("DB integration: stall event written for heartbeating agent (count=%d)", stallCount)
+		t.Errorf("DB integration: stall event written for recently-active agent (count=%d)", stallCount)
 	}
 }
 
-// TestHeartbeat_DB_Stalled_WhenNoHeartbeat uses a real DB to verify that an
-// agent with no heartbeat and an aged updated_at is detected as stalled and
-// an escalation note with heartbeat=none is written.
-func TestHeartbeat_DB_Stalled_WhenNoHeartbeat(t *testing.T) {
+// TestLivenessCheck_DB_Stalled_WhenNoLogMtime uses a real DB to verify that an
+// agent with no session log mtime and an aged updated_at is detected as stalled
+// and an escalation note is written.
+func TestLivenessCheck_DB_Stalled_WhenNoLogMtime(t *testing.T) {
 	origTmux := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = origTmux })
@@ -369,18 +378,26 @@ func TestHeartbeat_DB_Stalled_WhenNoHeartbeat(t *testing.T) {
 	if err := c.UpdateStatus(item.ID, "in_progress"); err != nil {
 		t.Fatal(err)
 	}
+	if err := c.Assign(item.ID, "alpha", "implement"); err != nil {
+		t.Fatal(err)
+	}
 
-	// Age updated_at — no heartbeat was ever emitted; fallback triggers stall.
+	// Age updated_at and stage_dispatched_at — no session log mtime; fallback triggers stall.
 	rawDB, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
 	if err != nil {
 		t.Fatal(err)
 	}
 	past := time.Now().UTC().Add(-2 * time.Hour)
-	if _, err := rawDB.Exec(`UPDATE droplets SET updated_at = ? WHERE id = ?`, past, item.ID); err != nil {
+	if _, err := rawDB.Exec(`UPDATE droplets SET updated_at = ?, stage_dispatched_at = ? WHERE id = ?`, past, past, item.ID); err != nil {
 		rawDB.Close()
 		t.Fatal(err)
 	}
 	rawDB.Close()
+
+	// Mock session log mtime to return zero time — agent has no session log.
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
 
 	cfg := testConfig()
 	cfg.StallThresholdMinutes = 1
@@ -388,15 +405,15 @@ func TestHeartbeat_DB_Stalled_WhenNoHeartbeat(t *testing.T) {
 	clients := map[string]CisternClient{"test-repo": c}
 	sched := NewFromParts(cfg, workflows, clients, newMockRunner(nil))
 
-	sched.heartbeatRepo(context.Background(), cfg.Repos[0])
+	sched.livenessCheckRepo(context.Background(), cfg.Repos[0])
 
-	// No heartbeat → stall detected → stall event recorded with heartbeat=none in payload.
+	// No session log → stall detected → stall event recorded.
 	stallCount, err := c.CountEventsByType(item.ID, cistern.EventStall, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stallCount == 0 {
-		t.Error("DB integration: expected stall event for no-heartbeat agent, got none")
+		t.Error("DB integration: expected stall event for no-liveness agent, got none")
 		return
 	}
 }

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -55,9 +55,6 @@ type CisternClient interface {
 	// FileDroplet creates a new droplet in the given repo. Used by the Architect
 	// to file structural fix work items.
 	FileDroplet(repo, title, description string, priority int) (*cistern.Droplet, error)
-	// Heartbeat records the current time as the agent's most recent activity
-	// timestamp. Called by agents via `ct droplet heartbeat <id>` every 60 seconds.
-	Heartbeat(id string) error
 	// RecordEvent inserts a typed event row into the events table. Used by CLI
 	// and dashboard handlers, and by Client methods internally.
 	RecordEvent(id, eventType, payload string) error
@@ -100,10 +97,10 @@ type Castellarius struct {
 	runner       CataractaeRunner
 	logger       *slog.Logger
 	pollInterval time.Duration
-	// heartbeatInterval controls how often orphaned in-progress droplets are
+	// livenessInterval controls how often orphaned in-progress droplets are
 	// checked. Independent of pollInterval so it fires even when the main tick
 	// is busy. Defaults to 30s.
-	heartbeatInterval  time.Duration
+	livenessInterval    time.Duration
 	sandboxRoot        string
 	cleanupInterval    time.Duration
 	dbPath             string
@@ -180,10 +177,10 @@ func WithDrainTimeout(d time.Duration) Option {
 	return func(s *Castellarius) { s.drainTimeout = d }
 }
 
-// WithHeartbeatInterval overrides how often the heartbeat scans for stalled
+// WithLivenessInterval overrides how often the liveness scan checks for stalled
 // in-progress droplets. Defaults to 30s; pass a shorter duration in tests.
-func WithHeartbeatInterval(d time.Duration) Option {
-	return func(s *Castellarius) { s.heartbeatInterval = d }
+func WithLivenessInterval(d time.Duration) Option {
+	return func(s *Castellarius) { s.livenessInterval = d }
 }
 
 // New creates a Castellarius from an AqueductConfig.
@@ -206,7 +203,7 @@ func New(config aqueduct.AqueductConfig, dbPath string, runner CataractaeRunner,
 		runner:             runner,
 		logger:             slog.Default(),
 		pollInterval:       10 * time.Second,
-		heartbeatInterval:  30 * time.Second,
+		livenessInterval:   30 * time.Second,
 		drainTimeout:       5 * time.Minute,
 		dbPath:             dbPath,
 		startupBinaryMtime: startupBinaryMtime,
@@ -247,12 +244,12 @@ func New(config aqueduct.AqueductConfig, dbPath string, runner CataractaeRunner,
 		s.cleanupInterval = 24 * time.Hour
 	}
 
-	if config.HeartbeatInterval != "" {
-		d, err := time.ParseDuration(config.HeartbeatInterval)
+	if config.LivenessInterval != "" {
+		d, err := time.ParseDuration(config.LivenessInterval)
 		if err != nil {
-			return nil, fmt.Errorf("castellarius: invalid heartbeat_interval %q: %w", config.HeartbeatInterval, err)
+			return nil, fmt.Errorf("castellarius: invalid liveness_interval %q: %w", config.LivenessInterval, err)
 		}
-		s.heartbeatInterval = d
+		s.livenessInterval = d
 	}
 
 	if config.DrainTimeoutMinutes > 0 {
@@ -298,7 +295,7 @@ func NewFromParts(
 		runner:            runner,
 		logger:            slog.Default(),
 		pollInterval:      10 * time.Second,
-		heartbeatInterval: 30 * time.Second,
+		livenessInterval: 30 * time.Second,
 		drainTimeout:      5 * time.Minute,
 	}
 	for _, o := range opts {
@@ -402,11 +399,11 @@ func (s *Castellarius) Run(ctx context.Context) error {
 		}()
 	}
 
-	// Heartbeat goroutine — runs independently of the main poll loop.
+	// Liveness goroutine — runs independently of the main poll loop.
 	// Detects orphaned in-progress droplets (dead sessions with no outcome)
 	// and resets them to open so they can be re-dispatched.
 	go func() {
-		hbTicker := time.NewTicker(s.heartbeatInterval)
+		hbTicker := time.NewTicker(s.livenessInterval)
 		defer hbTicker.Stop()
 		for {
 			select {
@@ -417,13 +414,13 @@ func (s *Castellarius) Run(ctx context.Context) error {
 					defer func() {
 						if r := recover(); r != nil {
 							stack := debug.Stack()
-							s.logger.Error("heartbeat: panic recovered",
+							s.logger.Error("liveness: panic recovered",
 								"panic", r,
 								"stack", string(stack),
 							)
 						}
 					}()
-					s.heartbeatInProgress(ctx)
+					s.livenessCheck(ctx)
 					s.checkHungDrought()
 				}()
 			}
@@ -1340,7 +1337,7 @@ func (s *Castellarius) handleTerminal(client CisternClient, itemID, terminal, fr
 // If the tmux session is still alive, leave the droplet alone — the agent
 // will signal its outcome.
 // Otherwise, reset to open for re-dispatch. The circuit breaker in
-// heartbeatRepo will pool the droplet if it keeps dying.
+// livenessCheckRepo will pool the droplet if it keeps dying.
 func (s *Castellarius) recoverInProgress() {
 	for _, repo := range s.config.Repos {
 		client := s.clients[repo.Name]
@@ -1392,15 +1389,15 @@ func (s *Castellarius) recoverInProgress() {
 	}
 }
 
-// heartbeatInProgress scans for in_progress droplets whose agent sessions
+// livenessCheck scans for in_progress droplets whose agent sessions
 // have exited. If the agent wrote an outcome, the observe cycle handles it.
 // If not, the droplet is reset for re-dispatch.
-func (s *Castellarius) heartbeatInProgress(ctx context.Context) {
+func (s *Castellarius) livenessCheck(ctx context.Context) {
 	for _, repo := range s.config.Repos {
 		if ctx.Err() != nil {
 			return
 		}
-		s.heartbeatRepo(ctx, repo)
+		s.livenessCheckRepo(ctx, repo)
 	}
 }
 
@@ -1427,13 +1424,13 @@ func (s *Castellarius) checkHungDrought() {
 	}
 }
 
-func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConfig) {
+func (s *Castellarius) livenessCheckRepo(ctx context.Context, repo aqueduct.RepoConfig) {
 	client := s.clients[repo.Name]
 	wf := s.workflows[repo.Name]
 
 	items, err := client.List(repo.Name, "in_progress")
 	if err != nil {
-		s.logger.Error("heartbeat: list in_progress failed", "repo", repo.Name, "error", err)
+		s.logger.Error("liveness: list in_progress failed", "repo", repo.Name, "error", err)
 		return
 	}
 
@@ -1448,7 +1445,7 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 		// destroys the session (remain-on-exit is off). A dead tmux session
 		// is the normal completion signal — check the DB for an outcome
 		// before deciding whether to reset for re-dispatch.
-		exitGuard := 4 * s.heartbeatInterval
+		exitGuard := 4 * s.livenessInterval
 		if item.Assignee != "" {
 			sessionID := repo.Name + "-" + item.Assignee
 			dispatchedAt := item.StageDispatchedAt
@@ -1465,12 +1462,12 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 				fresh, err := client.Get(item.ID)
 				if err == nil {
 					if fresh.Outcome != "" {
-						s.logger.Info("heartbeat: session exited with outcome — observe will process",
+						s.logger.Info("liveness: session exited with outcome — observe will process",
 							"repo", repo.Name, "droplet", item.ID, "outcome", fresh.Outcome)
 						continue
 					}
 					if fresh.CurrentCataractae != item.CurrentCataractae {
-						s.logger.Info("heartbeat: cataractae already advanced — observe already processed",
+						s.logger.Info("liveness: cataractae already advanced — observe already processed",
 							"repo", repo.Name, "droplet", item.ID,
 							"was", item.CurrentCataractae, "now", fresh.CurrentCataractae)
 						continue
@@ -1481,7 +1478,7 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 					// dead session belongs to the previous cataractae, not the
 					// current one.
 					if !fresh.StageDispatchedAt.IsZero() && fresh.StageDispatchedAt != item.StageDispatchedAt {
-						s.logger.Info("heartbeat: stage_dispatched_at changed — re-dispatched since snapshot",
+						s.logger.Info("liveness: stage_dispatched_at changed — re-dispatched since snapshot",
 							"repo", repo.Name, "droplet", item.ID,
 							"was", item.StageDispatchedAt, "now", fresh.StageDispatchedAt)
 						continue
@@ -1489,7 +1486,7 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 					// The assignee may have been cleared by observe or changed by
 					// dispatch. If so, the session we're checking is stale.
 					if fresh.Assignee != item.Assignee {
-						s.logger.Info("heartbeat: assignee changed — stale session check",
+						s.logger.Info("liveness: assignee changed — stale session check",
 							"repo", repo.Name, "droplet", item.ID,
 							"was", item.Assignee, "now", fresh.Assignee)
 						continue
@@ -1499,7 +1496,7 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 				// Session exited with no outcome — reset for re-dispatch.
 				step := currentCataracta(item, wf)
 				if step == nil {
-					s.logger.Error("heartbeat: no step for exited session — skipping",
+					s.logger.Error("liveness: no step for exited session — skipping",
 						"repo", repo.Name, "droplet", item.ID)
 					continue
 				}
@@ -1515,14 +1512,22 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 				})
 				s.addEvent(client, item.ID, cistern.EventExitNoOutcome, string(payload))
 				if err := client.Assign(item.ID, "", step.Name); err != nil {
-					s.logger.Error("heartbeat: reset failed", "droplet", item.ID, "error", err)
+					s.logger.Error("liveness: reset failed", "droplet", item.ID, "error", err)
 				}
 				continue
 			}
 		}
 
-		// Stall detection: agent heartbeat older than threshold.
-		stallSig := item.LastHeartbeatAt
+		// Stall detection: check session log mtime as liveness signal.
+		// If the agent is alive and working, it's writing to its session log
+		// via tmux pipe-pane. A stale mtime means the agent is stuck or dead.
+		var stallSig time.Time
+		if item.Assignee != "" {
+			sessionID := repo.Name + "-" + item.Assignee
+			if logMtime, err := sessionLogMtime(sessionID); err == nil && !logMtime.IsZero() {
+				stallSig = logMtime
+			}
+		}
 		if stallSig.IsZero() {
 			stallSig = item.UpdatedAt
 		}
@@ -1530,18 +1535,12 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 			continue
 		}
 
-		// Stalled — write an escalation note.
-		heartbeatStatus := "none"
-		if !item.LastHeartbeatAt.IsZero() {
-			heartbeatStatus = item.LastHeartbeatAt.UTC().Format(time.RFC3339)
-		}
 		stallPayload, _ := json.Marshal(map[string]any{
 			"cataractae": item.CurrentCataractae,
 			"elapsed":    formatStallDuration(time.Since(stallSig)),
-			"heartbeat":  heartbeatStatus,
 		})
 		s.addEvent(client, item.ID, cistern.EventStall, string(stallPayload))
-		s.logger.Warn("heartbeat: stall detected",
+		s.logger.Warn("liveness: stall detected",
 			"repo", repo.Name, "droplet", item.ID,
 			"cataractae", item.CurrentCataractae,
 			"stall_duration", time.Since(stallSig).Round(time.Second).String(),
@@ -1559,10 +1558,10 @@ func (s *Castellarius) heartbeatRepo(ctx context.Context, repo aqueduct.RepoConf
 				"cataractae": stepName,
 			})
 			s.addEvent(client, item.ID, cistern.EventRecovery, string(recoveryPayload))
-			s.logger.Info("heartbeat: orphan reset to open",
+			s.logger.Info("liveness: orphan reset to open",
 				"repo", repo.Name, "droplet", item.ID, "cataractae", stepName)
 			if err := client.Assign(item.ID, "", stepName); err != nil {
-				s.logger.Error("heartbeat: orphan reset failed", "droplet", item.ID, "error", err)
+				s.logger.Error("liveness: orphan reset failed", "droplet", item.ID, "error", err)
 			}
 		}
 	}
@@ -1689,6 +1688,27 @@ var isTmuxAliveFn = func(sessionID string) bool {
 // isTmuxAlive returns true if a tmux session with the given name is running.
 func isTmuxAlive(sessionID string) bool {
 	return isTmuxAliveFn(sessionID)
+}
+
+// sessionLogMtime returns the modification time of the session log file.
+// Used as a liveness signal: an active agent writes to its session log via
+// tmux pipe-pane, so a stale mtime indicates the agent is stuck or dead.
+// Returns zero time if the log file does not exist.
+var sessionLogMtimeFn = func(sessionID string) (time.Time, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return time.Time{}, err
+	}
+	path := filepath.Join(home, ".cistern", "session-logs", sessionID+".log")
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, nil
+	}
+	return info.ModTime().UTC(), nil
+}
+
+func sessionLogMtime(sessionID string) (time.Time, error) {
+	return sessionLogMtimeFn(sessionID)
 }
 
 // sandboxHead returns the current HEAD commit hash in the given directory.

--- a/internal/castellarius/scheduler_test.go
+++ b/internal/castellarius/scheduler_test.go
@@ -231,17 +231,6 @@ func (m *mockClient) FileDroplet(repo, title, description string, priority int) 
 	return d, nil
 }
 
-func (m *mockClient) Heartbeat(id string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	item, ok := m.items[id]
-	if !ok {
-		return fmt.Errorf("droplet not found: %s", id)
-	}
-	item.LastHeartbeatAt = time.Now()
-	return nil
-}
-
 func (m *mockClient) List(repo, status string) ([]*cistern.Droplet, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1990,12 +1979,12 @@ func TestDispatch_DiffOnlyStepGetsSandboxDir(t *testing.T) {
 	}
 }
 
-// --- heartbeat progress-monitoring tests ---
+// --- liveness check progress-monitoring tests ---
 
-// TestHeartbeatRepo_StallDetected_AppendsNoteAndWarnLog verifies that when all
-// three progress signals are older than the stall threshold, heartbeatRepo
+// TestLivenessCheckRepo_StallDetected_AppendsNoteAndWarnLog verifies that when all
+// three progress signals are older than the stall threshold, livenessCheckRepo
 // appends a note to the droplet and emits a Warn-level log entry.
-func TestHeartbeatRepo_StallDetected_AppendsNoteAndWarnLog(t *testing.T) {
+func TestLivenessCheckRepo_StallDetected_AppendsNoteAndWarnLog(t *testing.T) {
 	var buf bytes.Buffer
 	client := newMockClient()
 
@@ -2017,7 +2006,7 @@ func TestHeartbeatRepo_StallDetected_AppendsNoteAndWarnLog(t *testing.T) {
 	sched := NewFromParts(config, workflows, clients, runner,
 		WithLogger(newTestLogger(&buf)))
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
 	// Stall event and recovery event must both be recorded.
 	if len(client.events) != 2 {
@@ -2033,18 +2022,18 @@ func TestHeartbeatRepo_StallDetected_AppendsNoteAndWarnLog(t *testing.T) {
 	// A Warn-level log entry must be present containing the droplet ID.
 	out := buf.String()
 	if !strings.Contains(out, "stall-basic") {
-		t.Errorf("heartbeat log missing droplet ID; got: %s", out)
+		t.Errorf("liveness check log missing droplet ID; got: %s", out)
 	}
 	if !strings.Contains(out, "stall_duration=") {
-		t.Errorf("heartbeat log missing stall_duration field; got: %s", out)
+		t.Errorf("liveness check log missing stall_duration field; got: %s", out)
 	}
 }
 
-// TestHeartbeatRepo_OrphanRecovery_SecondTick_ItemResetToOpenNotReprocessed
+// TestLivenessCheckRepo_OrphanRecovery_SecondTick_ItemResetToOpenNotReprocessed
 // verifies that after orphan handling resets a no-assignee in_progress droplet
-// to open on the first tick, the second heartbeat tick writes no additional
+// to open on the first tick, the second liveness check tick writes no additional
 // notes because the item is no longer in_progress and is not returned by List.
-func TestHeartbeatRepo_OrphanRecovery_SecondTick_ItemResetToOpenNotReprocessed(t *testing.T) {
+func TestLivenessCheckRepo_OrphanRecovery_SecondTick_ItemResetToOpenNotReprocessed(t *testing.T) {
 	client := newMockClient()
 
 	item := &cistern.Droplet{
@@ -2064,7 +2053,7 @@ func TestHeartbeatRepo_OrphanRecovery_SecondTick_ItemResetToOpenNotReprocessed(t
 	sched := NewFromParts(config, workflows, clients, runner)
 
 	// First call: no signals → stalled → stall event + recovery event written, item reset to open.
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 	if len(client.events) != 2 {
 		t.Fatalf("expected 2 events (stall + recovery) after first tick, got %d", len(client.events))
 	}
@@ -2073,27 +2062,37 @@ func TestHeartbeatRepo_OrphanRecovery_SecondTick_ItemResetToOpenNotReprocessed(t
 	}
 
 	// Second call: item is now open (no longer in_progress) → no additional events.
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 	if len(client.events) != 2 {
 		t.Errorf("expected still 2 events after second tick (item is open), got %d", len(client.events))
 	}
 }
 
-// TestHeartbeatRepo_StallThreshold_ExplicitMinutesRespected verifies that an
+// TestLivenessCheckRepo_StallThreshold_ExplicitMinutesRespected verifies that an
 // explicitly configured stall_threshold_minutes is used for stall detection.
-func TestHeartbeatRepo_StallThreshold_ExplicitMinutesRespected(t *testing.T) {
+func TestLivenessCheckRepo_StallThreshold_ExplicitMinutesRespected(t *testing.T) {
 	client := newMockClient()
 
-	// Droplet with heartbeat 2 minutes old.
-	twoMinAgo := time.Now().Add(-2 * time.Minute)
+	// Droplet with session log mtime 2 minutes old.
+	// Assignee and StageDispatchedAt must be set so the exit guard passes
+	// and session log mtime is checked for stall detection.
 	item := &cistern.Droplet{
 		ID:                "stall-thresh-explicit",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
-		Assignee:          "",
-		LastHeartbeatAt:   twoMinAgo,
+		Assignee:          "alpha",
+		StageDispatchedAt: time.Now().Add(-5 * time.Minute),
 	}
 	client.items[item.ID] = item
+
+	// Mock session log mtime to return 2 minutes ago — older than threshold.
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-2 * time.Minute), nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
 
 	config := testConfig()
 	config.StallThresholdMinutes = 1 // 2 min > 1 min → stalled
@@ -2103,29 +2102,39 @@ func TestHeartbeatRepo_StallThreshold_ExplicitMinutesRespected(t *testing.T) {
 	runner := newMockRunner(client)
 	sched := NewFromParts(config, workflows, clients, runner)
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
-	if len(client.events) != 2 {
-		t.Errorf("expected 2 events (stall + recovery) with 1-min threshold and 2-min-old heartbeat, got %d", len(client.events))
+	if len(client.events) != 1 {
+		t.Errorf("expected 1 stall event with 1-min threshold and 2-min-old session log, got %d", len(client.events))
 	}
 }
 
-// TestHeartbeatRepo_StallThreshold_DefaultsTo45Minutes verifies that when
+// TestLivenessCheckRepo_StallThreshold_DefaultsTo45Minutes verifies that when
 // stall_threshold_minutes is absent or zero, the default threshold of 45
-// minutes is used and a droplet with a heartbeat only 2 minutes old is not stalled.
-func TestHeartbeatRepo_StallThreshold_DefaultsTo45Minutes(t *testing.T) {
+// minutes is used and a droplet with a session log mtime only 2 minutes old is not stalled.
+func TestLivenessCheckRepo_StallThreshold_DefaultsTo45Minutes(t *testing.T) {
 	client := newMockClient()
 
-	// Droplet with heartbeat 2 minutes old — well within the 45-min default.
-	twoMinAgo := time.Now().Add(-2 * time.Minute)
+	// Droplet with session log mtime 2 minutes old — well within the 45-min default.
+	// Assignee and StageDispatchedAt must be set so the exit guard passes
+	// and session log mtime is checked for stall detection.
 	item := &cistern.Droplet{
 		ID:                "stall-thresh-default",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
-		Assignee:          "",
-		LastHeartbeatAt:   twoMinAgo,
+		Assignee:          "alpha",
+		StageDispatchedAt: time.Now().Add(-5 * time.Minute),
 	}
 	client.items[item.ID] = item
+
+	// Mock session log mtime to return 2 minutes ago — within default threshold.
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-2 * time.Minute), nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
+	orig := isTmuxAliveFn
+	isTmuxAliveFn = func(_ string) bool { return true }
+	t.Cleanup(func() { isTmuxAliveFn = orig })
 
 	config := testConfig()
 	// StallThresholdMinutes deliberately left at zero → should default to 45 min.
@@ -2135,19 +2144,19 @@ func TestHeartbeatRepo_StallThreshold_DefaultsTo45Minutes(t *testing.T) {
 	runner := newMockRunner(client)
 	sched := NewFromParts(config, workflows, clients, runner)
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
 	// 2 min < 45 min → not stalled → no events written.
 	if len(client.events) != 0 {
-		t.Errorf("expected 0 events with default 45-min threshold and 2-min-old heartbeat, got %d", len(client.events))
+		t.Errorf("expected 0 events with default 45-min threshold and 2-min-old session log, got %d", len(client.events))
 	}
 }
 
-// TestHeartbeatRepo_StallWithAssignee_WritesNoteNoRespawn verifies that when a
+// TestLivenessCheckRepo_StallWithAssignee_WritesNoteNoRespawn verifies that when a
 // stall is detected and the droplet has an assignee, a stall note is written but
 // runner.Spawn is NOT called. Stall detection no longer auto-respawns: agents
-// emitting heartbeats are alive, and dead agents are handled by exit detection.
-func TestHeartbeatRepo_StallWithAssignee_WritesNoteNoRespawn(t *testing.T) {
+// emitting session log mtime signals are alive, and dead agents are handled by exit detection.
+func TestLivenessCheckRepo_StallWithAssignee_WritesNoteNoRespawn(t *testing.T) {
 	// Mock tmux as alive so liveness check passes through to stall detector.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
@@ -2171,7 +2180,7 @@ func TestHeartbeatRepo_StallWithAssignee_WritesNoteNoRespawn(t *testing.T) {
 	clients := map[string]CisternClient{"test-repo": client}
 	sched := NewFromParts(config, workflows, clients, runner)
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
 	// Stall event must be recorded.
 	if len(client.events) != 1 {
@@ -2198,11 +2207,11 @@ func TestHeartbeatRepo_StallWithAssignee_WritesNoteNoRespawn(t *testing.T) {
 	}
 }
 
-// TestHeartbeatRepo_StallWithNoAssignee_RecoverAndNoSpawn verifies that when a
+// TestLivenessCheckRepo_StallWithNoAssignee_RecoverAndNoSpawn verifies that when a
 // stall is detected on an orphaned droplet (no assignee), both the stall note and
 // the recovery note are written, the droplet is reset to open for re-dispatch,
 // and runner.Spawn is NOT called (there is no session to resume).
-func TestHeartbeatRepo_StallWithNoAssignee_RecoverAndNoSpawn(t *testing.T) {
+func TestLivenessCheckRepo_StallWithNoAssignee_RecoverAndNoSpawn(t *testing.T) {
 	client := newMockClient()
 	runner := newMockRunner(client)
 
@@ -2221,7 +2230,7 @@ func TestHeartbeatRepo_StallWithNoAssignee_RecoverAndNoSpawn(t *testing.T) {
 	clients := map[string]CisternClient{"test-repo": client}
 	sched := NewFromParts(config, workflows, clients, runner)
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
 	// Stall event and recovery event must both be recorded.
 	if len(client.events) != 2 {
@@ -2245,10 +2254,10 @@ func TestHeartbeatRepo_StallWithNoAssignee_RecoverAndNoSpawn(t *testing.T) {
 	}
 }
 
-// TestHeartbeatRepo_OrphanRecovery_ClearsAssignedAqueduct verifies that the
+// TestLivenessCheckRepo_OrphanRecovery_ClearsAssignedAqueduct verifies that the
 // orphan handling path clears assigned_aqueduct so the pooled droplet is not
 // locked to a specific aqueduct operator that may no longer exist.
-func TestHeartbeatRepo_OrphanRecovery_ClearsAssignedAqueduct(t *testing.T) {
+func TestLivenessCheckRepo_OrphanRecovery_ClearsAssignedAqueduct(t *testing.T) {
 	client := newMockClient()
 	runner := newMockRunner(client)
 
@@ -2268,7 +2277,7 @@ func TestHeartbeatRepo_OrphanRecovery_ClearsAssignedAqueduct(t *testing.T) {
 	clients := map[string]CisternClient{"test-repo": client}
 	sched := NewFromParts(config, workflows, clients, runner)
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
 	if item.Status != "open" {
 		t.Errorf("expected item status=open after orphan handling, got %q", item.Status)
@@ -2278,10 +2287,10 @@ func TestHeartbeatRepo_OrphanRecovery_ClearsAssignedAqueduct(t *testing.T) {
 	}
 }
 
-// TestHeartbeatRepo_OrphanRecovery_AssignFailure_ClearsDebounce verifies that
+// TestLivenessCheckRepo_OrphanRecovery_AssignFailure_ClearsDebounce verifies that
 // when the Assign call fails, the debounce entry is cleared so the next
-// heartbeat retries the orphan handling rather than suppressing it permanently.
-func TestHeartbeatRepo_OrphanRecovery_AssignFailure_ClearsDebounce(t *testing.T) {
+// liveness check retries the orphan handling rather than suppressing it permanently.
+func TestLivenessCheckRepo_OrphanRecovery_AssignFailure_ClearsDebounce(t *testing.T) {
 	client := newMockClient()
 	client.assignErr = errors.New("db error")
 	runner := newMockRunner(client)
@@ -2301,7 +2310,7 @@ func TestHeartbeatRepo_OrphanRecovery_AssignFailure_ClearsDebounce(t *testing.T)
 	clients := map[string]CisternClient{"test-repo": client}
 	sched := NewFromParts(config, workflows, clients, runner)
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
 	// Recovery event must be recorded (best-effort) even when Pool fails.
 	recoveryEvents := 0
@@ -2315,28 +2324,30 @@ func TestHeartbeatRepo_OrphanRecovery_AssignFailure_ClearsDebounce(t *testing.T)
 	}
 }
 
-// --- heartbeat stall detection integration tests ---
+// --- liveness check stall detection integration tests ---
 
-// TestHeartbeatRepo_AgentEmittingHeartbeat_NotStalled verifies that an agent
-// actively emitting heartbeats (heartbeat < threshold) is not considered stalled,
-// even if it has been running for a long time without commits or an outcome.
-func TestHeartbeatRepo_AgentEmittingHeartbeat_NotStalled(t *testing.T) {
+// TestLivenessCheckRepo_RecentLogMtime_NotStalled verifies that an agent
+// with a recent session log mtime is not considered stalled, even if it has
+// been running for a long time without commits or an outcome.
+func TestLivenessCheckRepo_RecentLogMtime_NotStalled(t *testing.T) {
 	// Mock tmux as alive so exit detection is bypassed and stall
-	// detection runs on the heartbeat timestamp.
+	// detection runs on the session log mtime.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-30 * time.Second), nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
 	client := newMockClient()
 	runner := newMockRunner(client)
 
-	// Heartbeat 30s ago — well within the 1-minute threshold.
 	item := &cistern.Droplet{
-		ID:                "hb-alive",
+		ID:                "lc-alive",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
 		Assignee:          "alpha",
-		LastHeartbeatAt:   time.Now().Add(-30 * time.Second),
 	}
 	client.items[item.ID] = item
 
@@ -2347,39 +2358,41 @@ func TestHeartbeatRepo_AgentEmittingHeartbeat_NotStalled(t *testing.T) {
 	clients := map[string]CisternClient{"test-repo": client}
 	sched := NewFromParts(config, workflows, clients, runner)
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
-	// Agent is heartbeating → not stalled → no events written, no spawn.
+	// Agent has recent session log mtime → not stalled → no events written, no spawn.
 	if len(client.events) != 0 {
-		t.Errorf("expected no stall events for heartbeating agent, got %d", len(client.events))
+		t.Errorf("expected no stall events for active agent, got %d", len(client.events))
 	}
 	runner.mu.Lock()
 	calls := runner.calls
 	runner.mu.Unlock()
 	if len(calls) != 0 {
-		t.Errorf("expected no Spawn calls for heartbeating agent, got %d", len(calls))
+		t.Errorf("expected no Spawn calls for active agent, got %d", len(calls))
 	}
 }
 
-// TestHeartbeatRepo_AgentNotEmittingHeartbeat_Stalled verifies that an agent
-// that has not emitted a heartbeat for longer than the stall threshold is
+// TestLivenessCheckRepo_StaleLogMtime_Stalled verifies that an agent
+// that has a stale session log mtime (beyond stall threshold) is
 // detected as stalled and an escalation note is written. No auto-respawn occurs.
-func TestHeartbeatRepo_AgentNotEmittingHeartbeat_Stalled(t *testing.T) {
+func TestLivenessCheckRepo_StaleLogMtime_Stalled(t *testing.T) {
 	// Mock tmux as alive to avoid exit detection path.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
+	origMtime := sessionLogMtimeFn
+	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-90 * time.Second), nil }
+	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+
 	client := newMockClient()
 	runner := newMockRunner(nil) // nil client: Spawn must not be called
 
-	// Heartbeat 90s ago — older than the 1-minute threshold.
 	item := &cistern.Droplet{
-		ID:                "hb-stalled",
+		ID:                "lc-stalled",
 		CurrentCataractae: "implement",
 		Status:            "in_progress",
 		Assignee:          "alpha",
-		LastHeartbeatAt:   time.Now().Add(-90 * time.Second),
 	}
 	client.items[item.ID] = item
 
@@ -2390,17 +2403,14 @@ func TestHeartbeatRepo_AgentNotEmittingHeartbeat_Stalled(t *testing.T) {
 	clients := map[string]CisternClient{"test-repo": client}
 	sched := NewFromParts(config, workflows, clients, runner)
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
 	// Stall detected → escalation event recorded.
 	if len(client.events) != 1 {
-		t.Fatalf("expected 1 stall event for non-heartbeating agent, got %d", len(client.events))
+		t.Fatalf("expected 1 stall event for stale-log agent, got %d", len(client.events))
 	}
 	if client.events[0].eventType != cistern.EventStall {
 		t.Errorf("stall event type = %q, want %q", client.events[0].eventType, cistern.EventStall)
-	}
-	if !strings.Contains(client.events[0].payload, "heartbeat") {
-		t.Errorf("stall event payload missing heartbeat field; got: %s", client.events[0].payload)
 	}
 
 	// No auto-respawn — stall detection does not respawn; that is exit detection's job.
@@ -2412,12 +2422,12 @@ func TestHeartbeatRepo_AgentNotEmittingHeartbeat_Stalled(t *testing.T) {
 	}
 }
 
-// --- heartbeat exit detection tests ---
+// --- liveness check exit detection tests ---
 
-// TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet verifies that when the
+// TestLivenessCheckRepo_TmuxDead_WritesNoteAndResetsDroplet verifies that when the
 // tmux session is dead the droplet is reset to open for re-dispatch and an
 // exit-no-outcome note is written.
-func TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet(t *testing.T) {
+func TestLivenessCheckRepo_TmuxDead_WritesNoteAndResetsDroplet(t *testing.T) {
 	// Ensure tmux appears dead for our test session.
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return false }
@@ -2440,7 +2450,7 @@ func TestHeartbeatRepo_TmuxDead_WritesNoteAndResetsDroplet(t *testing.T) {
 	runner := newMockRunner(client)
 	sched := NewFromParts(config, workflows, clients, runner)
 
-	sched.heartbeatRepo(context.Background(), config.Repos[0])
+	sched.livenessCheckRepo(context.Background(), config.Repos[0])
 
 	// Event must have been recorded.
 	if len(client.events) != 1 {

--- a/internal/castellarius/smoke_test.go
+++ b/internal/castellarius/smoke_test.go
@@ -219,10 +219,6 @@ func (c *pipelineClient) FileDroplet(repo, title, description string, priority i
 	return &cistern.Droplet{ID: "smoke-filed", Repo: repo}, nil
 }
 
-func (c *pipelineClient) Heartbeat(id string) error {
-	return nil
-}
-
 func (c *pipelineClient) RecordEvent(id, eventType, payload string) error {
 	return nil
 }

--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -49,9 +49,9 @@ type Session struct {
 // Spawn creates a new tmux session running the agent and returns immediately.
 // The Castellarius observe loop detects completion via the outcome field in the DB —
 // agents signal their outcome by calling `ct droplet pass/recirculate/pool <id>`.
-// When the session exits for any reason the heartbeat detects the dead tmux session
+// When the session exits for any reason the liveness check detects the dead tmux session
 // and resets the droplet for re-dispatch. If a session log file exists at
-// ~/.cistern/session-logs/<id>.log the heartbeat reads and logs the tail for diagnostics.
+// ~/.cistern/session-logs/<id>.log the liveness check reads and logs the tail for diagnostics.
 func (s *Session) Spawn() error {
 	return s.spawn()
 }
@@ -99,8 +99,8 @@ func (s *Session) spawn() error {
 	)
 
 	// Session output log: prepare the log directory so pipe-pane can write to it
-	// after the session is created. The log path is also read by the heartbeat
-	// for quick-exit diagnostics.
+	// after the session is created. The log path is also read by the liveness
+	// check for stall detection via mtime.
 	sessionLogPath := filepath.Join(home, ".cistern", "session-logs", s.ID+".log")
 	logDirReady := os.MkdirAll(filepath.Dir(sessionLogPath), 0o750) == nil
 
@@ -479,9 +479,7 @@ continues flowing.
    requirements, and all revision notes from prior cycles.
 2. Adopt the persona described in your role instructions below.
 3. Complete your work according to that persona.
-4. Periodically call ct droplet heartbeat <id> between major operations (after
-   exploring, after implementing, after committing) to prevent stall detection.
-5. Signal your outcome before exiting. You MUST call one of:
+4. Signal your outcome before exiting. You MUST call one of:
      ct droplet pass <id> --notes "..."
      ct droplet recirculate <id> --notes "..."
      ct droplet pool <id> --notes "..."

--- a/internal/cistern/client.go
+++ b/internal/cistern/client.go
@@ -58,10 +58,6 @@ type Droplet struct {
 	// Format: 'provider:key' (e.g. 'jira:DPF-456', 'linear:LIN-789').
 	// Empty string means no external reference (NULL in DB).
 	ExternalRef string `json:"external_ref,omitempty"`
-	// LastHeartbeatAt is the most recent time the agent called `ct droplet heartbeat`.
-	// Zero value means no heartbeat has been emitted yet. Used by the stall detector
-	// to distinguish alive-but-slow agents from genuinely stuck or dead ones.
-	LastHeartbeatAt time.Time `json:"last_heartbeat_at,omitempty"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
@@ -100,7 +96,7 @@ func New(dbPath, prefix string) (*Client, error) {
 		return nil, fmt.Errorf("cistern: open %s: %w", dbPath, err)
 	}
 	// SQLite only supports one concurrent writer. Limit the connection pool to
-	// a single connection so concurrent goroutines (dispatch, heartbeat, observe)
+	// a single connection so concurrent goroutines (dispatch, liveness, observe)
 	// queue behind the same connection rather than racing across independent
 	// *sql.DB pools, which causes "database is locked" errors even with WAL mode.
 	db.SetMaxOpenConns(1)
@@ -229,7 +225,7 @@ func (c *Client) GetReady(repo string) (*Droplet, error) {
 	defer tx.Rollback()
 
 	row := tx.QueryRow(
-		`SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+		`SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, created_at, updated_at, stage_dispatched_at
 		 FROM droplets d
 		 WHERE d.repo = ? COLLATE NOCASE AND d.status = 'open'
 		   AND NOT EXISTS (
@@ -244,11 +240,11 @@ func (c *Client) GetReady(repo string) (*Droplet, error) {
 
 	var droplet Droplet
 	var assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef sql.NullString
-	var lastHeartbeatAt, stageDispatchedAt sql.NullTime
+	var stageDispatchedAt sql.NullTime
 	err = row.Scan(
 		&droplet.ID, &droplet.Repo, &droplet.Title, &droplet.Description,
 		&droplet.Priority, &droplet.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
-		&lastHeartbeatAt, &droplet.CreatedAt, &droplet.UpdatedAt, &stageDispatchedAt,
+		&droplet.CreatedAt, &droplet.UpdatedAt, &stageDispatchedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -256,7 +252,7 @@ func (c *Client) GetReady(repo string) (*Droplet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cistern: scan ready droplet: %w", err)
 	}
-	fillDropletFromNullable(&droplet, assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef, lastHeartbeatAt, stageDispatchedAt)
+	fillDropletFromNullable(&droplet, assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef, stageDispatchedAt)
 
 	now := time.Now().UTC()
 	if _, err := tx.Exec(
@@ -295,7 +291,7 @@ func (c *Client) GetReadyForAqueduct(repo, aqueductName string) (*Droplet, error
 	defer tx.Rollback()
 
 	row := tx.QueryRow(
-		`SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+		`SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, created_at, updated_at, stage_dispatched_at
 		 FROM droplets d
 		 WHERE d.repo = ? COLLATE NOCASE AND d.status = 'open'
 		   AND (d.assigned_aqueduct = '' OR d.assigned_aqueduct IS NULL OR d.assigned_aqueduct = ?)
@@ -311,12 +307,12 @@ func (c *Client) GetReadyForAqueduct(repo, aqueductName string) (*Droplet, error
 
 	var droplet Droplet
 	var assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef sql.NullString
-	var lastHeartbeatAt, stageDispatchedAt sql.NullTime
+	var stageDispatchedAt sql.NullTime
 	now := time.Now().UTC()
 	err = row.Scan(
 		&droplet.ID, &droplet.Repo, &droplet.Title, &droplet.Description,
 		&droplet.Priority, &droplet.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
-		&lastHeartbeatAt, &droplet.CreatedAt, &droplet.UpdatedAt, &stageDispatchedAt,
+		&droplet.CreatedAt, &droplet.UpdatedAt, &stageDispatchedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -324,7 +320,7 @@ func (c *Client) GetReadyForAqueduct(repo, aqueductName string) (*Droplet, error
 	if err != nil {
 		return nil, fmt.Errorf("cistern: scan ready droplet: %w", err)
 	}
-	fillDropletFromNullable(&droplet, assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef, lastHeartbeatAt, stageDispatchedAt)
+	fillDropletFromNullable(&droplet, assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef, stageDispatchedAt)
 
 	if _, err := tx.Exec(
 		`UPDATE "droplets" SET "status" = 'in_progress', "updated_at" = ? WHERE "id" = ?`,
@@ -443,26 +439,6 @@ func (c *Client) SetExternalRef(id, ref string) error {
 		return fmt.Errorf("cistern: set external_ref %s: %w", id, err)
 	}
 	return checkRowsAffected(res, id)
-}
-
-// Heartbeat records the current time as the agent's most recent activity
-// timestamp. Called by agents via `ct droplet heartbeat <id>` every 60 seconds
-// while working. The stall detector uses this timestamp to distinguish alive
-// (heartbeating) agents from genuinely stuck or dead ones.
-func (c *Client) Heartbeat(id string) error {
-	now := time.Now().UTC()
-	res, err := c.db.Exec(
-		`UPDATE droplets SET last_heartbeat_at = ? WHERE id = ?`,
-		now, id,
-	)
-	if err != nil {
-		return fmt.Errorf("cistern: heartbeat %s: %w", id, err)
-	}
-	if err := checkRowsAffected(res, id); err != nil {
-		return err
-	}
-	payload, _ := json.Marshal(map[string]any{"at": now.Format(time.RFC3339)})
-	return c.RecordEvent(id, EventHeartbeat, string(payload))
 }
 
 // EditDropletFields holds the optional fields for EditDroplet.
@@ -949,7 +925,7 @@ func (c *Client) SetCataractae(id, cataractaeName string) error {
 // Get retrieves a single droplet by ID. Returns an error if not found.
 func (c *Client) Get(id string) (*Droplet, error) {
 	row := c.db.QueryRow(
-		`SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+		`SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, created_at, updated_at, stage_dispatched_at
 		 FROM droplets WHERE id = ?`,
 		id,
 	)
@@ -966,7 +942,7 @@ func (c *Client) Get(id string) (*Droplet, error) {
 // List returns droplets filtered by repo and/or status. Empty strings mean no filter.
 // Cancelled droplets are always excluded unless status is explicitly "cancelled".
 func (c *Client) List(repo, status string) ([]*Droplet, error) {
-	query := `SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+	query := `SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, created_at, updated_at, stage_dispatched_at
 		 FROM droplets WHERE 1=1`
 	var args []any
 	if repo != "" {
@@ -1005,7 +981,7 @@ func (c *Client) List(repo, status string) ([]*Droplet, error) {
 // (empty means all). priority is an exact match on priority (0 means all).
 // Results are ordered by priority ASC, created_at ASC.
 func (c *Client) Search(query, status string, priority int) ([]*Droplet, error) {
-	qry := `SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, last_heartbeat_at, created_at, updated_at, stage_dispatched_at
+	qry := `SELECT id, repo, title, description, priority, status, assignee, current_cataractae, outcome, assigned_aqueduct, last_reviewed_commit, external_ref, created_at, updated_at, stage_dispatched_at
 		 FROM droplets WHERE 1=1`
 	var args []any
 	if query != "" {
@@ -1047,11 +1023,11 @@ func (c *Client) Search(query, status string, priority int) ([]*Droplet, error) 
 func scanDroplet(row *sql.Row) (*Droplet, error) {
 	var d Droplet
 	var assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef sql.NullString
-	var lastHeartbeatAt, stageDispatchedAt sql.NullTime
+	var stageDispatchedAt sql.NullTime
 	err := row.Scan(
 		&d.ID, &d.Repo, &d.Title, &d.Description,
 		&d.Priority, &d.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
-		&lastHeartbeatAt, &d.CreatedAt, &d.UpdatedAt, &stageDispatchedAt,
+		&d.CreatedAt, &d.UpdatedAt, &stageDispatchedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -1059,7 +1035,7 @@ func scanDroplet(row *sql.Row) (*Droplet, error) {
 	if err != nil {
 		return nil, err
 	}
-	fillDropletFromNullable(&d, assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef, lastHeartbeatAt, stageDispatchedAt)
+	fillDropletFromNullable(&d, assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef, stageDispatchedAt)
 	return &d, nil
 }
 
@@ -1067,15 +1043,15 @@ func scanDroplet(row *sql.Row) (*Droplet, error) {
 func scanDropletFromRows(rows *sql.Rows) (*Droplet, error) {
 	var d Droplet
 	var assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef sql.NullString
-	var lastHeartbeatAt, stageDispatchedAt sql.NullTime
+	var stageDispatchedAt sql.NullTime
 	if err := rows.Scan(
 		&d.ID, &d.Repo, &d.Title, &d.Description,
 		&d.Priority, &d.Status, &assignee, &currentCataracta, &outcome, &assignedAqueduct, &lastReviewedCommit, &externalRef,
-		&lastHeartbeatAt, &d.CreatedAt, &d.UpdatedAt, &stageDispatchedAt,
+		&d.CreatedAt, &d.UpdatedAt, &stageDispatchedAt,
 	); err != nil {
 		return nil, err
 	}
-	fillDropletFromNullable(&d, assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef, lastHeartbeatAt, stageDispatchedAt)
+	fillDropletFromNullable(&d, assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef, stageDispatchedAt)
 	return &d, nil
 }
 
@@ -1083,7 +1059,7 @@ func scanDropletFromRows(rows *sql.Rows) (*Droplet, error) {
 func fillDropletFromNullable(
 	d *Droplet,
 	assignee, currentCataracta, outcome, assignedAqueduct, lastReviewedCommit, externalRef sql.NullString,
-	lastHeartbeatAt, stageDispatchedAt sql.NullTime,
+	stageDispatchedAt sql.NullTime,
 ) {
 	d.Assignee = assignee.String
 	d.CurrentCataractae = currentCataracta.String
@@ -1091,9 +1067,6 @@ func fillDropletFromNullable(
 	d.AssignedAqueduct = assignedAqueduct.String
 	d.LastReviewedCommit = lastReviewedCommit.String
 	d.ExternalRef = externalRef.String
-	if lastHeartbeatAt.Valid {
-		d.LastHeartbeatAt = lastHeartbeatAt.Time
-	}
 	if stageDispatchedAt.Valid {
 		d.StageDispatchedAt = stageDispatchedAt.Time
 	}
@@ -1690,7 +1663,7 @@ func (c *Client) Restart(id, cataractaeName string) (*Droplet, error) {
 	res, err := tx.Exec(
 		`UPDATE droplets SET status = 'open', assignee = '', outcome = NULL,
 		 current_cataractae = ?, assigned_aqueduct = '', updated_at = ?,
-		 stage_dispatched_at = NULL, last_heartbeat_at = NULL
+		 stage_dispatched_at = NULL
 		 WHERE id = ?`,
 		cataractaeName, now, id,
 	)
@@ -1717,7 +1690,6 @@ func (c *Client) Restart(id, cataractaeName string) (*Droplet, error) {
 	droplet.AssignedAqueduct = ""
 	droplet.UpdatedAt = now
 	droplet.StageDispatchedAt = time.Time{}
-	droplet.LastHeartbeatAt = time.Time{}
 	return droplet, nil
 }
 

--- a/internal/cistern/client_test.go
+++ b/internal/cistern/client_test.go
@@ -1723,172 +1723,7 @@ func TestExternalRef_RoundTrips_ThroughSearch(t *testing.T) {
 	}
 }
 
-// --- Heartbeat round-trip tests ---
-
-// TestHeartbeat_RoundTrips_ThroughGet verifies that Get returns the
-// last_heartbeat_at written by Heartbeat(). A column scan order bug would
-// leave LastHeartbeatAt zero and this test would fail.
-func TestHeartbeat_RoundTrips_ThroughGet(t *testing.T) {
-	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	before := time.Now().UTC().Add(-time.Second)
-	if err := c.Heartbeat(item.ID); err != nil {
-		t.Fatal(err)
-	}
-	after := time.Now().UTC().Add(time.Second)
-
-	// When: Get is called.
-	got, err := c.Get(item.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Then: LastHeartbeatAt is populated.
-	if got.LastHeartbeatAt.IsZero() {
-		t.Fatal("Get: LastHeartbeatAt is zero after Heartbeat()")
-	}
-	if got.LastHeartbeatAt.Before(before) || got.LastHeartbeatAt.After(after) {
-		t.Errorf("Get: LastHeartbeatAt = %v, want between %v and %v", got.LastHeartbeatAt, before, after)
-	}
-}
-
-// TestHeartbeat_RoundTrips_ThroughList verifies that List returns the
-// last_heartbeat_at written by Heartbeat().
-func TestHeartbeat_RoundTrips_ThroughList(t *testing.T) {
-	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	before := time.Now().UTC().Add(-time.Second)
-	if err := c.Heartbeat(item.ID); err != nil {
-		t.Fatal(err)
-	}
-	after := time.Now().UTC().Add(time.Second)
-
-	// When: List is called.
-	items, err := c.List("myrepo", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(items) != 1 {
-		t.Fatalf("List returned %d items, want 1", len(items))
-	}
-
-	// Then: LastHeartbeatAt is populated.
-	if items[0].LastHeartbeatAt.IsZero() {
-		t.Fatal("List: LastHeartbeatAt is zero after Heartbeat()")
-	}
-	if items[0].LastHeartbeatAt.Before(before) || items[0].LastHeartbeatAt.After(after) {
-		t.Errorf("List: LastHeartbeatAt = %v, want between %v and %v", items[0].LastHeartbeatAt, before, after)
-	}
-}
-
-// TestHeartbeat_RoundTrips_ThroughSearch verifies that Search returns the
-// last_heartbeat_at written by Heartbeat().
-func TestHeartbeat_RoundTrips_ThroughSearch(t *testing.T) {
-	c := testClient(t)
-	item, err := c.Add("myrepo", "Heartbeat task", "", 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	before := time.Now().UTC().Add(-time.Second)
-	if err := c.Heartbeat(item.ID); err != nil {
-		t.Fatal(err)
-	}
-	after := time.Now().UTC().Add(time.Second)
-
-	// When: Search is called.
-	results, err := c.Search("Heartbeat task", "", 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("Search returned %d items, want 1", len(results))
-	}
-
-	// Then: LastHeartbeatAt is populated.
-	if results[0].LastHeartbeatAt.IsZero() {
-		t.Fatal("Search: LastHeartbeatAt is zero after Heartbeat()")
-	}
-	if results[0].LastHeartbeatAt.Before(before) || results[0].LastHeartbeatAt.After(after) {
-		t.Errorf("Search: LastHeartbeatAt = %v, want between %v and %v", results[0].LastHeartbeatAt, before, after)
-	}
-}
-
-// TestHeartbeat_RoundTrips_ThroughGetReady verifies that GetReady returns the
-// last_heartbeat_at written by Heartbeat().
-func TestHeartbeat_RoundTrips_ThroughGetReady(t *testing.T) {
-	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	before := time.Now().UTC().Add(-time.Second)
-	if err := c.Heartbeat(item.ID); err != nil {
-		t.Fatal(err)
-	}
-	after := time.Now().UTC().Add(time.Second)
-
-	// When: GetReady is called.
-	got, err := c.GetReady("myrepo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got == nil {
-		t.Fatal("GetReady returned nil")
-	}
-
-	// Then: LastHeartbeatAt is populated.
-	if got.LastHeartbeatAt.IsZero() {
-		t.Fatal("GetReady: LastHeartbeatAt is zero after Heartbeat()")
-	}
-	if got.LastHeartbeatAt.Before(before) || got.LastHeartbeatAt.After(after) {
-		t.Errorf("GetReady: LastHeartbeatAt = %v, want between %v and %v", got.LastHeartbeatAt, before, after)
-	}
-}
-
-// TestHeartbeat_RoundTrips_ThroughGetReadyForAqueduct verifies that
-// GetReadyForAqueduct returns the last_heartbeat_at written by Heartbeat().
-func TestHeartbeat_RoundTrips_ThroughGetReadyForAqueduct(t *testing.T) {
-	c := testClient(t)
-	item, err := c.Add("myrepo", "Task", "", 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	before := time.Now().UTC().Add(-time.Second)
-	if err := c.Heartbeat(item.ID); err != nil {
-		t.Fatal(err)
-	}
-	after := time.Now().UTC().Add(time.Second)
-
-	// When: GetReadyForAqueduct is called.
-	got, err := c.GetReadyForAqueduct("myrepo", "feature")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got == nil {
-		t.Fatal("GetReadyForAqueduct returned nil")
-	}
-
-	// Then: LastHeartbeatAt is populated.
-	if got.LastHeartbeatAt.IsZero() {
-		t.Fatal("GetReadyForAqueduct: LastHeartbeatAt is zero after Heartbeat()")
-	}
-	if got.LastHeartbeatAt.Before(before) || got.LastHeartbeatAt.After(after) {
-		t.Errorf("GetReadyForAqueduct: LastHeartbeatAt = %v, want between %v and %v", got.LastHeartbeatAt, before, after)
-	}
-}
-
-// TestSetExternalRef_ReturnsError_WhenDropletNotFound verifies that SetExternalRef
+// TestSetExternalRef_ReturnsError_WhenDropletNotFound verifies that SetExternalRef verifies that SetExternalRef
 // returns an error when the given ID does not exist in the database.
 func TestSetExternalRef_ReturnsError_WhenDropletNotFound(t *testing.T) {
 	c := testClient(t)
@@ -2234,69 +2069,6 @@ func TestSetAssignedAqueduct_WhenAlreadySet_DoesNotOverwrite(t *testing.T) {
 	}
 	if got.AssignedAqueduct != "cistern-alpha" {
 		t.Errorf("AssignedAqueduct after second SetAssignedAqueduct = %q, want %q (original must not be overwritten)", got.AssignedAqueduct, "cistern-alpha")
-	}
-}
-
-// TestNew_LastHeartbeatAtMigration_AddsColumnToExistingDB verifies that when
-// New() is called on a DB that predates the last_heartbeat_at column, the ALTER
-// TABLE migration adds the column so that Heartbeat() and subsequent reads work
-// without error.
-//
-// Given: a DB created without last_heartbeat_at (simulating a pre-migration install)
-// When:  New() is called to open that DB
-// Then:  Heartbeat() succeeds and Get returns a non-zero LastHeartbeatAt
-func TestNew_LastHeartbeatAtMigration_AddsColumnToExistingDB(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "legacy.db")
-
-	// Seed a DB that has stage_dispatched_at but not last_heartbeat_at,
-	// bypassing New() so the migration has not yet run.
-	seedDB, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := seedDB.Exec(`CREATE TABLE IF NOT EXISTS droplets (
-		id TEXT PRIMARY KEY,
-		repo TEXT NOT NULL,
-		title TEXT NOT NULL,
-		description TEXT DEFAULT '',
-		priority INTEGER DEFAULT 2,
-		status TEXT DEFAULT 'open',
-		assignee TEXT DEFAULT '',
-		current_cataractae TEXT DEFAULT '',
-		outcome TEXT DEFAULT NULL,
-		assigned_aqueduct TEXT DEFAULT '',
-		last_reviewed_commit TEXT DEFAULT NULL,
-		external_ref TEXT DEFAULT NULL,
-		stage_dispatched_at DATETIME DEFAULT NULL,
-		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-	)`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := seedDB.Exec(`INSERT INTO droplets (id, repo, title) VALUES ('migrate-test', 'myrepo', 'heartbeat migration test')`); err != nil {
-		t.Fatal(err)
-	}
-	seedDB.Close()
-
-	// When: New() is called — the ALTER TABLE migration should add last_heartbeat_at.
-	c, err := New(dbPath, "bf")
-	if err != nil {
-		t.Fatalf("New() on legacy DB: %v", err)
-	}
-	defer c.Close()
-
-	// Then: Heartbeat must succeed (would fail with "no such column" without the migration).
-	if err := c.Heartbeat("migrate-test"); err != nil {
-		t.Fatalf("Heartbeat() after migration: %v", err)
-	}
-
-	// And: Get must return a populated LastHeartbeatAt.
-	got, err := c.Get("migrate-test")
-	if err != nil {
-		t.Fatalf("Get() after migration: %v", err)
-	}
-	if got.LastHeartbeatAt.IsZero() {
-		t.Error("Get: LastHeartbeatAt is zero after migration + Heartbeat(); expected non-zero")
 	}
 }
 
@@ -2873,32 +2645,6 @@ func TestRestart_ClearsStageDispatchedAt(t *testing.T) {
 	}
 }
 
-func TestRestart_ClearsLastHeartbeatAt(t *testing.T) {
-	c := testClient(t)
-	item, _ := c.Add("myrepo", "Task", "", 1)
-
-	if err := c.Heartbeat(item.ID); err != nil {
-		t.Fatal(err)
-	}
-	pre, _ := c.Get(item.ID)
-	if pre.LastHeartbeatAt.IsZero() {
-		t.Fatal("precondition: LastHeartbeatAt must be set after Heartbeat()")
-	}
-
-	got, err := c.Restart(item.ID, "implement")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !got.LastHeartbeatAt.IsZero() {
-		t.Errorf("LastHeartbeatAt = %v, want zero after restart", got.LastHeartbeatAt)
-	}
-
-	reloaded, _ := c.Get(item.ID)
-	if !reloaded.LastHeartbeatAt.IsZero() {
-		t.Errorf("reloaded LastHeartbeatAt = %v, want zero after restart", reloaded.LastHeartbeatAt)
-	}
-}
-
 // ── FilterSession CRUD ──
 
 func TestClient_CreateFilterSession(t *testing.T) {
@@ -3325,7 +3071,7 @@ func TestValidEventTypes_ContainsAllConstants(t *testing.T) {
 		EventPool, EventCancel,
 		EventExitNoOutcome, EventStall, EventRecovery,
 		EventCircuitBreaker, EventLoopRecovery,
-		EventAutoPromote, EventNoRoute, EventHeartbeat,
+		EventAutoPromote, EventNoRoute,
 	}
 	for _, e := range expected {
 		if !ValidEventTypes[e] {

--- a/internal/cistern/event_types.go
+++ b/internal/cistern/event_types.go
@@ -23,7 +23,6 @@ const (
 	EventCircuitBreaker = "circuit_breaker"
 	EventLoopRecovery   = "loop_recovery"
 	EventAutoPromote    = "auto_promote"
-	EventHeartbeat      = "heartbeat"
 	EventNoRoute        = "no_route"
 )
 
@@ -45,7 +44,6 @@ const (
 	EventLoopRecovery:   true,
 	EventAutoPromote:    true,
 	EventNoRoute:        true,
-	EventHeartbeat:      true,
 }
 
 func parsePayload(payload string) map[string]any {
@@ -100,8 +98,6 @@ func DisplayInfo(eventType, payload string) (eventLabel, detail string) {
 		return "auto_promote", displayInfoAutoPromote(m)
 	case EventNoRoute:
 		return "no_route", displayInfoCataractae(m)
-	case EventHeartbeat:
-		return "heartbeat", displayInfoHeartbeat(m)
 	default:
 		return eventType, payload
 	}
@@ -230,9 +226,6 @@ func displayInfoStall(m map[string]any) string {
 	if elapsed, ok := m["elapsed"]; ok && elapsed != "" {
 		parts = append(parts, fmt.Sprintf("elapsed: %v", elapsed))
 	}
-	if heartbeat, ok := m["heartbeat"]; ok && heartbeat != "" {
-		parts = append(parts, fmt.Sprintf("heartbeat: %v", heartbeat))
-	}
 	return strings.Join(parts, ", ")
 }
 
@@ -277,23 +270,6 @@ func displayInfoAutoPromote(m map[string]any) string {
 	}
 	if routedTo, ok := m["routed_to"]; ok && routedTo != "" {
 		parts = append(parts, fmt.Sprintf("routed to: %v", routedTo))
-	}
-	return strings.Join(parts, ", ")
-}
-
-func displayInfoHeartbeat(m map[string]any) string {
-	if m == nil {
-		return "heartbeat recorded"
-	}
-	var parts []string
-	if cat, ok := m["cataractae"]; ok && cat != "" {
-		parts = append(parts, fmt.Sprintf("step: %v", cat))
-	}
-	if elapsed, ok := m["elapsed"]; ok && elapsed != "" {
-		parts = append(parts, fmt.Sprintf("elapsed: %v", elapsed))
-	}
-	if len(parts) == 0 {
-		return "heartbeat recorded"
 	}
 	return strings.Join(parts, ", ")
 }

--- a/internal/cistern/migrate_test.go
+++ b/internal/cistern/migrate_test.go
@@ -111,7 +111,7 @@ func TestEndToEndSchemaVerification(t *testing.T) {
 		"id", "repo", "title", "description", "priority",
 		"status", "assignee", "current_cataractae", "outcome",
 		"assigned_aqueduct", "last_reviewed_commit", "external_ref",
-		"last_heartbeat_at", "created_at", "updated_at", "stage_dispatched_at",
+		"created_at", "updated_at", "stage_dispatched_at",
 	}
 
 	rows, err := c.db.Query(`PRAGMA table_info("droplets")`)
@@ -154,8 +154,8 @@ func TestEndToEndSchemaVerification(t *testing.T) {
 
 	var migrationCount int
 	c.db.QueryRow(`SELECT COUNT(*) FROM "_schema_migrations"`).Scan(&migrationCount)
-	if migrationCount != 19 {
-		t.Errorf("expected 19 migration records, got %d", migrationCount)
+	if migrationCount != 20 {
+		t.Errorf("expected 20 migration records, got %d", migrationCount)
 	}
 }
 

--- a/internal/cistern/migrations/020_drop_last_heartbeat_at.sql
+++ b/internal/cistern/migrations/020_drop_last_heartbeat_at.sql
@@ -1,0 +1,4 @@
+-- Migration 020: Drop last_heartbeat_at column.
+-- Agent heartbeats are replaced by Castellarius-driven liveness detection
+-- (session log mtime). The column is no longer written or read.
+ALTER TABLE "droplets" DROP COLUMN "last_heartbeat_at";

--- a/internal/cistern/schema.sql
+++ b/internal/cistern/schema.sql
@@ -11,7 +11,6 @@ CREATE TABLE IF NOT EXISTS "droplets" (
     "assigned_aqueduct" TEXT DEFAULT '',
     "last_reviewed_commit" TEXT DEFAULT NULL,
     "external_ref" TEXT DEFAULT NULL,
-    "last_heartbeat_at" DATETIME DEFAULT NULL,
     "created_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
     "updated_at" DATETIME DEFAULT CURRENT_TIMESTAMP,
     "stage_dispatched_at" DATETIME DEFAULT NULL

--- a/skills/cistern/references/commands.md
+++ b/skills/cistern/references/commands.md
@@ -42,7 +42,6 @@ ct droplet restart <id> --cataractae delivery --notes "..."   # Re-enter with a 
 ct droplet pool <id>                    # Pool — cannot currently proceed
 ct droplet cancel <id> --reason "..."    # Cancel droplet — won't be implemented or no longer needed (reason required)
 ct droplet note <id> "..."               # Add a note
-ct droplet heartbeat <id>                # Record agent heartbeat (called by agents every 60 seconds)
 ```
 
 ### Tail — Stream Droplet Events

--- a/skills/cistern/references/troubleshooting.md
+++ b/skills/cistern/references/troubleshooting.md
@@ -187,30 +187,24 @@ When a droplet has been inactive for a prolonged period (default: 45 minutes), t
 
 **Stall event display in `ct droplet log`:**
 ```
-stall  step: implement, elapsed: 2h30m, heartbeat: 2026-01-15T10:30:45Z
-```
-or, if no heartbeat has been emitted:
-```
-stall  step: implement, elapsed: 2h30m, heartbeat: none
+stall  step: implement, elapsed: 2h30m
 ```
 
 **Fields explained:**
 - `step` — The cataractae stage where the droplet is stalled
 - `elapsed` — How long the droplet has been inactive (rounded to nearest minute; e.g., `2h30m`, `45m`)
-- `heartbeat` — The RFC3339 timestamp of the agent's most recent `ct droplet heartbeat <id>` call, or `none` if no heartbeat has ever been emitted (pre-feature agents or agents that exited before their first heartbeat)
 
-**Rate-limiting:** To prevent log spam from long-stalled droplets, the scheduler writes at most one stall event per hour for the same droplet. If a droplet remains stalled beyond the first detection, no new event is written until 60 minutes have passed since the last event (or until the heartbeat advances, which resets the window).
+The Castellarius determines liveness by checking the session log mtime (the file written by tmux `pipe-pane`). If the agent is alive and working, it's writing to its session log continuously. A stale mtime means the agent is stuck or dead. If no session log exists (orphan droplets with no assignee), `updated_at` is used as a fallback signal.
+
+**Rate-limiting:** To prevent log spam from long-stalled droplets, the scheduler writes at most one stall event per hour for the same droplet. If a droplet remains stalled beyond the first detection, no new event is written until 60 minutes have passed since the last event.
 
 **What to do when you see stall events:**
-1. Check the `heartbeat` field: if it shows `none`, the agent never emitted a heartbeat — it likely died before starting work. Check exit detection logs and consider restarting:
-   - `ct droplet restart <id>` — restart at current cataractae
-   - `ct droplet restart <id> --cataractae implement` — restart at a specific cataractae
-2. If `heartbeat` shows a timestamp, the agent was alive at that point. Check if the agent session is still running: `ct droplet peek <id>` (shows live session output)
-3. A stall event does **not** trigger an automatic respawn — the agent may simply be slow (e.g., waiting on an LLM response). Monitor before acting.
-4. If the droplet can proceed, restart it:
+1. Check if the agent session is still running: `ct droplet peek <id>` (shows live session output)
+2. A stall event does **not** trigger an automatic respawn — the agent may simply be slow (e.g., waiting on an LLM response). Monitor before acting.
+3. If the droplet can proceed, restart it:
    - `ct droplet restart <id>` — restart at current cataractae
    - `ct droplet restart <id> --cataractae review` — restart at a specific cataractae
-5. If it's a known limitation or awaiting external resources, pool it: `ct droplet pool <id> --notes "..."`
+4. If it's a known limitation or awaiting external resources, pool it: `ct droplet pool <id> --notes "..."`
 
 ### Droplet Repeatedly Failing with "backing off" Messages
 
@@ -239,7 +233,7 @@ If you see an `exit_no_outcome` event in `ct droplet log <id>`, the Castellarius
 **What this means:**
 - The agent's tmux session is gone (agent finished and exited, or crashed)
 - The agent never called `ct droplet pass/recirculate/pool` before exiting
-- The Castellarius heartbeat detected this and checked the DB — no outcome was written, and the cataractae stage hadn't advanced — so it reset the droplet for re-dispatch
+- The Castellarius liveness check detected this and checked the DB — no outcome was written, and the cataractae stage hadn't advanced — so it reset the droplet for re-dispatch
 
 **Expected behavior:**
 1. An `exit_no_outcome` event is recorded in the droplet history
@@ -313,7 +307,7 @@ If you see a `recovery` event in `ct droplet log <id>` (displayed as `recovery  
 - The droplet had no assignee, so the Castellarius could not identify a tmux session to resume and triggered orphan recovery after the stall threshold elapsed
 - The droplet was invisible to any aqueduct and could not make progress
 - This typically occurs after Castellarius crash/restart or failed dispatch where the droplet was never assigned to a worker
-- The Castellarius heartbeat automatically recovered it (check interval: 30 seconds by default)
+- The Castellarius liveness check automatically recovered it (check interval: 30 seconds by default)
 
 **Expected behavior:**
 1. A `recovery` event is recorded in the droplet history

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -12,7 +12,6 @@ export interface Droplet {
   assigned_aqueduct?: string;
   last_reviewed_commit?: string;
   external_ref?: string;
-  last_heartbeat_at?: string;
   created_at: string;
   updated_at: string;
   stage_dispatched_at?: string;


### PR DESCRIPTION
## Summary

- **Remove agent-driven heartbeat** (`ct droplet heartbeat`) and replace with **Castellarius-driven liveness detection** using session log mtime
- Agents no longer need to call any heartbeat command — the Castellarius passively checks whether the tmux `pipe-pane` session log has been written to recently
- This removes context-wasting LLM calls and eliminates an entire class of bugs where agents forgot or mis-called heartbeat

## What changed

**Removed:**
- `ct droplet heartbeat <id>` CLI command
- `POST /api/droplets/{id}/heartbeat` API endpoint
- `Client.Heartbeat()` method and `CisternClient.Heartbeat()` interface method
- `last_heartbeat_at` database column (migration 020 drops it)
- `EventHeartbeat` event type and `displayInfoHeartbeat()` function
- Heartbeat instruction from agent prompt in `session.go`
- `heartbeat` field from stall event payload
- `HeartbeatInterval` config field (renamed to `LivenessInterval`)
- `heartbeatInterval` / `heartbeatInProgress` / `heartbeatRepo` (renamed to `livenessInterval` / `livenessCheck` / `livenessCheckRepo`)

**Added:**
- `sessionLogMtime()` function that checks `~/.cistern/session-logs/<repo>-<worker>.log` modification time
- Stall detection now uses session log mtime (with fallback to `updated_at` for orphans)
- 16 liveness regression tests covering exit detection, stall detection, orphan recovery, DB integration, and error fallbacks

## Why

Agent heartbeats were added when reading agent output was unreliable. Those bugs are now solved, and the heartbeat mechanism:
- Wastes LLM context (every 60s the agent calls a CLI command)
- Adds complexity (agent must remember to call it, Castellarius must track the timestamp)
- Creates event noise (60 events/hour/droplet)
- Doesn't actually distinguish "alive" from "stuck" better than checking whether the agent's session log is still being written to

The session log mtime is a passive signal — the agent is already writing to it via tmux `pipe-pane`, so no agent cooperation is needed.

## Testing

- All 13 packages pass (including 16 new liveness regression tests)
- Existing castellarius, client, and CLI tests updated
- Migration 020 verified in `TestEndToEndSchemaVerification`