### PR TITLE
refactor: extract sessionlog package to unify session log path resolution

### DIFF
--- a/cmd/ct/cistern.go
+++ b/cmd/ct/cistern.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -19,6 +18,7 @@ import (
 	"github.com/MichielDean/cistern/internal/aqueduct"
 	"github.com/MichielDean/cistern/internal/cistern"
 	"github.com/MichielDean/cistern/internal/provider"
+	"github.com/MichielDean/cistern/internal/sessionlog"
 	"github.com/spf13/cobra"
 )
 
@@ -1013,7 +1013,6 @@ var (
 	peekRaw       bool
 	peekFollow    bool
 	peekSnapshot  bool
-	sessionLogDir string // overrideable in tests; empty means ~/.cistern/session-logs
 )
 
 // tmuxHasSession reports whether the named tmux session exists.
@@ -1090,16 +1089,11 @@ var dropletPeekCmd = &cobra.Command{
 			if peekFollow {
 				return fmt.Errorf("--raw is incompatible with --follow")
 			}
-			logDir := sessionLogDir
-			if logDir == "" {
-				home, err := os.UserHomeDir()
-				if err != nil {
-					return fmt.Errorf("cannot determine home directory: %w", err)
-				}
-				logDir = filepath.Join(home, ".cistern", "session-logs")
+			logPath, err := sessionlog.Path(session)
+			if err != nil {
+				return fmt.Errorf("cannot resolve session log path: %w", err)
 			}
-			logPath := filepath.Join(logDir, session+".log")
-			f, err := os.Open(logPath)
+			data, err := sessionlog.Read(session)
 			if err != nil {
 				if os.IsNotExist(err) {
 					fmt.Printf("No session log found at %s\n", logPath)
@@ -1107,8 +1101,7 @@ var dropletPeekCmd = &cobra.Command{
 				}
 				return err
 			}
-			defer f.Close()
-			_, err = io.Copy(os.Stdout, f)
+			_, err = os.Stdout.Write(data)
 			return err
 		}
 

--- a/cmd/ct/peek_test.go
+++ b/cmd/ct/peek_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/MichielDean/cistern/internal/cistern"
+	"github.com/MichielDean/cistern/internal/sessionlog"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -236,8 +237,9 @@ func TestDropletPeekRaw_ReadsSessionLog(t *testing.T) {
 
 	// Create a session log file in a temp dir.
 	logDir := t.TempDir()
-	sessionLogDir = logDir
-	defer func() { sessionLogDir = "" }()
+	origLogDirFn := sessionlog.LogDirFn
+	sessionlog.LogDirFn = func() (string, error) { return logDir, nil }
+	t.Cleanup(func() { sessionlog.LogDirFn = origLogDirFn })
 
 	logContent := "agent output line 1\nagent output line 2\n"
 	logFile := filepath.Join(logDir, "myrepo-test-worker.log")
@@ -284,9 +286,10 @@ func TestDropletPeekRaw_ReadsSessionLog(t *testing.T) {
 func TestDropletPeekRaw_NoLogFile_PrintsHelpfulMessage(t *testing.T) {
 	itemID := makeInProgressItem(t)
 
-	// Point sessionLogDir to an empty temp dir (no log file present).
-	sessionLogDir = t.TempDir()
-	defer func() { sessionLogDir = "" }()
+	// Point LogDirFn to an empty temp dir (no log file present).
+	origLogDirFn := sessionlog.LogDirFn
+	sessionlog.LogDirFn = func() (string, error) { return t.TempDir(), nil }
+	t.Cleanup(func() { sessionlog.LogDirFn = origLogDirFn })
 
 	old := os.Stdout
 	r, w, _ := os.Pipe()

--- a/internal/castellarius/coverage_gaps_test.go
+++ b/internal/castellarius/coverage_gaps_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MichielDean/cistern/internal/aqueduct"
 	"github.com/MichielDean/cistern/internal/cistern"
+	"github.com/MichielDean/cistern/internal/sessionlog"
 )
 
 // testDB creates a temporary cistern database and returns its path.
@@ -341,9 +342,9 @@ func TestLivenessCheckRepo_StallDetected_ForAssignedDroplet(t *testing.T) {
 	client.items[item.ID] = item
 
 	sched := testScheduler(client, newMockRunner(client))
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	sched.livenessCheckRepo(context.Background(), sched.config.Repos[0])
 
@@ -369,9 +370,9 @@ func TestLivenessCheckRepo_ActiveDroplet_NotStalled(t *testing.T) {
 	client.items[item.ID] = item
 
 	sched := testScheduler(client, newMockRunner(client))
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-1 * time.Minute), nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-1 * time.Minute), nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	sched.livenessCheckRepo(context.Background(), sched.config.Repos[0])
 
@@ -397,9 +398,9 @@ func TestLivenessCheckRepo_UnknownAssignee_WritesStallNote(t *testing.T) {
 	client.items[item.ID] = item
 
 	sched := testScheduler(client, newMockRunner(client))
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	sched.livenessCheckRepo(context.Background(), sched.config.Repos[0])
 

--- a/internal/castellarius/liveness_regression_test.go
+++ b/internal/castellarius/liveness_regression_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MichielDean/cistern/internal/aqueduct"
 	"github.com/MichielDean/cistern/internal/cistern"
+	"github.com/MichielDean/cistern/internal/sessionlog"
 )
 
 // --- Liveness Regression Tests ---
@@ -254,11 +255,11 @@ func TestLiveness_Stall_RecentSessionLogMtime_NotStalled(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true } // session alive
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(_ string) (time.Time, error) {
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(_ string) (time.Time, error) {
 		return time.Now().Add(-30 * time.Second), nil // active agent
 	}
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 
 	client := newMockClient()
@@ -295,11 +296,11 @@ func TestLiveness_Stall_OldSessionLogMtime_IsStalled(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(_ string) (time.Time, error) {
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(_ string) (time.Time, error) {
 		return time.Now().Add(-60 * time.Minute), nil // stale
 	}
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 
 	client := newMockClient()
@@ -341,9 +342,9 @@ func TestLiveness_Stall_NoSessionLog_FallsBackToUpdatedAt(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil } // no log
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil } // no log
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 
 	client := newMockClient()
@@ -385,9 +386,9 @@ func TestLiveness_Stall_NoSessionLog_RecentUpdatedAt_NotStalled(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil } // no log
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil } // no log
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 
 	client := newMockClient()
@@ -425,9 +426,9 @@ func TestLiveness_Stall_NoAssignee_OrphanRecovery(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 
 	client := newMockClient()
@@ -513,9 +514,9 @@ func TestLiveness_DB_StallWithOrphanRecovery(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = origTmux })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	c, err := cistern.New(dbPath, "ts")
@@ -643,9 +644,9 @@ func TestLiveness_Stall_SessionLogReadError_FallsBackToUpdatedAt(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, sql.ErrConnDone } // read error
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(_ string) (time.Time, error) { return time.Time{}, sql.ErrConnDone } // read error
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 
 	client := newMockClient()
@@ -687,9 +688,9 @@ func TestLiveness_Stall_NoAssignee_NoSessionLog_UsesUpdatedAt(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(_ string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 
 	client := newMockClient()

--- a/internal/castellarius/production_gaps_test.go
+++ b/internal/castellarius/production_gaps_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/MichielDean/cistern/internal/aqueduct"
 	"github.com/MichielDean/cistern/internal/cistern"
+	"github.com/MichielDean/cistern/internal/sessionlog"
 )
 
 // --- Liveness check progress-monitoring tests ---
@@ -32,9 +33,9 @@ func TestLivenessCheck_StallDetected_WhenNoSignals(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	buf := &bytes.Buffer{}
 	client := newMockClient()
@@ -67,9 +68,9 @@ func TestLivenessCheck_NoStallNote_WhenRecentLogMtime(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-5 * time.Second), nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-5 * time.Second), nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	buf := &bytes.Buffer{}
 	client := newMockClient()
@@ -334,9 +335,9 @@ func TestLivenessCheck_DB_NotStalled_WhenRecentLogMtime(t *testing.T) {
 	rawDB.Close()
 
 	// Mock session log mtime to return a recent time — agent is alive and working.
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-5 * time.Second), nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-5 * time.Second), nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	cfg := testConfig()
 	cfg.StallThresholdMinutes = 1
@@ -395,9 +396,9 @@ func TestLivenessCheck_DB_Stalled_WhenNoLogMtime(t *testing.T) {
 	rawDB.Close()
 
 	// Mock session log mtime to return zero time — agent has no session log.
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Time{}, nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	cfg := testConfig()
 	cfg.StallThresholdMinutes = 1

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/MichielDean/cistern/internal/aqueduct"
 	"github.com/MichielDean/cistern/internal/cistern"
+	"github.com/MichielDean/cistern/internal/sessionlog"
 )
 
 // CisternClient is the interface for interacting with the work cistern.
@@ -1690,22 +1691,10 @@ func isTmuxAlive(sessionID string) bool {
 	return isTmuxAliveFn(sessionID)
 }
 
-// sessionLogMtime returns the modification time of the session log file.
-// Used as a liveness signal: an active agent writes to its session log via
-// tmux pipe-pane, so a stale mtime indicates the agent is stuck or dead.
-// Returns zero time if the log file does not exist.
-var sessionLogMtimeFn = func(sessionID string) (time.Time, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return time.Time{}, err
-	}
-	path := filepath.Join(home, ".cistern", "session-logs", sessionID+".log")
-	info, err := os.Stat(path)
-	if err != nil {
-		return time.Time{}, nil
-	}
-	return info.ModTime().UTC(), nil
-}
+// sessionLogMtime delegates to the sessionlog package for testability.
+// Tests can override sessionLogMtimeFn (or sessionlog.MtimeFn directly)
+// to control the mtime returned without creating real files.
+var sessionLogMtimeFn = sessionlog.Mtime
 
 func sessionLogMtime(sessionID string) (time.Time, error) {
 	return sessionLogMtimeFn(sessionID)

--- a/internal/castellarius/scheduler_test.go
+++ b/internal/castellarius/scheduler_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/MichielDean/cistern/internal/aqueduct"
 	"github.com/MichielDean/cistern/internal/cistern"
+	"github.com/MichielDean/cistern/internal/sessionlog"
 )
 
 // newTestLogger creates a slog.Logger backed by buf for test inspection.
@@ -2086,9 +2087,9 @@ func TestLivenessCheckRepo_StallThreshold_ExplicitMinutesRespected(t *testing.T)
 	client.items[item.ID] = item
 
 	// Mock session log mtime to return 2 minutes ago — older than threshold.
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-2 * time.Minute), nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-2 * time.Minute), nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
@@ -2128,9 +2129,9 @@ func TestLivenessCheckRepo_StallThreshold_DefaultsTo45Minutes(t *testing.T) {
 	client.items[item.ID] = item
 
 	// Mock session log mtime to return 2 minutes ago — within default threshold.
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-2 * time.Minute), nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-2 * time.Minute), nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	orig := isTmuxAliveFn
 	isTmuxAliveFn = func(_ string) bool { return true }
@@ -2336,9 +2337,9 @@ func TestLivenessCheckRepo_RecentLogMtime_NotStalled(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-30 * time.Second), nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-30 * time.Second), nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	client := newMockClient()
 	runner := newMockRunner(client)
@@ -2381,9 +2382,9 @@ func TestLivenessCheckRepo_StaleLogMtime_Stalled(t *testing.T) {
 	isTmuxAliveFn = func(_ string) bool { return true }
 	t.Cleanup(func() { isTmuxAliveFn = orig })
 
-	origMtime := sessionLogMtimeFn
-	sessionLogMtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-90 * time.Second), nil }
-	t.Cleanup(func() { sessionLogMtimeFn = origMtime })
+	origMtime := sessionlog.MtimeFn
+	sessionlog.MtimeFn = func(sessionID string) (time.Time, error) { return time.Now().Add(-90 * time.Second), nil }
+	t.Cleanup(func() { sessionlog.MtimeFn = origMtime })
 
 	client := newMockClient()
 	runner := newMockRunner(nil) // nil client: Spawn must not be called

--- a/internal/cataractae/session.go
+++ b/internal/cataractae/session.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/MichielDean/cistern/internal/aqueduct"
 	"github.com/MichielDean/cistern/internal/provider"
+	"github.com/MichielDean/cistern/internal/sessionlog"
 )
 
 // Session manages an agent execution inside a tmux session.
@@ -101,8 +102,11 @@ func (s *Session) spawn() error {
 	// Session output log: prepare the log directory so pipe-pane can write to it
 	// after the session is created. The log path is also read by the liveness
 	// check for stall detection via mtime.
-	sessionLogPath := filepath.Join(home, ".cistern", "session-logs", s.ID+".log")
-	logDirReady := os.MkdirAll(filepath.Dir(sessionLogPath), 0o750) == nil
+	sessionLogPath, err := sessionlog.Path(s.ID)
+	if err != nil {
+		slog.Default().Warn("session: could not resolve log path", "session", s.ID, "error", err)
+	}
+	logDirReady := sessionlog.EnsureDir() == nil
 
 	args = append(args, s.collectEnvArgs()...)
 	args = append(args, agentCmd)

--- a/internal/sessionlog/sessionlog.go
+++ b/internal/sessionlog/sessionlog.go
@@ -1,0 +1,84 @@
+// Package sessionlog provides a single source of truth for session log file
+// paths and operations. The Castellarius liveness check, the CLI peek command,
+// and the cataractae spawn logic all resolve session log paths through this
+// package — no duplicated path strings, no inconsistent home-directory lookups.
+package sessionlog
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// LogDirFn returns the session log directory. Override in tests to control
+// the log directory without creating real directories. Defaults to
+// ~/.cistern/session-logs.
+var LogDirFn = defaultLogDir
+
+func defaultLogDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cistern", "session-logs"), nil
+}
+
+// Path returns the full path to the session log file for the given session ID.
+// The session ID is typically "<repo>-<assignee>" (e.g. "myrepo-alpha").
+func Path(sessionID string) (string, error) {
+	dir, err := LogDirFn()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, sessionID+".log"), nil
+}
+
+// MtimeFn is the function used by Mtime. Override in tests to control
+// the returned mtime without creating real files.
+var MtimeFn = defaultMtime
+
+func defaultMtime(sessionID string) (time.Time, error) {
+	p, err := Path(sessionID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return time.Time{}, nil
+		}
+		return time.Time{}, err
+	}
+	return info.ModTime().UTC(), nil
+}
+
+// Mtime returns the modification time of the session log file.
+// Used by the Castellarius liveness check to detect stalled agents:
+// an active agent writes to its session log continuously via tmux pipe-pane,
+// so a stale mtime indicates the agent is stuck or dead.
+// Returns zero time if the log file does not exist.
+func Mtime(sessionID string) (time.Time, error) {
+	return MtimeFn(sessionID)
+}
+
+// Read returns the full contents of the session log file.
+// Used by ct droplet peek --raw to display agent output without tmux.
+// Returns an error if the file cannot be read. Callers should handle
+// os.IsNotExist for missing logs.
+func Read(sessionID string) ([]byte, error) {
+	p, err := Path(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(p)
+}
+
+// EnsureDir creates the session log directory if it does not exist.
+// Called by the cataractae spawn logic before setting up tmux pipe-pane.
+func EnsureDir() error {
+	dir, err := LogDirFn()
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(dir, 0o750)
+}

--- a/internal/sessionlog/sessionlog_test.go
+++ b/internal/sessionlog/sessionlog_test.go
@@ -1,0 +1,107 @@
+package sessionlog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPath_ReturnsExpectedFormat(t *testing.T) {
+	p, err := Path("myrepo-alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(p) != "myrepo-alpha.log" {
+		t.Errorf("Base(Path) = %q, want %q", filepath.Base(p), "myrepo-alpha.log")
+	}
+	if filepath.Ext(p) != ".log" {
+		t.Errorf("Ext(Path) = %q, want .log", filepath.Ext(p))
+	}
+}
+
+func TestEnsureDir_CreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	orig := LogDirFn
+	LogDirFn = func() (string, error) { return filepath.Join(dir, "session-logs"), nil }
+	t.Cleanup(func() { LogDirFn = orig })
+
+	if err := EnsureDir(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "session-logs")); err != nil {
+		t.Errorf("expected directory to exist: %v", err)
+	}
+}
+
+func TestMtime_ReturnsZeroWhenFileMissing(t *testing.T) {
+	dir := t.TempDir()
+	orig := LogDirFn
+	LogDirFn = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { LogDirFn = orig })
+
+	mtime, err := Mtime("nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mtime.IsZero() {
+		t.Errorf("Mtime of missing file = %v, want zero", mtime)
+	}
+}
+
+func TestMtime_ReturnsModificationTime(t *testing.T) {
+	dir := t.TempDir()
+	orig := LogDirFn
+	LogDirFn = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { LogDirFn = orig })
+
+	before := time.Now().UTC().Truncate(time.Second)
+	logPath := filepath.Join(dir, "test.log")
+	if err := os.WriteFile(logPath, []byte("output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mtime, err := Mtime("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mtime.Before(before) {
+		t.Errorf("Mtime = %v, want >= %v", mtime, before)
+	}
+}
+
+func TestRead_ReturnsContent(t *testing.T) {
+	dir := t.TempDir()
+	orig := LogDirFn
+	LogDirFn = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { LogDirFn = orig })
+
+	content := "line 1\nline 2\n"
+	logPath := filepath.Join(dir, "test.log")
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := Read("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != content {
+		t.Errorf("Read = %q, want %q", string(data), content)
+	}
+}
+
+func TestRead_ReturnsErrorWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	orig := LogDirFn
+	LogDirFn = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { LogDirFn = orig })
+
+	_, err := Read("nonexistent")
+	if err == nil {
+		t.Error("Read of missing file should return error")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("error = %v, want IsNotExist", err)
+	}
+}


### PR DESCRIPTION
## Summary

Extract a shared `internal/sessionlog` package so the session log path (`~/.cistern/session-logs/<id>.log`) is resolved in one place instead of three.

**Before:** Hard-coded `filepath.Join(home, ".cistern", "session-logs", id+".log")` in:
- `internal/cataractae/session.go` — spawn (writes the log)
- `internal/castellarius/scheduler.go` — liveness (reads mtime)
- `cmd/ct/cistern.go` — peek `--raw` (reads content)

**After:** All three use `sessionlog.Path()`, `sessionlog.Mtime()`, `sessionlog.Read()`, and `sessionlog.EnsureDir()`.

## What changed

- New `internal/sessionlog` package with `Path()`, `Mtime()`, `Read()`, `EnsureDir()`
- `LogDirFn` and `MtimeFn` are exported for test overrides (same pattern as `isTmuxAliveFn`)
- Scheduler's `sessionLogMtimeFn` now delegates to `sessionlog.MtimeFn`
- CLI peek's `--raw` mode uses `sessionlog.Read()` instead of manual `os.Open`
- Cataractae spawn uses `sessionlog.Path()` and `sessionlog.EnsureDir()`
- 6 unit tests for the new package
- Removed `sessionLogDir` variable from CLI peek tests (uses `sessionlog.LogDirFn` instead)

This is a follow-up to #506 (heartbeat removal) and does not depend on it being merged first — it builds on the same `sessionLogMtimeFn` that PR already introduced, just moving it to a shared package.