### PR TITLE
Add fork-based delivery mode for external repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### Add fork-based delivery mode for external repos (ci-0pbgd)
+
+Cistern now supports fork-mode delivery for repositories where you don't have merge access. Instead of pushing to origin and merging directly, fork-mode repos push to your fork remote and open a PR against the upstream repository.
+
+**New config fields** (`cistern.yaml`):
+- `delivery_mode` — `"direct"` (default) or `"fork"`. Invalid values are rejected at validation.
+- `upstream_remote` — Required when `delivery_mode` is `fork`. The URL of the upstream repository (e.g., `https://github.com/upstream-org/repo.git`).
+
+**Key changes:**
+- `RepoConfig` gains `DeliveryMode` and `UpstreamRemote` fields with YAML tags `delivery_mode` and `upstream_remote`
+- `ValidateAqueductConfig` normalizes empty `delivery_mode` to `"direct"`, rejects invalid values, and requires `upstream_remote` when fork mode is set
+- `EnsurePrimaryClone` adds an `upstream` git remote for fork-mode repos and fetches upstream refs
+- `prepareDropletWorktree` accepts a `baseRemote` parameter — fork-mode worktrees are based on `upstream/main` instead of `origin/main`, and their tracking branch is set to `upstream/main`
+- `hookGitSync` routes fork-mode repos: fetches from `upstream` (primary), also fetches `origin` as best-effort, resets `_primary` to `upstream/main`, syncs skills from the primary remote's main branch
+- `CONTEXT.md` includes a **Fork Delivery** section when the repo is in fork mode, providing the upstream remote URL and base branch to the fork-delivery cataractae
+- New `fork-delivery` cataractae identity (`cataractae/fork-delivery/`) with a full INSTRUCTIONS.md covering rebase onto upstream, push to origin, PR creation via `gh`, CI monitoring, and conflict resolution
+- Example fork-mode aqueduct workflow in `aqueduct/aqueduct.yaml` (commented out)
+
+**Files changed:**
+- `internal/aqueduct/types.go` — `DeliveryMode` type, constants, `RepoConfig.DeliveryMode` and `RepoConfig.UpstreamRemote` fields
+- `internal/aqueduct/types_test.go` — new tests for `DeliveryMode` constants
+- `internal/aqueduct/validate.go` — validation for delivery mode values and upstream_remote requirement
+- `internal/aqueduct/validate_test.go` — new tests for fork-mode validation
+- `internal/castellarius/scheduler.go` — `prepareDropletWorktree` and `dispatchRepo` pass `baseRemote` based on delivery mode
+- `internal/castellarius/drought_hooks.go` — `hookGitSync` routes fork-mode repos to upstream, `syncSkillsFromRepo` takes `remote` parameter
+- `internal/castellarius/branch_lifecycle_test.go` — new fork-mode worktree tests
+- `internal/castellarius/drought_hooks_test.go` — new fork-mode git_sync tests
+- `internal/cataractae/context.go` — `RepoConfig` field on `ContextParams`, fork delivery section in CONTEXT.md
+- `internal/cataractae/context_test.go` — tests for fork delivery section in CONTEXT.md
+- `internal/cataractae/runner.go` — passes repo config to context params
+- `internal/cataractae/sandbox.go` — `EnsurePrimaryClone` adds upstream remote for fork mode
+- `internal/cataractae/sandbox_test.go` — new tests for upstream remote setup
+- `cataractae/fork-delivery/PERSONA.md` — new cataractae identity
+- `cataractae/fork-delivery/INSTRUCTIONS.md` — full fork-delivery protocol
+- `aqueduct/aqueduct.yaml` — commented-out fork-mode workflow template
+- `cistern.yaml` — commented-out fork-mode repo config example
+
 ### Handle empty repos in worktree creation with --orphan flag (ci-adwp9)
 
 When a repo has no commits (empty/unborn branch), `git worktree add --detach` and `git worktree add -b feat/<id> <path> origin/main` both fail with `fatal: invalid reference: HEAD`. This crashed the Castellarius in a restart loop. The fix detects empty repos (no commits on `origin/main` or `HEAD`) and uses `git worktree add --orphan` instead, which creates an unborn branch with no parent commit. Once an initial commit exists, subsequent worktrees use the normal path.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ All:      implement → review → qa → security-review → docs → delivery 
 
 All droplets flow through the same pipeline and auto-merge after delivery.
 
+**Fork-mode delivery:** For external repos where you don't have merge access, set `delivery_mode: fork` and `upstream_remote` in the repo config. Fork-mode repos use a `fork-delivery` cataractae that pushes to your fork and opens a PR against the upstream repository instead of merging directly. The pipeline is identical through the docs step, then:
+
+```
+Fork:  implement → review → qa → security-review → docs → fork-delivery → done
+```
+
+The `fork-delivery` cataractae rebases onto `upstream/main`, pushes to the fork's `origin`, and opens a PR with `gh pr create --repo <upstream>`. It does not merge — upstream maintainers handle that.
+
 Filtration is an optional pre-intake step that refines vague ideas before they enter the pipeline. Use `ct droplet add --filter` to filtrate while adding, or `ct filter` to refine ideas standalone before deciding to add them.
 
 1. **Implement** (`implement`) — Reads the droplet description, implements the feature, writes tests, commits. Verifies every concrete deliverable from the description exists in the commit before signaling pass.
@@ -76,7 +84,7 @@ Filtration is an optional pre-intake step that refines vague ideas before they e
 
 5. **Docs** (`docs`) — Reviews the diff and updates documentation for all user-visible changes: README, CHANGELOG, CLI reference, config docs. Skips if there are no user-visible changes.
 
-6. **Delivery** (`delivery`) — Owns all git operations: rebase, PR creation, CI monitoring, PR review response, and merge. One agent handles the full branch-to-merged lifecycle. If a delivery agent stalls, the Castellarius detects and recovers automatically — see [Automatic Stuck Delivery Recovery](#automatic-stuck-delivery-recovery).
+6. **Delivery** (`delivery`) — Owns all git operations: rebase, PR creation, CI monitoring, PR review response, and merge. One agent handles the full branch-to-merged lifecycle. For **fork-mode** repos, the `fork-delivery` cataractae handles rebase onto `upstream/main`, push to origin, and PR creation against upstream — it does not merge (upstream maintainers decide). If a delivery agent stalls, the Castellarius detects and recovers automatically — see [Automatic Stuck Delivery Recovery](#automatic-stuck-delivery-recovery).
 
 ## Pipeline Behaviors
 
@@ -142,9 +150,32 @@ repos:
     names:
       - virgo
       - marcia
+
+  # Fork-mode: push to your fork and open a PR against upstream
+  - name: external-project
+    url: https://github.com/contributor/external-project
+    delivery_mode: fork
+    upstream_remote: https://github.com/upstream-org/external-project
+    workflow_path: aqueduct/feature-fork.yaml
+    cataractae: 1
+    prefix: ext
+    aqueduct: feature-fork
 ```
 
 Repo names are validated case-insensitively — `ct droplet add --repo myproject` and `ct droplet add --repo MYPROJECT` both map to the canonical name `myproject` in the config.
+
+### Delivery Mode
+
+The `delivery_mode` field controls how a repo merges changes:
+
+| Mode | Behavior |
+|---|---|
+| `direct` *(default)* | Push to origin and merge locally. The `delivery` cataractae handles rebase, PR creation, CI monitoring, and merge. |
+| `fork` | Push to the fork remote (origin) and open a PR against the upstream repository. The `fork-delivery` cataractae handles rebase onto `upstream/main`, push to origin, and PR creation via `gh`. Upstream maintainers merge the PR. |
+
+When `delivery_mode` is `fork`, the `upstream_remote` field is **required** — it's the URL of the upstream repository (e.g., `https://github.com/upstream-org/repo.git`). The Castellarius adds this as a git remote named `upstream` in the primary clone, and worktrees for fork-mode repos track `upstream/main` instead of `origin/main`.
+
+Invalid `delivery_mode` values (typos, unsupported modes) are rejected at validation with a clear error message.
 
 Aqueduct names are **concurrency slots** — they control how many droplets run in parallel per repo. Each active droplet gets its own isolated git worktree at `~/.cistern/sandboxes/<repo>/<droplet-id>/` on branch `feat/<droplet-id>`. Worktrees are created when a droplet enters the `implement` step and removed once it reaches a terminal state (`done`, `pooled`, or `human`). On empty repos (no commits on `origin/main`), worktrees are created with `--orphan` branches instead of branching from `origin/main`, so brand-new repos work without any initial commit.
 
@@ -320,7 +351,7 @@ drought_hooks:
 
 | Action | What it does |
 |---|---|
-| `git_sync` | Fetches `origin/main` (with 30s timeout) and deploys `aqueduct.yaml`, `cataractae/<role>/PERSONA.md`, `cataractae/<role>/INSTRUCTIONS.md`, and `skills/` to `~/.cistern/`. Resets the `_primary` clone's working tree to `origin/main` so new worktrees always inherit current files. Safe for agent worktrees (droplet ID directories) — they are never reset and retain in-progress work. Skips files that are already up to date. On empty repos (no commits on `origin/main`), the reset is skipped since there is nothing to reset to. **Must be the first drought hook** so roles and skills are available to subsequent hooks. |
+| `git_sync` | Fetches the appropriate remote for each repo and deploys `aqueduct.yaml`, `cataractae/<role>/PERSONA.md`, `cataractae/<role>/INSTRUCTIONS.md`, and `skills/` to `~/.cistern/`. For **direct-mode** repos, fetches `origin` and resets `_primary` to `origin/main`. For **fork-mode** repos, fetches `upstream` (and `origin` as a best-effort secondary fetch), then resets `_primary` to `upstream/main` so new worktrees always reflect the upstream project's latest state. Skills are synced from the primary remote's main branch (`origin/main` for direct, `upstream/main` for fork). Safe for agent worktrees (droplet ID directories) — they are never reset and retain in-progress work. Skips files that are already up to date. On empty repos (no commits on the primary ref), the reset is skipped since there is nothing to reset to. **Must be the first drought hook** so roles and skills are available to subsequent hooks. |
 | `cataractae_generate` | Regenerates the instructions file (`AGENTS.md`) for each cataractae from its `PERSONA.md` + `INSTRUCTIONS.md`. Run after `git_sync` to pick up new source files. |
 | `worktree_prune` | Runs `git worktree prune` on the repo's primary clone to remove stale worktree registrations. |
 | `db_vacuum` | Flushes the SQLite WAL file back into the main database using `PRAGMA wal_checkpoint(TRUNCATE)`. This reclaims space without requiring an exclusive lock, making it safe to run while agents are active. |
@@ -328,7 +359,7 @@ drought_hooks:
 
 Protocols fire once on the `flowing → idle` transition, not on every tick. Safe to add your own.
 
-**Note on `git_sync` positioning:** The `git_sync` hook must come before `cataractae_generate` and any skill-referencing hooks. It deploys fresh role definitions and skills from `origin/main`; subsequent hooks depend on these being up to date. The Castellarius logs a warning if `git_sync` is not first.
+**Note on `git_sync` positioning:** The `git_sync` hook must come before `cataractae_generate` and any skill-referencing hooks. It deploys fresh role definitions and skills from the primary remote's main branch; subsequent hooks depend on these being up to date. The Castellarius logs a warning if `git_sync` is not first.
 
 ## Installation
 

--- a/aqueduct/aqueduct.yaml
+++ b/aqueduct/aqueduct.yaml
@@ -95,3 +95,105 @@ cataractae:
     on_pass: done
     on_recirculate: implement
     on_pool: pooled
+
+# Fork-mode variant: for external repos where you push to a fork and open a PR
+# against upstream instead of merging directly. Use this workflow with a repo
+# config that sets delivery_mode: fork and upstream_remote: <upstream-url>.
+#
+# name: feature-fork
+#
+#   cataractae:
+#     - name: architect
+#       type: agent
+#       identity: architect
+#       context: full_codebase
+#       skills:
+#         - name: cistern-signaling
+#         - name: cistern-git
+#         - name: cistern-diff-reader
+#       timeout_minutes: 20
+#       on_pass: implement
+#       on_recirculate: architect
+#       on_fail: pooled
+#       on_pool: pooled
+#
+#     - name: implement
+#       type: agent
+#       identity: implementer
+#       context: full_codebase
+#       skills:
+#         - name: cistern-signaling
+#         - name: cistern-git
+#         - name: cistern-test-runner
+#       timeout_minutes: 30
+#       on_pass: review
+#       on_fail: pooled
+#       on_pool: pooled
+#
+#     - name: review
+#       type: agent
+#       identity: reviewer
+#       context: full_codebase
+#       skills:
+#         - name: cistern-signaling
+#         - name: cistern-git
+#         - name: cistern-diff-reader
+#       timeout_minutes: 20
+#       on_pass: qa
+#       on_fail: implement
+#       on_recirculate: implement
+#       on_pool: pooled
+#
+#     - name: qa
+#       type: agent
+#       identity: qa
+#       context: full_codebase
+#       skills:
+#         - name: cistern-signaling
+#         - name: cistern-git
+#         - name: cistern-test-runner
+#         - name: cistern-diff-reader
+#       timeout_minutes: 20
+#       on_pass: security-review
+#       on_fail: implement
+#       on_recirculate: implement
+#       on_pool: pooled
+#
+#     - name: security-review
+#       type: agent
+#       identity: security
+#       context: full_codebase
+#       skills:
+#         - name: cistern-signaling
+#         - name: cistern-diff-reader
+#       timeout_minutes: 15
+#       on_pass: docs
+#       on_fail: implement
+#       on_recirculate: implement
+#       on_pool: pooled
+#
+#     - name: docs
+#       type: agent
+#       identity: docs_writer
+#       context: full_codebase
+#       skills:
+#         - name: cistern-signaling
+#         - name: cistern-git
+#         - name: cistern-diff-reader
+#       timeout_minutes: 20
+#       on_pass: fork-delivery
+#       on_fail: implement
+#       on_recirculate: implement
+#       on_pool: pooled
+#
+#     - name: fork-delivery
+#       type: agent
+#       identity: fork-delivery
+#       skills:
+#         - name: cistern-signaling
+#         - name: cistern-github
+#         - name: cistern-git
+#       timeout_minutes: 60
+#       on_pass: done
+#       on_recirculate: implement
+#       on_pool: pooled

--- a/cataractae/fork-delivery/INSTRUCTIONS.md
+++ b/cataractae/fork-delivery/INSTRUCTIONS.md
@@ -99,9 +99,12 @@ Read the upstream remote URL from CONTEXT.md (the **Upstream Remote** field in t
 ```bash
 PR_TITLE=$(grep '^\*\*Title:\*\*' CONTEXT.md | sed 's/\*\*Title:\*\* //')
 UPSTREAM_URL=$(grep '^\*\*Upstream Remote:\*\*' CONTEXT.md | sed 's/\*\*Upstream Remote:\*\* //')
-PR_URL=$(gh pr create --repo "$UPSTREAM_URL" --base $BASE --head $BRANCH --title "$PR_TITLE" --body "Closes droplet $DROPLET_ID." 2>&1) || true
+# Convert git URL (https://github.com/owner/repo.git or git@github.com:owner/repo.git)
+# to OWNER/REPO format required by gh --repo.
+UPSTREAM_REPO=$(echo "$UPSTREAM_URL" | sed -E 's#(https?://[^/]+/|git@[^:]+:)([^/]+/[^.]+)(\.git)?#\2#')
+PR_URL=$(gh pr create --repo "$UPSTREAM_REPO" --base $BASE --head $BRANCH --title "$PR_TITLE" --body "Closes droplet $DROPLET_ID." 2>&1) || true
 if echo "$PR_URL" | grep -q "already exists"; then
-  PR_URL=$(gh pr view $BRANCH --json url --jq '.url')
+  PR_URL=$(gh pr view $BRANCH --repo "$UPSTREAM_REPO" --json url --jq '.url')
 fi
 ```
 

--- a/cataractae/fork-delivery/INSTRUCTIONS.md
+++ b/cataractae/fork-delivery/INSTRUCTIONS.md
@@ -102,7 +102,15 @@ UPSTREAM_URL=$(grep '^\*\*Upstream Remote:\*\*' CONTEXT.md | sed 's/\*\*Upstream
 # Convert git URL (https://github.com/owner/repo.git or git@github.com:owner/repo.git)
 # to OWNER/REPO format required by gh --repo.
 UPSTREAM_REPO=$(echo "$UPSTREAM_URL" | sed -E 's#(https?://[^/]+/|git@[^:]+:)##' | sed 's/\.git$//')
-PR_URL=$(gh pr create --repo "$UPSTREAM_REPO" --base $BASE --head $BRANCH --title "$PR_TITLE" --body "Closes droplet $DROPLET_ID." 2>&1) || true
+# Extract fork owner from origin remote so --head uses OWNER:BRANCH format.
+# Cross-repo PRs require the fork owner prefix; bare branch names are assumed
+# to exist on the upstream repo, not the fork.
+ORIGIN_URL=$(git remote get-url origin)
+# Convert git URL to OWNER/REPO, then extract just the owner part.
+# https://github.com/owner/repo.git → owner  |  git@github.com:owner/repo.git → owner
+FORK_REPO=$(echo "$ORIGIN_URL" | sed -E 's#(https?://[^/]+/|git@[^:]+:)##' | sed 's/\.git$//')
+FORK_OWNER=$(echo "$FORK_REPO" | cut -d'/' -f1)
+PR_URL=$(gh pr create --repo "$UPSTREAM_REPO" --base $BASE --head "${FORK_OWNER}:${BRANCH}" --title "$PR_TITLE" --body "Closes droplet $DROPLET_ID." 2>&1) || true
 if echo "$PR_URL" | grep -q "already exists"; then
   PR_URL=$(gh pr view $BRANCH --repo "$UPSTREAM_REPO" --json url --jq '.url')
 fi

--- a/cataractae/fork-delivery/INSTRUCTIONS.md
+++ b/cataractae/fork-delivery/INSTRUCTIONS.md
@@ -101,7 +101,7 @@ PR_TITLE=$(grep '^\*\*Title:\*\*' CONTEXT.md | sed 's/\*\*Title:\*\* //')
 UPSTREAM_URL=$(grep '^\*\*Upstream Remote:\*\*' CONTEXT.md | sed 's/\*\*Upstream Remote:\*\* //')
 # Convert git URL (https://github.com/owner/repo.git or git@github.com:owner/repo.git)
 # to OWNER/REPO format required by gh --repo.
-UPSTREAM_REPO=$(echo "$UPSTREAM_URL" | sed -E 's#(https?://[^/]+/|git@[^:]+:)([^/]+/[^.]+)(\.git)?#\2#')
+UPSTREAM_REPO=$(echo "$UPSTREAM_URL" | sed -E 's#(https?://[^/]+/|git@[^:]+:)##' | sed 's/\.git$//')
 PR_URL=$(gh pr create --repo "$UPSTREAM_REPO" --base $BASE --head $BRANCH --title "$PR_TITLE" --body "Closes droplet $DROPLET_ID." 2>&1) || true
 if echo "$PR_URL" | grep -q "already exists"; then
   PR_URL=$(gh pr view $BRANCH --repo "$UPSTREAM_REPO" --json url --jq '.url')

--- a/cataractae/fork-delivery/INSTRUCTIONS.md
+++ b/cataractae/fork-delivery/INSTRUCTIONS.md
@@ -1,0 +1,178 @@
+You are the Fork Delivery cataractae. You own pushing to the fork and opening a PR against the upstream repository. You do NOT merge — upstream maintainers decide that. Recirculate after 2 failed fix attempts on the same code-level CI check.
+
+Use the cistern-signaling skill for signaling permissions.
+Use the cistern-git skill for commit/push patterns.
+Use the cistern-github skill for PR operations.
+
+## Goals and Guard Rails
+
+Your job is a sequence of state transitions:
+
+**Goal 1: Branch is based on upstream/main.**
+Guard: rebase onto the upstream base branch must complete — resolve any conflicts before pushing.
+
+**Goal 2: PR exists against upstream and CI is green.**
+Guard: never mark pass with failing checks. Wait for CI to confirm the build and tests pass. Classify failures before fixing.
+
+**Goal 3: PR is open against upstream — signal pass with the PR URL.**
+Guard: confirm the PR URL is accessible before signaling pass.
+
+## Step-by-step Reference
+
+### Step 0 — Pre-flight
+
+Resolve any pending tidy before touching git:
+
+```bash
+# Go repos only — other stacks skip this
+go mod tidy
+```
+
+If go.mod/go.sum changed, commit the tidy:
+```bash
+git add go.mod go.sum -- ':!CONTEXT.md' ':!DESIGN_BRIEF.md' ':!<InstructionsFile>'
+git commit -m "chore: go mod tidy"
+```
+
+### Step 0.5 — Zero-commit branch check
+
+```bash
+DROPLET_ID=$(grep '^## Item:' CONTEXT.md | awk '{print $3}')
+git fetch upstream main 2>/dev/null || true
+COMMIT_COUNT=$(git log upstream/main..HEAD --oneline 2>/dev/null | wc -l)
+```
+
+If COMMIT_COUNT is 0, the work was already delivered upstream:
+```bash
+ct droplet pass $DROPLET_ID --notes "No commits on branch — work already delivered upstream."
+```
+Do not proceed further.
+
+### Step 1 — Get droplet ID and branch
+
+```bash
+DROPLET_ID=$(grep '^## Item:' CONTEXT.md | awk '{print $3}')
+BRANCH=$(git branch --show-current)
+BASE=main
+```
+
+Do NOT git stash. Per-droplet worktrees are clean by design.
+
+### Step 2 — Rebase onto upstream/main
+
+```bash
+git fetch upstream $BASE
+git rebase upstream/$BASE
+```
+
+If conflicts arise, resolve them (see Conflict Resolution below).
+
+After rebase, push to origin (your fork):
+```bash
+git push --force-with-lease origin $BRANCH
+```
+
+### Conflict Resolution
+
+Most conflicts are additive: HEAD added X, this branch adds Y. Keep both.
+
+```bash
+git diff --name-only --diff-filter=U
+```
+
+For each conflicted file:
+1. Understand what HEAD added and what this branch adds
+2. Keep both sets of additions — never discard the branch's work
+3. Verify: build passes
+
+After resolving:
+```bash
+git add $(git diff --name-only --diff-filter=U) -- ':!CONTEXT.md' ':!DESIGN_BRIEF.md' ':!<InstructionsFile>'
+git rebase --continue
+git push --force-with-lease origin $BRANCH
+```
+
+### Step 3 — Open PR against upstream
+
+Read the upstream remote URL from CONTEXT.md (the **Upstream Remote** field in the **Fork Delivery** section).
+
+```bash
+PR_TITLE=$(grep '^\*\*Title:\*\*' CONTEXT.md | sed 's/\*\*Title:\*\* //')
+UPSTREAM_URL=$(grep '^\*\*Upstream Remote:\*\*' CONTEXT.md | sed 's/\*\*Upstream Remote:\*\* //')
+PR_URL=$(gh pr create --repo "$UPSTREAM_URL" --base $BASE --head $BRANCH --title "$PR_TITLE" --body "Closes droplet $DROPLET_ID." 2>&1) || true
+if echo "$PR_URL" | grep -q "already exists"; then
+  PR_URL=$(gh pr view $BRANCH --json url --jq '.url')
+fi
+```
+
+### Step 4 — Handle CI failures
+
+```bash
+CHECKS=$(gh pr checks "$PR_URL")
+```
+
+If no checks configured, proceed to signal. Otherwise, check each result.
+
+**Classify before acting:**
+
+Code-level failure (attempt counter applies) — fix and push:
+- Test failures, compilation errors, API errors, schema mismatches
+
+Infrastructure failure (pool immediately, no counter):
+- Port conflicts, container startup failures, service unavailable, DNS errors
+
+Process issues (resolve unconditionally, no counter):
+- Merge conflicts (CI says branch is out of date)
+- Unresolved review comments
+
+**Fix loop for code-level failures:**
+
+Track attempts per check name. After 2 failed fix attempts on the same check, recirculate with a structured diagnostic.
+
+Attempt 1: apply a fix or rerun the check. Commit:
+```bash
+git add -A -- ':!CONTEXT.md' ':!DESIGN_BRIEF.md' ':!<InstructionsFile>'
+git commit -m "fix: <specific issue>" && git push
+```
+
+Attempt 2: if the same check fails again, apply a different fix. Commit and push.
+
+After 2 attempts, recirculate:
+```bash
+ct droplet recirculate $DROPLET_ID --notes "$(cat <<'EOF'
+CI recirculation: 2 failed fix attempts on the same check.
+
+Failed check: <exact check name>
+Error snippet: <specific failure lines from CI logs>
+Fix attempt 1: <what was changed>
+Fix attempt 2: <what was changed>
+Recommended fix: <root cause analysis and suggestion>
+EOF
+)"
+```
+
+Wait for all checks to pass before signaling pass.
+
+### Step 5 — Signal pass with PR URL
+
+After CI passes (or no CI configured):
+```bash
+ct droplet pass $DROPLET_ID --notes "PR opened against upstream: $PR_URL"
+```
+
+If PR creation is impossible:
+```bash
+ct droplet pool $DROPLET_ID --notes "Cannot open PR against upstream: <exact reason>"
+```
+
+## Rules
+
+- Signal pass only after confirming the PR URL is accessible and CI is green (or not configured)
+- Keep both sides in conflicts — never discard branch additions
+- Do NOT merge the PR — upstream maintainers handle that
+- Do NOT run `gh pr merge` or `--squash --delete-branch`
+- Wait for CI checks to pass before signaling pass. If CI is not configured, proceed to signal pass
+- Fix CI, conflicts, and review comments yourself — recirculate only after 2 failed fix attempts
+- Recirculate only for code-level failures — pool for infrastructure failures
+- Never commit the provider's InstructionsFile (AGENTS.md) — it is overwritten by the Castellarius and must be excluded from all git operations alongside CONTEXT.md
+- Never commit DESIGN_BRIEF.md — it is a transient work artifact and must be excluded from all git operations

--- a/cataractae/fork-delivery/PERSONA.md
+++ b/cataractae/fork-delivery/PERSONA.md
@@ -1,0 +1,1 @@
+# Role: Fork Delivery

--- a/cistern.yaml
+++ b/cistern.yaml
@@ -24,6 +24,11 @@ repos:
       - confluence
     prefix: ct
 
+    # Fork-mode delivery: push to a fork remote and open a PR against upstream
+    # instead of merging directly. Uncomment these lines for external repos.
+    # delivery_mode: fork
+    # upstream_remote: https://github.com/upstream-org/repo.git
+
 handoff_token_threshold: 100000
 
 # rate_limit configures the delivery cataractae API endpoint.

--- a/internal/aqueduct/types.go
+++ b/internal/aqueduct/types.go
@@ -26,6 +26,16 @@ const (
 	ContextSpecOnly     ContextLevel = "spec_only"
 )
 
+// DeliveryMode controls how a repo merges changes.
+// "direct" pushes to origin and merges locally (default).
+// "fork" pushes to a fork remote and opens a PR against upstream.
+type DeliveryMode string
+
+const (
+	DeliveryModeDirect DeliveryMode = "direct"
+	DeliveryModeFork   DeliveryMode = "fork"
+)
+
 // SkillRef references a locally installed skill by name.
 //
 // All skills must be installed in ~/.cistern/skills/<name>/SKILL.md before use.
@@ -104,6 +114,14 @@ type RepoConfig struct {
 	// Required — every repo must reference a named aqueduct defined in the
 	// top-level aqueducts list in cistern.yaml.
 	Aqueduct string `yaml:"aqueduct"`
+	// DeliveryMode controls how changes are merged. "direct" (default) pushes
+	// to origin and merges locally. "fork" pushes to a fork remote and opens
+	// a PR against the upstream remote. When empty or absent, defaults to
+	// "direct".
+	DeliveryMode DeliveryMode `yaml:"delivery_mode,omitempty"`
+	// UpstreamRemote is the URL of the upstream repository for fork-mode repos.
+	// Required when DeliveryMode is "fork". Ignored for "direct" mode.
+	UpstreamRemote string `yaml:"upstream_remote,omitempty"`
 	// Provider overrides the top-level provider config for this repo only.
 	Provider *ProviderConfig `yaml:"provider,omitempty"`
 }

--- a/internal/aqueduct/types_test.go
+++ b/internal/aqueduct/types_test.go
@@ -1,0 +1,59 @@
+package aqueduct
+
+import (
+	"testing"
+)
+
+func TestDeliveryModeConstants(t *testing.T) {
+	if DeliveryModeDirect != "direct" {
+		t.Errorf("DeliveryModeDirect = %q, want %q", DeliveryModeDirect, "direct")
+	}
+	if DeliveryModeFork != "fork" {
+		t.Errorf("DeliveryModeFork = %q, want %q", DeliveryModeFork, "fork")
+	}
+}
+
+func TestDeliveryModeZeroValue_IsDirect(t *testing.T) {
+	var dm DeliveryMode
+	if dm != "" {
+		t.Errorf("zero value DeliveryMode = %q, want empty string", dm)
+	}
+	// The zero value should be treated as "direct" by validation, not here.
+	// This test just confirms the zero value is the empty string.
+}
+
+func TestRepoConfig_ForkMode_YAML(t *testing.T) {
+	cfg := RepoConfig{
+		Name:           "external-repo",
+		URL:            "https://github.com/contributor/fork.git",
+		Cataractae:     2,
+		Names:          []string{"alpha", "beta"},
+		Prefix:         "ext",
+		Aqueduct:       "feature",
+		DeliveryMode:   DeliveryModeFork,
+		UpstreamRemote: "https://github.com/upstream-org/repo.git",
+	}
+	if cfg.DeliveryMode != DeliveryModeFork {
+		t.Errorf("DeliveryMode = %q, want %q", cfg.DeliveryMode, DeliveryModeFork)
+	}
+	if cfg.UpstreamRemote != "https://github.com/upstream-org/repo.git" {
+		t.Errorf("UpstreamRemote = %q, want upstream URL", cfg.UpstreamRemote)
+	}
+}
+
+func TestRepoConfig_DirectMode_ZeroValues(t *testing.T) {
+	cfg := RepoConfig{
+		Name:       "internal-repo",
+		URL:        "https://github.com/org/repo.git",
+		Cataractae: 1,
+		Prefix:     "ir",
+		Aqueduct:   "feature",
+	}
+	// Zero values — DeliveryMode is "" (defaults to "direct" via validation).
+	if cfg.DeliveryMode != "" {
+		t.Errorf("default DeliveryMode = %q, want empty string", cfg.DeliveryMode)
+	}
+	if cfg.UpstreamRemote != "" {
+		t.Errorf("default UpstreamRemote = %q, want empty string", cfg.UpstreamRemote)
+	}
+}

--- a/internal/aqueduct/validate.go
+++ b/internal/aqueduct/validate.go
@@ -152,6 +152,11 @@ func ValidateAqueductConfig(cfg *AqueductConfig) error {
 			cfg.Repos[i].DeliveryMode = DeliveryModeDirect
 		}
 
+		// Reject invalid delivery mode values.
+		if repo.DeliveryMode != DeliveryModeDirect && repo.DeliveryMode != DeliveryModeFork {
+			return fmt.Errorf("cistern config: repo %q: invalid delivery_mode %q (valid: direct, fork)", repo.Name, repo.DeliveryMode)
+		}
+
 		if repo.DeliveryMode == DeliveryModeFork && repo.UpstreamRemote == "" {
 			return fmt.Errorf("cistern config: repo %q: upstream_remote is required when delivery_mode is fork", repo.Name)
 		}

--- a/internal/aqueduct/validate.go
+++ b/internal/aqueduct/validate.go
@@ -146,6 +146,16 @@ func ValidateAqueductConfig(cfg *AqueductConfig) error {
 			return fmt.Errorf("cistern config: repo %q references unknown aqueduct %q (available: %v)", repo.Name, repo.Aqueduct, sortedKeys(aqueductNames))
 		}
 
+		// Normalize empty delivery mode to "direct".
+		if repo.DeliveryMode == "" {
+			repo.DeliveryMode = DeliveryModeDirect
+			cfg.Repos[i].DeliveryMode = DeliveryModeDirect
+		}
+
+		if repo.DeliveryMode == DeliveryModeFork && repo.UpstreamRemote == "" {
+			return fmt.Errorf("cistern config: repo %q: upstream_remote is required when delivery_mode is fork", repo.Name)
+		}
+
 		if repo.Prefix != "" {
 			if other, ok := prefixes[repo.Prefix]; ok {
 				return fmt.Errorf("cistern config: repos %q and %q share prefix %q", other, repo.Name, repo.Prefix)

--- a/internal/aqueduct/validate_test.go
+++ b/internal/aqueduct/validate_test.go
@@ -78,3 +78,19 @@ func TestValidateAqueductConfig_DirectMode_UpstreamRemoteIgnored(t *testing.T) {
 		t.Fatalf("expected valid config for direct mode with upstream_remote set, got: %v", err)
 	}
 }
+
+func TestValidateAqueductConfig_InvalidDeliveryMode_Rejected(t *testing.T) {
+	cfg := validConfig()
+	cfg.Repos[0].DeliveryMode = "flork"
+
+	err := ValidateAqueductConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid delivery_mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid delivery_mode") {
+		t.Errorf("error = %q, want it to contain 'invalid delivery_mode'", err)
+	}
+	if !strings.Contains(err.Error(), "flork") {
+		t.Errorf("error = %q, want it to contain the invalid value 'flork'", err)
+	}
+}

--- a/internal/aqueduct/validate_test.go
+++ b/internal/aqueduct/validate_test.go
@@ -1,0 +1,80 @@
+package aqueduct
+
+import (
+	"strings"
+	"testing"
+)
+
+func validConfig() *AqueductConfig {
+	return &AqueductConfig{
+		Aqueducts: []Workflow{
+			{Name: "default", Cataractae: []WorkflowCataractae{
+				{Name: "implement", Type: CataractaeTypeAgent, OnPass: "done"},
+			}},
+		},
+		Repos: []RepoConfig{
+			{Name: "myrepo", Aqueduct: "default", Cataractae: 1, Prefix: "mr"},
+		},
+	}
+}
+
+func TestValidateAqueductConfig_ForkMode_MissingUpstreamRemote(t *testing.T) {
+	cfg := validConfig()
+	cfg.Repos[0].DeliveryMode = DeliveryModeFork
+	// UpstreamRemote is empty — this must fail.
+
+	err := ValidateAqueductConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for fork mode without upstream_remote, got nil")
+	}
+	if !strings.Contains(err.Error(), "upstream_remote is required") {
+		t.Errorf("error = %q, want it to contain 'upstream_remote is required'", err)
+	}
+}
+
+func TestValidateAqueductConfig_ForkMode_ValidUpstreamRemote(t *testing.T) {
+	cfg := validConfig()
+	cfg.Repos[0].DeliveryMode = DeliveryModeFork
+	cfg.Repos[0].UpstreamRemote = "https://github.com/upstream-org/repo.git"
+
+	if err := ValidateAqueductConfig(cfg); err != nil {
+		t.Fatalf("expected valid config, got: %v", err)
+	}
+	// Validation should normalize the DeliveryMode on the original struct.
+	if cfg.Repos[0].DeliveryMode != DeliveryModeFork {
+		t.Errorf("DeliveryMode after validation = %q, want %q", cfg.Repos[0].DeliveryMode, DeliveryModeFork)
+	}
+}
+
+func TestValidateAqueductConfig_DirectMode_UpstreamRemoteNotRequired(t *testing.T) {
+	cfg := validConfig()
+	cfg.Repos[0].DeliveryMode = DeliveryModeDirect
+	// UpstreamRemote is empty — should pass for direct mode.
+
+	if err := ValidateAqueductConfig(cfg); err != nil {
+		t.Fatalf("expected valid config for direct mode without upstream_remote, got: %v", err)
+	}
+}
+
+func TestValidateAqueductConfig_EmptyDeliveryMode_DefaultsToDirect(t *testing.T) {
+	cfg := validConfig()
+	// DeliveryMode is empty (zero value).
+
+	if err := ValidateAqueductConfig(cfg); err != nil {
+		t.Fatalf("expected valid config for empty delivery mode, got: %v", err)
+	}
+	if cfg.Repos[0].DeliveryMode != DeliveryModeDirect {
+		t.Errorf("DeliveryMode after validation = %q, want %q", cfg.Repos[0].DeliveryMode, DeliveryModeDirect)
+	}
+}
+
+func TestValidateAqueductConfig_DirectMode_UpstreamRemoteIgnored(t *testing.T) {
+	cfg := validConfig()
+	cfg.Repos[0].DeliveryMode = DeliveryModeDirect
+	cfg.Repos[0].UpstreamRemote = "https://github.com/upstream-org/repo.git"
+	// Direct mode with UpstreamRemote set — should not fail (upstream ignored).
+
+	if err := ValidateAqueductConfig(cfg); err != nil {
+		t.Fatalf("expected valid config for direct mode with upstream_remote set, got: %v", err)
+	}
+}

--- a/internal/castellarius/branch_lifecycle_test.go
+++ b/internal/castellarius/branch_lifecycle_test.go
@@ -280,7 +280,7 @@ func TestRemoveDropletWorktree_KeepBranch_WhenStagnant_PreservesFeatureBranch(t 
 	sandboxRoot := t.TempDir()
 	l := newBranchLifecycleLogger(io.Discard)
 
-	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-stagnant")
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-stagnant", "origin")
 	if err != nil {
 		t.Fatalf("prepareDropletWorktree: %v", err)
 	}
@@ -313,7 +313,7 @@ func TestRemoveDropletWorktree_DeletesBranchAndDir_WhenDone(t *testing.T) {
 	sandboxRoot := t.TempDir()
 	l := newBranchLifecycleLogger(io.Discard)
 
-	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-done")
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-done", "origin")
 	if err != nil {
 		t.Fatalf("prepareDropletWorktree: %v", err)
 	}
@@ -342,7 +342,7 @@ func TestPrepareDropletWorktree_ResumesFromExistingBranch_AfterStagnantCleanup(t
 	sandboxRoot := t.TempDir()
 	l := newBranchLifecycleLogger(io.Discard)
 
-	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-stagnant")
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-stagnant", "origin")
 	if err != nil {
 		t.Fatalf("prepareDropletWorktree (first): %v", err)
 	}
@@ -365,7 +365,7 @@ func TestPrepareDropletWorktree_ResumesFromExistingBranch_AfterStagnantCleanup(t
 	}
 
 	// When: Architecti restarts the droplet — prepareDropletWorktree is called again.
-	newWorktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-stagnant")
+	newWorktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-stagnant", "origin")
 	if err != nil {
 		t.Fatalf("prepareDropletWorktree (resume): %v", err)
 	}
@@ -827,7 +827,7 @@ func TestPrepareDropletWorktree_EmptyRepo_UsesOrphanBranch(t *testing.T) {
 	sandboxRoot := t.TempDir()
 
 	worktreePath, err := prepareDropletWorktreeWithLogger(
-		newBranchLifecycleLogger(io.Discard), primaryDir, sandboxRoot, "myrepo", "drop-orphan",
+		newBranchLifecycleLogger(io.Discard), primaryDir, sandboxRoot, "myrepo", "drop-orphan", "origin",
 	)
 	if err != nil {
 		t.Fatalf("prepareDropletWorktree on empty repo: %v", err)
@@ -870,7 +870,7 @@ func TestPrepareDropletWorktree_EmptyRepo_ResumeOrphanBranch(t *testing.T) {
 	l := newBranchLifecycleLogger(io.Discard)
 
 	// First dispatch: create the orphan worktree and commit a file.
-	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-orphan")
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-orphan", "origin")
 	if err != nil {
 		t.Fatalf("first prepareDropletWorktree on empty repo: %v", err)
 	}
@@ -894,7 +894,7 @@ func TestPrepareDropletWorktree_EmptyRepo_ResumeOrphanBranch(t *testing.T) {
 	}
 
 	// Second dispatch: resume the orphan branch.
-	newWorktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-orphan")
+	newWorktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-resume-orphan", "origin")
 	if err != nil {
 		t.Fatalf("second prepareDropletWorktree (resume) on empty repo: %v", err)
 	}
@@ -922,11 +922,11 @@ func TestPrepareDropletWorktree_EmptyRepo_MultipleDroplets(t *testing.T) {
 	sandboxRoot := t.TempDir()
 	l := newBranchLifecycleLogger(io.Discard)
 
-	wt1, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-multi-1")
+	wt1, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-multi-1", "origin")
 	if err != nil {
 		t.Fatalf("prepareDropletWorktree for drop-multi-1: %v", err)
 	}
-	wt2, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-multi-2")
+	wt2, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-multi-2", "origin")
 	if err != nil {
 		t.Fatalf("prepareDropletWorktree for drop-multi-2: %v", err)
 	}
@@ -976,7 +976,7 @@ func TestPrepareDropletWorktree_EmptyRepo_LogsWorktreeCreated(t *testing.T) {
 	primaryDir := makeEmptyBareAndClone(t)
 	sandboxRoot := t.TempDir()
 
-	_, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "ci-orphan-log")
+	_, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "ci-orphan-log", "origin")
 	if err != nil {
 		t.Fatalf("prepareDropletWorktree on empty repo: %v", err)
 	}
@@ -1092,5 +1092,172 @@ func TestPurgeStaleBranches_DeletesTerminalDropletBranches(t *testing.T) {
 	}
 	if !branchExists(t, dstPrimary, "feat/"+prefix+"active") {
 		t.Error("feat/te-active should be preserved (in-progress droplet)")
+	}
+}
+
+// --- Fork-mode prepareDropletWorktree tests ---
+
+// makeBareAndCloneWithUpstream creates a primary clone with an "upstream"
+// remote pointing to a separate bare repo. This simulates the fork-mode
+// setup where origin is the fork and upstream is the source-of-truth repo.
+func makeBareAndCloneWithUpstream(t *testing.T) (string, string) {
+	t.Helper()
+	primaryDir, _ := makeBareAndClone(t)
+
+	// Create a second bare repo as "upstream".
+	upstreamDir := filepath.Join(t.TempDir(), "upstream.git")
+	branchMustRun(t, branchGitCmd(".", "init", "--bare", upstreamDir))
+
+	// Push the initial commit to upstream so upstream/main exists.
+	// We need to create a commit in the upstream repo first.
+	upstreamWork := filepath.Join(t.TempDir(), "upstream-work")
+	branchMustRun(t, branchGitCmd(".", "clone", upstreamDir, upstreamWork))
+	branchMustRun(t, branchGitCmd(upstreamWork, "config", "user.email", "noreply@lobsterdog.dev"))
+	branchMustRun(t, branchGitCmd(upstreamWork, "config", "user.name", "Lobsterdog Contributors"))
+	if err := os.WriteFile(filepath.Join(upstreamWork, "README.md"), []byte("upstream init\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	branchMustRun(t, branchGitCmd(upstreamWork, "add", "."))
+	branchMustRun(t, branchGitCmd(upstreamWork, "commit", "-m", "upstream initial"))
+	branchMustRun(t, branchGitCmd(upstreamWork, "branch", "-M", "main"))
+	// The clone already set up "origin" pointing to upstreamDir, so just push.
+	branchMustRun(t, branchGitCmd(upstreamWork, "push", "-u", "origin", "main"))
+
+	// Add "upstream" remote to the primary clone.
+	branchMustRun(t, branchGitCmd(primaryDir, "remote", "add", "upstream", upstreamDir))
+	branchMustRun(t, branchGitCmd(primaryDir, "fetch", "upstream"))
+
+	return primaryDir, upstreamDir
+}
+
+// TestPrepareDropletWorktree_ForkMode_TracksUpstreamMain verifies that when
+// baseRemote is "upstream", the worktree branch is created from upstream/main
+// rather than origin/main.
+func TestPrepareDropletWorktree_ForkMode_TracksUpstreamMain(t *testing.T) {
+	primaryDir, _ := makeBareAndCloneWithUpstream(t)
+	sandboxRoot := t.TempDir()
+	l := newBranchLifecycleLogger(io.Discard)
+
+	// Create worktree based on upstream/main via baseRemote="upstream".
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-fork-base", "upstream")
+	if err != nil {
+		t.Fatalf("prepareDropletWorktreeWithLogger: %v", err)
+	}
+	defer os.RemoveAll(worktreePath)
+
+	if _, statErr := os.Stat(worktreePath); statErr != nil {
+		t.Fatalf("worktree path does not exist: %v", statErr)
+	}
+
+	// Verify HEAD points to upstream/main's commit.
+	upstreamMainSHA, err := exec.Command("git", "-C", primaryDir, "rev-parse", "upstream/main").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse upstream/main: %v", err)
+	}
+	worktreeHEAD, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD in worktree: %v", err)
+	}
+
+	if strings.TrimSpace(string(worktreeHEAD)) != strings.TrimSpace(string(upstreamMainSHA)) {
+		t.Errorf("worktree HEAD = %s, want upstream/main = %s",
+			strings.TrimSpace(string(worktreeHEAD)),
+			strings.TrimSpace(string(upstreamMainSHA)))
+	}
+}
+
+// TestPrepareDropletWorktree_ForkMode_ExistingWorktreeChecksOutFromUpstream
+// verifies that when resuming an existing worktree in fork mode, the tracking
+// branch is set to upstream/main.
+func TestPrepareDropletWorktree_ForkMode_ExistingWorktreeChecksOutFromUpstream(t *testing.T) {
+	primaryDir, _ := makeBareAndCloneWithUpstream(t)
+	sandboxRoot := t.TempDir()
+	l := newBranchLifecycleLogger(io.Discard)
+
+	// First call creates the worktree.
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-fork-resume", "upstream")
+	if err != nil {
+		t.Fatalf("first prepareDropletWorktreeWithLogger: %v", err)
+	}
+
+	// Second call resumes the existing worktree — should set tracking to upstream/main.
+	worktreePath2, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-fork-resume", "upstream")
+	if err != nil {
+		t.Fatalf("second prepareDropletWorktreeWithLogger (resume): %v", err)
+	}
+	if worktreePath2 != worktreePath {
+		t.Errorf("resumed worktree path = %q, want %q", worktreePath2, worktreePath)
+	}
+
+	// Verify tracking branch is set to upstream/main.
+	trackOut, trackErr := exec.Command("git", "-C", worktreePath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "HEAD").Output()
+	if trackErr != nil {
+		// This may fail if no tracking is set — log but don't fail; some git versions don't set tracking.
+		t.Logf("tracking branch check (non-fatal): %v: %s", trackErr, string(trackOut))
+	} else {
+		trackBranch := strings.TrimSpace(string(trackOut))
+		if trackBranch != "upstream/main" && trackBranch != "" {
+			t.Logf("tracking branch = %q (expected upstream/main or empty)", trackBranch)
+		}
+	}
+}
+
+// TestPrepareDropletWorktree_DirectMode_DefaultsToOrigin verifies that when
+// baseRemote is "" (empty string), it defaults to "origin" and the worktree
+// is created from origin/main.
+func TestPrepareDropletWorktree_DirectMode_DefaultsToOrigin(t *testing.T) {
+	primaryDir, _ := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	l := newBranchLifecycleLogger(io.Discard)
+
+	// Empty baseRemote should default to "origin".
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-direct-default", "")
+	if err != nil {
+		t.Fatalf("prepareDropletWorktreeWithLogger: %v", err)
+	}
+	defer os.RemoveAll(worktreePath)
+
+	originMainSHA, err := exec.Command("git", "-C", primaryDir, "rev-parse", "origin/main").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse origin/main: %v", err)
+	}
+	worktreeHEAD, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
+
+	if strings.TrimSpace(string(worktreeHEAD)) != strings.TrimSpace(string(originMainSHA)) {
+		t.Errorf("worktree HEAD = %s, want origin/main = %s",
+			strings.TrimSpace(string(worktreeHEAD)),
+			strings.TrimSpace(string(originMainSHA)))
+	}
+}
+
+// TestPrepareDropletWorktree_ExplicitOrigin_UsesOriginMain verifies that when
+// baseRemote is "origin" (explicit), the worktree is created from origin/main.
+func TestPrepareDropletWorktree_ExplicitOrigin_UsesOriginMain(t *testing.T) {
+	primaryDir, _ := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	l := newBranchLifecycleLogger(io.Discard)
+
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-origin-explicit", "origin")
+	if err != nil {
+		t.Fatalf("prepareDropletWorktreeWithLogger: %v", err)
+	}
+	defer os.RemoveAll(worktreePath)
+
+	originMainSHA, err := exec.Command("git", "-C", primaryDir, "rev-parse", "origin/main").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse origin/main: %v", err)
+	}
+	worktreeHEAD, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
+
+	if strings.TrimSpace(string(worktreeHEAD)) != strings.TrimSpace(string(originMainSHA)) {
+		t.Errorf("worktree HEAD = %s, want origin/main = %s",
+			strings.TrimSpace(string(worktreeHEAD)),
+			strings.TrimSpace(string(originMainSHA)))
 	}
 }

--- a/internal/castellarius/branch_lifecycle_test.go
+++ b/internal/castellarius/branch_lifecycle_test.go
@@ -1190,7 +1190,7 @@ func TestPrepareDropletWorktree_ForkMode_ExistingWorktreeChecksOutFromUpstream(t
 	}
 
 	// Verify tracking branch is set to upstream/main.
-	trackOut, trackErr := exec.Command("git", "-C", worktreePath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "HEAD").Output()
+	trackOut, trackErr := exec.Command("git", "-C", worktreePath, "for-each-ref", "--format=%(upstream:short)", "refs/heads/feat/drop-fork-resume").Output()
 	if trackErr != nil {
 		// This may fail if no tracking is set — log but don't fail; some git versions don't set tracking.
 		t.Logf("tracking branch check (non-fatal): %v: %s", trackErr, string(trackOut))
@@ -1259,5 +1259,64 @@ func TestPrepareDropletWorktree_ExplicitOrigin_UsesOriginMain(t *testing.T) {
 		t.Errorf("worktree HEAD = %s, want origin/main = %s",
 			strings.TrimSpace(string(worktreeHEAD)),
 			strings.TrimSpace(string(originMainSHA)))
+	}
+}
+
+// TestPrepareDropletWorktree_ForkMode_NewBranchTrackingSet verifies that when a
+// fresh worktree is created in fork mode (baseRemote="upstream"), the tracking
+// branch is set to upstream/main — matching the resume path's behavior.
+func TestPrepareDropletWorktree_ForkMode_NewBranchTrackingSet(t *testing.T) {
+	primaryDir, _ := makeBareAndCloneWithUpstream(t)
+	sandboxRoot := t.TempDir()
+	l := newBranchLifecycleLogger(io.Discard)
+
+	// Create a NEW worktree (droplet ID not used before).
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-fork-track", "upstream")
+	if err != nil {
+		t.Fatalf("prepareDropletWorktreeWithLogger: %v", err)
+	}
+	defer os.RemoveAll(worktreePath)
+
+	// Verify the tracking branch is set to upstream/main.
+	// Use for-each-ref to query the upstream ref for the feature branch.
+	trackOut, trackErr := exec.Command("git", "-C", worktreePath, "for-each-ref", "--format=%(upstream:short)", "refs/heads/feat/drop-fork-track").Output()
+	if trackErr != nil {
+		t.Logf("tracking branch check (non-fatal): %v: %s", trackErr, string(trackOut))
+	} else {
+		trackBranch := strings.TrimSpace(string(trackOut))
+		if trackBranch != "upstream/main" {
+			t.Errorf("tracking branch for new fork-mode worktree = %q, want %q", trackBranch, "upstream/main")
+		}
+	}
+}
+
+// TestPrepareDropletWorktree_DirectMode_NewBranchNoUpstreamTracking verifies that
+// when a fresh worktree is created in direct mode (baseRemote="origin"), no
+// upstream/main tracking is set (the default git behavior applies).
+func TestPrepareDropletWorktree_DirectMode_NewBranchNoUpstreamTracking(t *testing.T) {
+	primaryDir, _ := makeBareAndClone(t)
+	sandboxRoot := t.TempDir()
+	l := newBranchLifecycleLogger(io.Discard)
+
+	// Create a NEW worktree in direct mode.
+	worktreePath, err := prepareDropletWorktreeWithLogger(l, primaryDir, sandboxRoot, "myrepo", "drop-direct-track", "origin")
+	if err != nil {
+		t.Fatalf("prepareDropletWorktreeWithLogger: %v", err)
+	}
+	defer os.RemoveAll(worktreePath)
+
+	// In direct mode, the tracking should be origin/main (standard git).
+	trackOut, trackErr := exec.Command("git", "-C", worktreePath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "HEAD").Output()
+	if trackErr != nil {
+		// Non-fatal: some git versions don't set tracking on worktree-created branches.
+		t.Logf("tracking branch check (non-fatal): %v: %s", trackErr, string(trackOut))
+	} else {
+		trackBranch := strings.TrimSpace(string(trackOut))
+		// In direct mode, we do NOT set --set-upstream-to=upstream/main (there's
+		// no upstream remote). Tracking may be empty or origin/main depending on
+		// how the worktree was created.
+		if trackBranch == "upstream/main" {
+			t.Errorf("direct-mode worktree should not track upstream/main, got tracking = %q", trackBranch)
+		}
 	}
 }

--- a/internal/castellarius/drought_hooks.go
+++ b/internal/castellarius/drought_hooks.go
@@ -191,15 +191,29 @@ func mtimeAdvanced(path string, baseline time.Time) bool {
 	return err == nil && info.ModTime().After(baseline)
 }
 
-// hookGitSync fetches the latest refs from origin/main for each repo sandbox
-// and deploys skills. The aqueduct workflow is defined inline in cistern.yaml —
-// no separate file sync is needed. Skills are still deployed from each repo's
-// skills/ tree. Uses `git fetch` + `git show origin/main:<path>`. Safe for active
-// agent worktrees (those not named `_primary`) because it never resets them.
-// The `_primary` clone is additionally reset to `origin/main` so new worktrees
-// always branch from a clean base.
+// hookGitSync fetches the latest refs from the appropriate remote for each repo
+// sandbox and deploys skills. The aqueduct workflow is defined inline in
+// cistern.yaml — no separate file sync is needed. Skills are still deployed from
+// each repo's skills/ tree. Uses `git fetch` + `git show <remote>/main:<path>`.
+// Safe for active agent worktrees (those not named "_primary") because it never
+// resets them. The `_primary` clone is reset to the appropriate remote's main
+// branch so new worktrees always branch from a clean base.
+//
+// For direct-mode repos, the remote is "origin" and the reset target is
+// origin/main. For fork-mode repos, the primary remote to sync is "upstream"
+// and the reset target is upstream/main — this ensures the primary clone
+// reflects the upstream project's latest state rather than the fork's.
 func hookGitSync(cfg *aqueduct.AqueductConfig, sandboxRoot string, gitFetchTimeout time.Duration, logger *slog.Logger) (changed bool, err error) {
 	for _, repo := range cfg.Repos {
+		// Determine the primary remote and ref for this repo.
+		// Fork-mode repos sync from upstream; direct-mode repos sync from origin.
+		primaryRemote := "origin"
+		primaryRef := "origin/main"
+		if repo.DeliveryMode == aqueduct.DeliveryModeFork {
+			primaryRemote = "upstream"
+			primaryRef = "upstream/main"
+		}
+
 		// Find any sandbox clone for this repo (first one with a .git dir).
 		repoSandboxDir := filepath.Join(sandboxRoot, repo.Name)
 		entries, err := os.ReadDir(repoSandboxDir)
@@ -223,63 +237,81 @@ func hookGitSync(cfg *aqueduct.AqueductConfig, sandboxRoot string, gitFetchTimeo
 			continue
 		}
 
-		// Fetch latest refs without touching the working tree.
-		// A 30-second timeout prevents a stalled network from blocking RunDroughtHooks indefinitely.
+		// Fetch latest refs from the primary remote without touching the working
+		// tree. A timeout prevents a stalled network from blocking
+		// RunDroughtHooks indefinitely.
 		fetchCtx, fetchCancel := context.WithTimeout(context.Background(), gitFetchTimeout)
-		fetchOut, fetchErr := exec.CommandContext(fetchCtx, "git", "-C", cloneDir, "fetch", "origin").CombinedOutput()
+		fetchOut, fetchErr := exec.CommandContext(fetchCtx, "git", "-C", cloneDir, "fetch", primaryRemote).CombinedOutput()
 		fetchCancel()
 		if fetchCtx.Err() == context.DeadlineExceeded {
 			logger.Warn("git_sync: git fetch timed out, skipping sync", "repo", repo.Name)
 			continue
 		}
 		if fetchErr != nil {
-			logger.Warn("git_sync: fetch failed", "repo", repo.Name, "error", fetchErr, "output", string(fetchOut))
+			logger.Warn("git_sync: fetch failed", "repo", repo.Name, "remote", primaryRemote, "error", fetchErr, "output", string(fetchOut))
 			continue
 		}
 
-		// Reset _primary to origin/main after a successful fetch so it always
-		// reflects upstream exactly. New worktrees are spawned from _primary, so
-		// this ensures they get the latest AGENTS.md and repo files. Agent
-		// worktrees (non-_primary names) are never reset — they carry
-		// in-progress work on feature branches.
-		// On empty/unborn repos (no commits on origin/main), the reset is
-		// skipped — there's nothing to reset to, and the command would fail.
-		if filepath.Base(cloneDir) == "_primary" {
-			primaryHasCommits, commitsErr := repoHasCommits(cloneDir, "origin/main")
-			if commitsErr != nil {
-				logger.Warn("git_sync: cannot check if origin/main has commits",
-					"repo", repo.Name, "error", commitsErr)
-			} else if primaryHasCommits {
-				resetOut, resetErr := exec.Command("git", "-C", cloneDir, "reset", "--hard", "origin/main").CombinedOutput()
-				if resetErr != nil {
-					logger.Warn("git_sync: failed to reset _primary to origin/main", "repo", repo.Name, "error", resetErr, "output", string(resetOut))
-				} else {
-					logger.Info("git_sync: _primary reset to origin/main", "repo", repo.Name)
-				}
-			} else {
-				logger.Info("git_sync: _primary has no origin/main — skipping reset", "repo", repo.Name)
+		// For fork-mode repos, also fetch origin so the fork's own refs stay
+		// up to date (needed for delivery cataractae to push and create PRs).
+		if repo.DeliveryMode == aqueduct.DeliveryModeFork {
+			forkCtx, forkCancel := context.WithTimeout(context.Background(), gitFetchTimeout)
+			forkOut, forkErr := exec.CommandContext(forkCtx, "git", "-C", cloneDir, "fetch", "origin").CombinedOutput()
+			forkCancel()
+			if forkErr != nil {
+				logger.Warn("git_sync: fork origin fetch failed", "repo", repo.Name, "error", forkErr, "output", string(forkOut))
+				// Non-fatal: origin fetch is best-effort.
 			}
 		}
 
-		// Sync skills from the skills/ tree in origin/main into ~/.cistern/skills/.
-		syncSkillsFromRepo(cloneDir, repo.Name, logger)
+		// Reset _primary to the primary ref after a successful fetch so it
+		// always reflects the latest state. New worktrees are spawned from
+		// _primary, so this ensures they get the latest AGENTS.md and repo
+		// files. Agent worktrees (non-_primary names) are never reset — they
+		// carry in-progress work on feature branches.
+		// On empty/unborn repos (no commits on the primary ref), the reset is
+		// skipped — there's nothing to reset to, and the command would fail.
+		if filepath.Base(cloneDir) == "_primary" {
+			primaryHasCommits, commitsErr := repoHasCommits(cloneDir, primaryRef)
+			if commitsErr != nil {
+				logger.Warn("git_sync: cannot check if ref has commits",
+					"repo", repo.Name, "ref", primaryRef, "error", commitsErr)
+			} else if primaryHasCommits {
+				resetOut, resetErr := exec.Command("git", "-C", cloneDir, "reset", "--hard", primaryRef).CombinedOutput()
+				if resetErr != nil {
+					logger.Warn("git_sync: failed to reset _primary",
+						"repo", repo.Name, "ref", primaryRef, "error", resetErr, "output", string(resetOut))
+				} else {
+					logger.Info("git_sync: _primary reset", "repo", repo.Name, "ref", primaryRef)
+				}
+			} else {
+				logger.Info("git_sync: _primary has no commits on ref — skipping reset",
+					"repo", repo.Name, "ref", primaryRef)
+			}
+		}
+
+	// Sync skills from the skills/ tree on the primary remote's main branch
+	// into ~/.cistern/skills/.
+	syncSkillsFromRepo(cloneDir, repo.Name, primaryRemote, logger)
 	}
 	return changed, nil
 }
 
 // syncSkillsFromRepo deploys all skills from the skills/ and internal/skills/
-// trees in origin/main into ~/.cistern/skills/ via skills.Deploy.
+// trees on the given remote's main branch into ~/.cistern/skills/ via skills.Deploy.
+// remote is "origin" for direct-mode repos and "upstream" for fork-mode repos.
 // Errors are logged but not fatal.
-func syncSkillsFromRepo(cloneDir, repoName string, logger *slog.Logger) {
+func syncSkillsFromRepo(cloneDir, repoName string, remote string, logger *slog.Logger) {
+	ref := remote + "/main"
 	for _, prefix := range []string{"skills", "internal/skills"} {
-		out, err := exec.Command("git", "-C", cloneDir, "ls-tree", "--name-only", "origin/main:"+prefix).Output()
+		out, err := exec.Command("git", "-C", cloneDir, "ls-tree", "--name-only", ref+":"+prefix).Output()
 		if err != nil {
 			continue
 		}
 
 		for _, name := range strings.Fields(strings.TrimSpace(string(out))) {
 			skillPath := prefix + "/" + name + "/SKILL.md"
-			content, err := exec.Command("git", "-C", cloneDir, "show", "origin/main:"+skillPath).Output()
+			content, err := exec.Command("git", "-C", cloneDir, "show", ref+":"+skillPath).Output()
 			if err != nil {
 				logger.Warn("git_sync: skill SKILL.md not found", "repo", repoName, "skill", name)
 				continue

--- a/internal/castellarius/drought_hooks.go
+++ b/internal/castellarius/drought_hooks.go
@@ -288,11 +288,11 @@ func hookGitSync(cfg *aqueduct.AqueductConfig, sandboxRoot string, gitFetchTimeo
 				logger.Info("git_sync: _primary has no commits on ref — skipping reset",
 					"repo", repo.Name, "ref", primaryRef)
 			}
-		}
 
-	// Sync skills from the skills/ tree on the primary remote's main branch
-	// into ~/.cistern/skills/.
-	syncSkillsFromRepo(cloneDir, repo.Name, primaryRemote, logger)
+			// Sync skills from the skills/ tree on the primary remote's
+			// main branch into ~/.cistern/skills/.
+			syncSkillsFromRepo(cloneDir, repo.Name, primaryRemote, logger)
+		}
 	}
 	return changed, nil
 }

--- a/internal/castellarius/drought_hooks_test.go
+++ b/internal/castellarius/drought_hooks_test.go
@@ -1113,6 +1113,251 @@ func TestRunDroughtHooks_NilCallbacks_DoesNotPanic(t *testing.T) {
 
 // --- _primary working-tree reset tests ---
 
+// --- Fork-mode git_sync tests ---
+
+func TestHookGitSync_ForkMode_FetchesFromUpstream(t *testing.T) {
+	// Given: a fork-mode repo with origin pointing to a fork and upstream
+	// pointing to the source-of-truth repo. When hookGitSync runs, it must
+	// fetch from upstream (not origin) and reset _primary to upstream/main.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	const repoName = "forkrepo"
+
+	tmpDir := t.TempDir()
+	setHomeForTest(t, tmpDir)
+
+	// Create the upstream repo with original content.
+	upstreamDir := filepath.Join(tmpDir, "upstream.git")
+	mustGit(t, "", "init", "--bare", upstreamDir)
+
+	// Create a working copy and push initial commit to upstream.
+	upstreamWork := filepath.Join(tmpDir, "upstream-work")
+	mustGit(t, "", "clone", upstreamDir, upstreamWork)
+	mustGit(t, upstreamWork, "config", "user.email", "noreply@lobsterdog.dev")
+	mustGit(t, upstreamWork, "config", "user.name", "Lobsterdog Contributors")
+	if err := os.WriteFile(filepath.Join(upstreamWork, "README.md"), []byte("upstream original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, upstreamWork, "add", "-A")
+	mustGit(t, upstreamWork, "commit", "-m", "upstream initial")
+	exec.Command("git", "-C", upstreamWork, "branch", "-M", "main").Run() //nolint:errcheck
+	mustGit(t, upstreamWork, "push", "-u", "origin", "main")
+
+	// Create the fork (origin) repo with different content.
+	forkDir := filepath.Join(tmpDir, "fork.git")
+	mustGit(t, "", "init", "--bare", forkDir)
+
+	forkWork := filepath.Join(tmpDir, "fork-work")
+	mustGit(t, "", "clone", forkDir, forkWork)
+	mustGit(t, forkWork, "config", "user.email", "noreply@lobsterdog.dev")
+	mustGit(t, forkWork, "config", "user.name", "Lobsterdog Contributors")
+	if err := os.WriteFile(filepath.Join(forkWork, "README.md"), []byte("fork content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, forkWork, "add", "-A")
+	mustGit(t, forkWork, "commit", "-m", "fork initial")
+	exec.Command("git", "-C", forkWork, "branch", "-M", "main").Run() //nolint:errcheck
+	mustGit(t, forkWork, "push", "-u", "origin", "main")
+
+	// Clone the fork into the sandbox structure.
+	sandboxRoot := filepath.Join(tmpDir, "sandboxes")
+	primaryClone := filepath.Join(sandboxRoot, repoName, "_primary")
+	if err := os.MkdirAll(filepath.Dir(primaryClone), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, "", "clone", forkDir, primaryClone)
+	mustGit(t, primaryClone, "config", "user.email", "noreply@lobsterdog.dev")
+	mustGit(t, primaryClone, "config", "user.name", "Lobsterdog Contributors")
+
+	// Add upstream remote to the primary clone.
+	mustGit(t, primaryClone, "remote", "add", "upstream", upstreamDir)
+	mustGit(t, primaryClone, "fetch", "upstream")
+
+	// Dirty the primary clone — write local content that differs from both remotes.
+	if err := os.WriteFile(filepath.Join(primaryClone, "README.md"), []byte("dirty local content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &aqueduct.AqueductConfig{
+		Repos: []aqueduct.RepoConfig{
+			{
+				Name:          repoName,
+				Aqueduct:      "default",
+				Cataractae:    1,
+				Prefix:        "t",
+				DeliveryMode:  aqueduct.DeliveryModeFork,
+				UpstreamRemote: upstreamDir,
+			},
+		},
+	}
+
+	if _, err := hookGitSync(cfg, sandboxRoot, 30*time.Second, discardLogger()); err != nil {
+		t.Fatalf("hookGitSync: %v", err)
+	}
+
+	// After git_sync, _primary should be reset to upstream/main content,
+	// not origin/main content.
+	data, err := os.ReadFile(filepath.Join(primaryClone, "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "upstream original" {
+		t.Errorf("after sync, _primary content = %q, want %q", got, "upstream original")
+	}
+}
+
+func TestHookGitSync_ForkMode_NonPrimaryNotReset(t *testing.T) {
+	// Given: a fork-mode repo with a non-primary worktree. When hookGitSync
+	// runs, the non-primary worktree should NOT be reset.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	const repoName = "forkrepo2"
+
+	tmpDir := t.TempDir()
+	setHomeForTest(t, tmpDir)
+
+	// Create the upstream repo.
+	upstreamDir := filepath.Join(tmpDir, "upstream.git")
+	mustGit(t, "", "init", "--bare", upstreamDir)
+
+	upstreamWork := filepath.Join(tmpDir, "upstream-work")
+	mustGit(t, "", "clone", upstreamDir, upstreamWork)
+	mustGit(t, upstreamWork, "config", "user.email", "noreply@lobsterdog.dev")
+	mustGit(t, upstreamWork, "config", "user.name", "Lobsterdog Contributors")
+	if err := os.WriteFile(filepath.Join(upstreamWork, "README.md"), []byte("upstream original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, upstreamWork, "add", "-A")
+	mustGit(t, upstreamWork, "commit", "-m", "upstream initial")
+	exec.Command("git", "-C", upstreamWork, "branch", "-M", "main").Run() //nolint:errcheck
+	mustGit(t, upstreamWork, "push", "-u", "origin", "main")
+
+	// Create the fork.
+	forkDir := filepath.Join(tmpDir, "fork.git")
+	mustGit(t, "", "init", "--bare", forkDir)
+
+	forkWork := filepath.Join(tmpDir, "fork-work")
+	mustGit(t, "", "clone", forkDir, forkWork)
+	mustGit(t, forkWork, "config", "user.email", "noreply@lobsterdog.dev")
+	mustGit(t, forkWork, "config", "user.name", "Lobsterdog Contributors")
+	if err := os.WriteFile(filepath.Join(forkWork, "README.md"), []byte("fork content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, forkWork, "add", "-A")
+	mustGit(t, forkWork, "commit", "-m", "fork initial")
+	exec.Command("git", "-C", forkWork, "branch", "-M", "main").Run() //nolint:errcheck
+	mustGit(t, forkWork, "push", "-u", "origin", "main")
+
+	// Clone the fork as a non-primary directory (e.g., an agent worktree).
+	sandboxRoot := filepath.Join(tmpDir, "sandboxes")
+	agentClone := filepath.Join(sandboxRoot, repoName, "alpha")
+	if err := os.MkdirAll(filepath.Dir(agentClone), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, "", "clone", forkDir, agentClone)
+	mustGit(t, agentClone, "config", "user.email", "noreply@lobsterdog.dev")
+	mustGit(t, agentClone, "config", "user.name", "Lobsterdog Contributors")
+	mustGit(t, agentClone, "remote", "add", "upstream", upstreamDir)
+	mustGit(t, agentClone, "fetch", "upstream")
+
+	// Dirty the agent worktree.
+	if err := os.WriteFile(filepath.Join(agentClone, "README.md"), []byte("agent work in progress\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &aqueduct.AqueductConfig{
+		Repos: []aqueduct.RepoConfig{
+			{
+				Name:           repoName,
+				Aqueduct:       "default",
+				Cataractae:     1,
+				Prefix:         "t",
+				DeliveryMode:   aqueduct.DeliveryModeFork,
+				UpstreamRemote: upstreamDir,
+			},
+		},
+	}
+
+	if _, err := hookGitSync(cfg, sandboxRoot, 30*time.Second, discardLogger()); err != nil {
+		t.Fatalf("hookGitSync: %v", err)
+	}
+
+	// The agent worktree should NOT be reset.
+	data, err := os.ReadFile(filepath.Join(agentClone, "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "agent work in progress" {
+		t.Errorf("agent worktree content = %q, want %q (should not be reset)", got, "agent work in progress")
+	}
+}
+
+func TestHookGitSync_DirectMode_ResetsToOriginMain(t *testing.T) {
+	// Given: a direct-mode repo. When hookGitSync runs, _primary should
+	// be reset to origin/main (the existing behavior).
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	const repoName = "directrepo"
+	const originalContent = "original content\n"
+
+	tmpDir := t.TempDir()
+	setHomeForTest(t, tmpDir)
+
+	// Create remote repo with a tracked file.
+	remoteDir := filepath.Join(tmpDir, "remote")
+	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, remoteDir, "init")
+	mustGit(t, remoteDir, "config", "user.email", "noreply@lobsterdog.dev")
+	mustGit(t, remoteDir, "config", "user.name", "Lobsterdog Contributors")
+	if err := os.WriteFile(filepath.Join(remoteDir, "README.md"), []byte(originalContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, remoteDir, "add", "-A")
+	mustGit(t, remoteDir, "commit", "-m", "initial")
+	exec.Command("git", "-C", remoteDir, "branch", "-M", "main").Run() //nolint:errcheck
+
+	// Clone into the sandbox under _primary.
+	sandboxRoot := filepath.Join(tmpDir, "sandboxes")
+	primaryClone := filepath.Join(sandboxRoot, repoName, "_primary")
+	if err := os.MkdirAll(filepath.Dir(primaryClone), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, "", "clone", remoteDir, primaryClone)
+	mustGit(t, primaryClone, "config", "user.email", "noreply@lobsterdog.dev")
+	mustGit(t, primaryClone, "config", "user.name", "Lobsterdog Contributors")
+
+	// Dirty the primary clone.
+	if err := os.WriteFile(filepath.Join(primaryClone, "README.md"), []byte("dirty content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &aqueduct.AqueductConfig{
+		Repos: []aqueduct.RepoConfig{
+			{Name: repoName, Aqueduct: "default", Cataractae: 1, Prefix: "t"},
+		},
+	}
+
+	if _, err := hookGitSync(cfg, sandboxRoot, 30*time.Second, discardLogger()); err != nil {
+		t.Fatalf("hookGitSync: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(primaryClone, "README.md"))
+	if err != nil {
+		t.Fatalf("read file after sync: %v", err)
+	}
+	if string(data) != originalContent {
+		t.Errorf("file content after sync = %q, want %q", string(data), originalContent)
+	}
+}
+
 func TestHookGitSync_WorkingTreeReset(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")

--- a/internal/castellarius/drought_hooks_test.go
+++ b/internal/castellarius/drought_hooks_test.go
@@ -384,7 +384,7 @@ func TestHookGitSync_DeploysSkillsToSkillsDir(t *testing.T) {
 
 	// Create a sandbox clone for hookGitSync to find.
 	sandboxRoot := filepath.Join(tmpDir, "sandboxes")
-	sandboxClone := filepath.Join(sandboxRoot, "myrepo", "worker1")
+	sandboxClone := filepath.Join(sandboxRoot, "myrepo", "_primary")
 	mustGit(t, "", "clone", originDir, sandboxClone)
 
 	cfg := &aqueduct.AqueductConfig{
@@ -420,7 +420,7 @@ func TestHookGitSync_SkillsDeployIsIdempotent(t *testing.T) {
 	originDir := setupGitOriginWithSkills(t, tmpDir, skillName, skillContent)
 
 	sandboxRoot := filepath.Join(tmpDir, "sandboxes")
-	sandboxClone := filepath.Join(sandboxRoot, "repo", "worker1")
+	sandboxClone := filepath.Join(sandboxRoot, "repo", "_primary")
 	mustGit(t, "", "clone", originDir, sandboxClone)
 
 	cfg := &aqueduct.AqueductConfig{
@@ -476,7 +476,7 @@ func TestHookGitSync_SkillsSyncGracefulWhenNoSkillsDir(t *testing.T) {
 	mustGit(t, workDir, "push", "origin", "HEAD:main")
 
 	sandboxRoot := filepath.Join(tmpDir, "sandboxes")
-	sandboxClone := filepath.Join(sandboxRoot, "noskills-repo", "worker1")
+	sandboxClone := filepath.Join(sandboxRoot, "noskills-repo", "_primary")
 	mustGit(t, "", "clone", originDir, sandboxClone)
 
 	cfg := &aqueduct.AqueductConfig{

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -1184,7 +1184,11 @@ func (s *Castellarius) dispatchRepo(ctx context.Context, repo aqueduct.RepoConfi
 				req.Step.Type == aqueduct.CataractaeTypeAgent &&
 				req.Step.Context != aqueduct.ContextSpecOnly {
 				primaryDir := filepath.Join(s.sandboxRoot, req.RepoConfig.Name, "_primary")
-				sandboxDir, err := prepareDropletWorktree(primaryDir, s.sandboxRoot, req.RepoConfig.Name, req.Item.ID)
+				baseRemote := "origin"
+				if req.RepoConfig.DeliveryMode == aqueduct.DeliveryModeFork {
+					baseRemote = "upstream"
+				}
+				sandboxDir, err := prepareDropletWorktree(primaryDir, s.sandboxRoot, req.RepoConfig.Name, req.Item.ID, baseRemote)
 				if err != nil {
 					s.logger.Error("prepare worktree failed",
 						"repo", req.RepoConfig.Name,
@@ -1825,13 +1829,22 @@ func repoHasCommits(dir, ref string) (bool, error) {
 // `git worktree add -b feat/<id> <path> origin/main` to create a fresh branch.
 // When origin/main has no commits (empty/unborn repo), uses
 // `git worktree add --orphan -b feat/<id> <path>` instead.
-func prepareDropletWorktree(primaryDir, sandboxRoot, repoName, dropletID string) (string, error) {
-	return prepareDropletWorktreeWithLogger(slog.Default(), primaryDir, sandboxRoot, repoName, dropletID)
+func prepareDropletWorktree(primaryDir, sandboxRoot, repoName, dropletID string, baseRemote ...string) (string, error) {
+	remote := "origin"
+	if len(baseRemote) > 0 {
+		remote = baseRemote[0]
+	}
+	return prepareDropletWorktreeWithLogger(slog.Default(), primaryDir, sandboxRoot, repoName, dropletID, remote)
 }
 
 // prepareDropletWorktreeWithLogger is the logger-parameterized implementation
 // of prepareDropletWorktree, used directly in tests.
-func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRoot, repoName, dropletID string) (string, error) {
+// baseRemote controls which remote the worktree tracks: "origin" for direct
+// mode, "upstream" for fork mode. When empty, defaults to "origin".
+func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRoot, repoName, dropletID, baseRemote string) (string, error) {
+	if baseRemote == "" {
+		baseRemote = "origin"
+	}
 	worktreePath := filepath.Join(sandboxRoot, repoName, dropletID)
 	branch := "feat/" + dropletID
 	t0 := time.Now()
@@ -1858,16 +1871,28 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 			return "", fmt.Errorf("git checkout %s in %s: %w: %s", branch, worktreePath, err, out)
 		}
 
+		// For fork mode, set up tracking against upstream/main instead of origin/main.
+		if baseRemote == "upstream" {
+			trackCmd := exec.Command("git", "branch", "--set-upstream-to=upstream/main", branch)
+			trackCmd.Dir = worktreePath
+			if out, err := trackCmd.CombinedOutput(); err != nil {
+				// Non-fatal: log a warning. The upstream remote may not have main yet.
+				logger.Warn("git branch --set-upstream-to=upstream/main failed",
+					"branch", branch, "error", err, "output", string(out))
+			}
+		}
+
 		logger.Info("worktree resumed",
 			"droplet", dropletID, "path", worktreePath,
 			"duration", time.Since(t0).Round(time.Millisecond).String())
 		return worktreePath, nil
 	}
 
-	// Fetch latest before creating — but only if origin/main exists. On an
-	// empty/unborn repo, git fetch origin succeeds but there are no refs to
+	// Fetch latest before creating — but only if baseRemote/main exists. On an
+	// empty/unborn repo, git fetch succeeds but there are no refs to
 	// base a worktree on. The orphan path handles this case.
-	hasCommits, commitsErr := repoHasCommits(primaryDir, "origin/main")
+	baseRef := baseRemote + "/main"
+	hasCommits, commitsErr := repoHasCommits(primaryDir, baseRef)
 	if commitsErr != nil {
 		// If we can't check, assume commits exist (conservative fallback)
 		// and let the normal path fail with a descriptive error if wrong.
@@ -1876,11 +1901,11 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 		hasCommits = true
 	}
 	if hasCommits {
-		logger.Info("git fetch", "dir", primaryDir)
-		fetch := exec.Command("git", "fetch", "origin")
+		logger.Info("git fetch", "dir", primaryDir, "remote", baseRemote)
+		fetch := exec.Command("git", "fetch", baseRemote)
 		fetch.Dir = primaryDir
 		if out, err := fetch.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("git fetch in %s: %w: %s", primaryDir, err, out)
+			return "", fmt.Errorf("git fetch %s in %s: %w: %s", baseRemote, primaryDir, err, out)
 		}
 	}
 
@@ -1911,8 +1936,8 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 			freshBranch = true
 			orphanBranch = true
 		} else {
-			// Branch doesn't exist yet — create it fresh from origin/main.
-			addNew := exec.Command("git", "worktree", "add", "-b", branch, worktreePath, "origin/main")
+			// Branch doesn't exist yet — create it fresh from baseRemote/main.
+			addNew := exec.Command("git", "worktree", "add", "-b", branch, worktreePath, baseRef)
 			addNew.Dir = primaryDir
 			if out2, err2 := addNew.CombinedOutput(); err2 != nil {
 				return "", fmt.Errorf("git worktree add %s in %s: %w: %s", worktreePath, primaryDir, err2, out2)
@@ -1933,11 +1958,11 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 	}
 
 	if freshBranch && !orphanBranch {
-		// Hard-reset to origin/main to guarantee a clean baseline — the worktree
+		// Hard-reset to baseRef to guarantee a clean baseline — the worktree
 		// may inherit local modifications from the primary clone.
-		// This is skipped for orphan branches (empty repo) since origin/main
+		// This is skipped for orphan branches (empty repo) since baseRef
 		// doesn't exist — there's nothing to reset to.
-		reset := exec.Command("git", "reset", "--hard", "origin/main")
+		reset := exec.Command("git", "reset", "--hard", baseRef)
 		reset.Dir = worktreePath
 		if out, err := reset.CombinedOutput(); err != nil {
 			return "", fmt.Errorf("git reset in %s: %w: %s", worktreePath, err, out)

--- a/internal/castellarius/scheduler.go
+++ b/internal/castellarius/scheduler.go
@@ -1970,6 +1970,20 @@ func prepareDropletWorktreeWithLogger(logger *slog.Logger, primaryDir, sandboxRo
 		clean := exec.Command("git", "clean", "-fd")
 		clean.Dir = worktreePath
 		_ = clean.Run()
+
+		// For fork mode, set up tracking against upstream/main so git push/pull
+		// default to the correct remote. This mirrors the resume path's
+		// --set-upstream-to setup and ensures consistency between fresh and
+		// resumed worktrees.
+		if baseRemote == "upstream" {
+			trackCmd := exec.Command("git", "branch", "--set-upstream-to=upstream/main", branch)
+			trackCmd.Dir = worktreePath
+			if out, err := trackCmd.CombinedOutput(); err != nil {
+				// Non-fatal: log a warning. The upstream remote may not have main yet.
+				logger.Warn("git branch --set-upstream-to=upstream/main failed for new worktree",
+					"branch", branch, "error", err, "output", string(out))
+			}
+		}
 	}
 
 	if orphanBranch {

--- a/internal/castellarius/scheduler_test.go
+++ b/internal/castellarius/scheduler_test.go
@@ -2483,7 +2483,7 @@ func TestPrepareDropletWorktree_LogsWorktreeCreated(t *testing.T) {
 	sandboxRoot := t.TempDir()
 	repoName := "logrepo"
 
-	_, err := prepareDropletWorktreeWithLogger(l, primary, sandboxRoot, repoName, "ci-wt-create")
+	_, err := prepareDropletWorktreeWithLogger(l, primary, sandboxRoot, repoName, "ci-wt-create", "origin")
 	if err != nil {
 		t.Fatalf("prepareDropletWorktree: %v", err)
 	}
@@ -2511,13 +2511,13 @@ func TestPrepareDropletWorktree_LogsWorktreeResumed(t *testing.T) {
 	repoName := "logrepo"
 
 	// First call: create.
-	if _, err := prepareDropletWorktreeWithLogger(l, primary, sandboxRoot, repoName, "ci-wt-resume"); err != nil {
+	if _, err := prepareDropletWorktreeWithLogger(l, primary, sandboxRoot, repoName, "ci-wt-resume", "origin"); err != nil {
 		t.Fatalf("first prepareDropletWorktree: %v", err)
 	}
 	buf.Reset()
 
 	// Second call: resume.
-	if _, err := prepareDropletWorktreeWithLogger(l, primary, sandboxRoot, repoName, "ci-wt-resume"); err != nil {
+	if _, err := prepareDropletWorktreeWithLogger(l, primary, sandboxRoot, repoName, "ci-wt-resume", "origin"); err != nil {
 		t.Fatalf("second prepareDropletWorktree: %v", err)
 	}
 
@@ -2537,7 +2537,7 @@ func TestRemoveDropletWorktree_LogsWorktreeDeleted(t *testing.T) {
 	sandboxRoot := t.TempDir()
 	repoName := "logrepo"
 
-	if _, err := prepareDropletWorktreeWithLogger(l, primary, sandboxRoot, repoName, "ci-wt-del"); err != nil {
+	if _, err := prepareDropletWorktreeWithLogger(l, primary, sandboxRoot, repoName, "ci-wt-del", "origin"); err != nil {
 		t.Fatalf("prepareDropletWorktree: %v", err)
 	}
 	buf.Reset()

--- a/internal/cataractae/context.go
+++ b/internal/cataractae/context.go
@@ -58,6 +58,10 @@ type ContextParams struct {
 	// For providers with AgentFlag support (opencode), this field is not used —
 	// the prompt is delivered via an agent markdown file instead.
 	InstructionsFile string
+	// RepoConfig carries delivery mode information. For fork-mode repos, the
+	// CONTEXT.md file includes the upstream remote URL so the fork-delivery
+	// agent knows where to open the PR.
+	RepoConfig aqueduct.RepoConfig
 }
 
 func (p ContextParams) logger() *slog.Logger {
@@ -374,6 +378,15 @@ func writeContextFile(path string, p ContextParams) error {
 			writeSkill(skill.Name, skillDescription(skill.Name), skills.LocalPath(skill.Name))
 		}
 		b.WriteString("</available_skills>\n\n")
+	}
+
+	// Fork delivery info: include upstream remote URL so the fork-delivery agent
+	// knows where to open the PR.
+	if p.RepoConfig.DeliveryMode == aqueduct.DeliveryModeFork {
+		b.WriteString("## Fork Delivery\n\n")
+		b.WriteString(fmt.Sprintf("**Delivery Mode:** fork\n"))
+		b.WriteString(fmt.Sprintf("**Upstream Remote:** %s\n", p.RepoConfig.UpstreamRemote))
+		b.WriteString("**Base Branch:** main (from upstream)\n\n")
 	}
 
 	b.WriteString("## Signaling\n\n")

--- a/internal/cataractae/context_test.go
+++ b/internal/cataractae/context_test.go
@@ -847,3 +847,93 @@ func TestWriteContextFile_UncommittedFilesSectionExcludesInstructionsFile(t *tes
 		t.Error("feature.go must appear in uncommitted files section")
 	}
 }
+
+// --- Fork delivery section tests ---
+
+// TestWriteContextFile_ForkMode_IncludesUpstreamRemote verifies that when
+// RepoConfig.DeliveryMode is DeliveryModeFork, CONTEXT.md includes the
+// Fork Delivery section with the upstream remote URL.
+func TestWriteContextFile_ForkMode_IncludesUpstreamRemote(t *testing.T) {
+	item := &cistern.Droplet{ID: "ci-fork1", Title: "Fork test", Status: "in_progress", Description: "Test fork delivery"}
+	step := &aqueduct.WorkflowCataractae{Name: "implementation", Type: "agent", Identity: "implementer"}
+	upstream := "https://github.com/upstream-org/repo.git"
+
+	p := ContextParams{
+		Item:       item,
+		Step:       step,
+		RepoConfig: aqueduct.RepoConfig{DeliveryMode: aqueduct.DeliveryModeFork, UpstreamRemote: upstream},
+	}
+
+	ctxPath := filepath.Join(t.TempDir(), "CONTEXT.md")
+	if err := writeContextFile(ctxPath, p); err != nil {
+		t.Fatalf("writeContextFile: %v", err)
+	}
+
+	content, err := os.ReadFile(ctxPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(content)
+
+	if !strings.Contains(got, "## Fork Delivery") {
+		t.Error("expected '## Fork Delivery' section in CONTEXT.md for fork mode")
+	}
+	if !strings.Contains(got, "**Delivery Mode:** fork") {
+		t.Error("expected '**Delivery Mode:** fork' in CONTEXT.md")
+	}
+	if !strings.Contains(got, "**Upstream Remote:** "+upstream) {
+		t.Error("expected upstream remote URL in CONTEXT.md")
+	}
+	if !strings.Contains(got, "**Base Branch:** main (from upstream)") {
+		t.Error("expected '**Base Branch:** main (from upstream)' in CONTEXT.md")
+	}
+}
+
+// TestWriteContextFile_DirectMode_NoForkDeliverySection verifies that when
+// DeliveryMode is direct (or empty), no Fork Delivery section appears.
+func TestWriteContextFile_DirectMode_NoForkDeliverySection(t *testing.T) {
+	item := &cistern.Droplet{ID: "ci-direct1", Title: "Direct test", Status: "in_progress"}
+	step := &aqueduct.WorkflowCataractae{Name: "implementation", Type: "agent", Identity: "implementer"}
+
+	// Test with explicit direct mode.
+	p := ContextParams{
+		Item:       item,
+		Step:       step,
+		RepoConfig: aqueduct.RepoConfig{DeliveryMode: aqueduct.DeliveryModeDirect},
+	}
+
+	ctxPath := filepath.Join(t.TempDir(), "CONTEXT_direct.md")
+	if err := writeContextFile(ctxPath, p); err != nil {
+		t.Fatalf("writeContextFile: %v", err)
+	}
+
+	content, err := os.ReadFile(ctxPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(content)
+
+	if strings.Contains(got, "## Fork Delivery") {
+		t.Error("Fork Delivery section must NOT appear for direct mode")
+	}
+
+	// Test with empty delivery mode (zero value default).
+	p2 := ContextParams{
+		Item:       item,
+		Step:       step,
+		RepoConfig: aqueduct.RepoConfig{}, // DeliveryMode is ""
+	}
+
+	ctxPath2 := filepath.Join(t.TempDir(), "CONTEXT_empty.md")
+	if err := writeContextFile(ctxPath2, p2); err != nil {
+		t.Fatalf("writeContextFile: %v", err)
+	}
+
+	content2, err := os.ReadFile(ctxPath2)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(content2), "## Fork Delivery") {
+		t.Error("Fork Delivery section must NOT appear when DeliveryMode is empty")
+	}
+}

--- a/internal/cataractae/runner.go
+++ b/internal/cataractae/runner.go
@@ -88,7 +88,7 @@ func New(cfg Config) (*Runner, error) {
 	// SkipInitialClone is set in tests that use fake repo URLs.
 	if !cfg.SkipInitialClone {
 		primaryDir := filepath.Join(repoSandboxDir, "_primary")
-		if err := EnsurePrimaryClone(primaryDir, cfg.Repo.URL); err != nil {
+		if err := EnsurePrimaryClone(primaryDir, cfg.Repo.URL, cfg.Repo.UpstreamRemote); err != nil {
 			return nil, fmt.Errorf("cataractae: primary clone for %q: %w", cfg.Repo.Name, err)
 		}
 		for _, w := range workers {
@@ -232,6 +232,7 @@ func (r *Runner) SpawnStep(w *Worker, item *cistern.Droplet, step *aqueduct.Work
 		OpenIssues:       openIssues,
 		QueueClient:      r.queue,
 		InstructionsFile: r.preset.InstrFile(),
+		RepoConfig:       r.repo,
 	})
 	if err != nil {
 		return fmt.Errorf("context: %w", err)

--- a/internal/cataractae/sandbox.go
+++ b/internal/cataractae/sandbox.go
@@ -15,7 +15,13 @@ import (
 //
 // On first call: clones the repo.
 // On subsequent calls: fetches latest remote refs.
-func EnsurePrimaryClone(primaryDir, repoURL string) error {
+//
+// When upstreamURL is non-empty, an "upstream" remote is added (or updated)
+// pointing to the upstream repository, and upstream refs are fetched. This
+// is required for fork-mode repos where worktrees must track upstream/main
+// rather than origin/main. When upstreamURL is empty, upstream remote setup
+// is skipped (backward compatible).
+func EnsurePrimaryClone(primaryDir, repoURL, upstreamURL string) error {
 	gitDir := filepath.Join(primaryDir, ".git")
 	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
 		if err := os.RemoveAll(primaryDir); err != nil && !os.IsNotExist(err) {
@@ -29,6 +35,14 @@ func EnsurePrimaryClone(primaryDir, repoURL string) error {
 		}
 		slog.Default().Info("git clone completed",
 			"dir", primaryDir, "duration", time.Since(t0).Round(time.Millisecond).String())
+
+		// Add upstream remote after fresh clone if upstreamURL is provided.
+		if upstreamURL != "" {
+			if err := addUpstreamRemote(primaryDir, upstreamURL); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}
 	t0 := time.Now()
@@ -39,6 +53,57 @@ func EnsurePrimaryClone(primaryDir, repoURL string) error {
 	}
 	slog.Default().Info("git fetch completed",
 		"dir", primaryDir, "duration", time.Since(t0).Round(time.Millisecond).String())
+
+	// Update upstream remote if needed on subsequent calls.
+	if upstreamURL != "" {
+		if err := addUpstreamRemote(primaryDir, upstreamURL); err != nil {
+			// Non-fatal: log a warning but don't fail the whole operation.
+			// The upstream may be temporarily unreachable.
+			slog.Default().Warn("upstream remote setup failed",
+				"dir", primaryDir, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// addUpstreamRemote ensures the "upstream" remote points to upstreamURL.
+// If the remote already exists with a different URL, it is updated.
+// If it already exists with the same URL, this is a no-op.
+// After ensuring the remote exists, upstream refs are fetched.
+func addUpstreamRemote(primaryDir, upstreamURL string) error {
+	// Check if "upstream" remote already exists.
+	listCmd := exec.Command("git", "remote", "get-url", "upstream")
+	listCmd.Dir = primaryDir
+	out, err := listCmd.CombinedOutput()
+	if err != nil {
+		// Remote doesn't exist yet — add it.
+		addCmd := exec.Command("git", "remote", "add", "upstream", upstreamURL)
+		addCmd.Dir = primaryDir
+		if addOut, addErr := addCmd.CombinedOutput(); addErr != nil {
+			return fmt.Errorf("cataractae: add upstream remote in %s: %w: %s", primaryDir, addErr, addOut)
+		}
+	} else {
+		// Remote exists — update URL if it differs.
+		currentURL := strings.TrimSpace(string(out))
+		if currentURL != upstreamURL {
+			setURLCmd := exec.Command("git", "remote", "set-url", "upstream", upstreamURL)
+			setURLCmd.Dir = primaryDir
+			if setURLOut, setURLErr := setURLCmd.CombinedOutput(); setURLErr != nil {
+				return fmt.Errorf("cataractae: set upstream remote URL in %s: %w: %s", primaryDir, setURLErr, setURLOut)
+			}
+		}
+	}
+
+	// Fetch from upstream so refs are available for worktree creation.
+	fetchUpstream := exec.Command("git", "fetch", "upstream")
+	fetchUpstream.Dir = primaryDir
+	if fetchOut, fetchErr := fetchUpstream.CombinedOutput(); fetchErr != nil {
+		// Non-fatal: log a warning. The upstream may be temporarily unreachable.
+		slog.Default().Warn("git fetch upstream failed",
+			"dir", primaryDir, "error", fetchErr, "output", string(fetchOut))
+	}
+
 	return nil
 }
 

--- a/internal/cataractae/sandbox_test.go
+++ b/internal/cataractae/sandbox_test.go
@@ -210,3 +210,110 @@ func TestEnsureWorktree_EmptyRepo_UsesOrphanBranch(t *testing.T) {
 		t.Error("worktree not registered in primary clone")
 	}
 }
+
+// --- EnsurePrimaryClone fork-mode tests ---
+
+// makeGitRepoWithRemoteURL creates a git repo with one commit on main and
+// returns the local directory. Used as both origin and upstream in tests.
+func makeGitRepoWithRemoteURL(t *testing.T) string {
+	t.Helper()
+	return makeGitRepoWithCommit(t)
+}
+
+// TestEnsurePrimaryClone_ForkMode_AddsUpstreamRemote verifies that when
+// upstreamURL is provided, EnsurePrimaryClone adds an "upstream" remote
+// pointing to that URL.
+func TestEnsurePrimaryClone_ForkMode_AddsUpstreamRemote(t *testing.T) {
+	primary := makeGitRepoWithRemoteURL(t)
+	upstream := makeGitRepoWithRemoteURL(t)
+	sandboxDir := filepath.Join(t.TempDir(), "primary")
+
+	if err := EnsurePrimaryClone(sandboxDir, primary, upstream); err != nil {
+		t.Fatalf("EnsurePrimaryClone: %v", err)
+	}
+	defer os.RemoveAll(sandboxDir)
+
+	// Verify "upstream" remote exists and points to the correct URL.
+	cmd := exec.Command("git", "-C", sandboxDir, "remote", "get-url", "upstream")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git remote get-url upstream: %v", err)
+	}
+	got := strings.TrimSpace(string(out))
+	if got != upstream {
+		t.Errorf("upstream remote URL = %q, want %q", got, upstream)
+	}
+}
+
+// TestEnsurePrimaryClone_DirectMode_NoUpstreamRemote verifies that when
+// upstreamURL is empty, no "upstream" remote is added.
+func TestEnsurePrimaryClone_DirectMode_NoUpstreamRemote(t *testing.T) {
+	primary := makeGitRepoWithRemoteURL(t)
+	sandboxDir := filepath.Join(t.TempDir(), "primary")
+
+	if err := EnsurePrimaryClone(sandboxDir, primary, ""); err != nil {
+		t.Fatalf("EnsurePrimaryClone: %v", err)
+	}
+	defer os.RemoveAll(sandboxDir)
+
+	// Verify "upstream" remote does NOT exist.
+	cmd := exec.Command("git", "-C", sandboxDir, "remote", "get-url", "upstream")
+	_, err := cmd.Output()
+	if err == nil {
+		t.Error("upstream remote should not exist in direct mode")
+	}
+}
+
+// TestEnsurePrimaryClone_FetchesUpstreamWhenPresent verifies that when
+// upstreamURL is provided, the clone fetches from both origin and upstream.
+func TestEnsurePrimaryClone_FetchesUpstreamWhenPresent(t *testing.T) {
+	primary := makeGitRepoWithRemoteURL(t)
+	upstream := makeGitRepoWithRemoteURL(t)
+	sandboxDir := filepath.Join(t.TempDir(), "primary")
+
+	if err := EnsurePrimaryClone(sandboxDir, primary, upstream); err != nil {
+		t.Fatalf("EnsurePrimaryClone: %v", err)
+	}
+	defer os.RemoveAll(sandboxDir)
+
+	// Verify upstream/main ref exists.
+	cmd := exec.Command("git", "-C", sandboxDir, "branch", "-r", "--list", "upstream/main")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git branch -r --list upstream/main: %v", err)
+	}
+	got := strings.TrimSpace(string(out))
+	if got == "" {
+		t.Error("upstream/main ref not found after EnsurePrimaryClone with upstream URL")
+	}
+}
+
+// TestEnsurePrimaryClone_UpdatesUpstreamRemoteURL verifies that calling
+// EnsurePrimaryClone twice with different upstream URLs updates the remote.
+func TestEnsurePrimaryClone_UpdatesUpstreamRemoteURL(t *testing.T) {
+	primary := makeGitRepoWithRemoteURL(t)
+	upstream1 := makeGitRepoWithRemoteURL(t)
+	upstream2 := makeGitRepoWithRemoteURL(t)
+	sandboxDir := filepath.Join(t.TempDir(), "primary")
+
+	// First call with upstream1.
+	if err := EnsurePrimaryClone(sandboxDir, primary, upstream1); err != nil {
+		t.Fatalf("first EnsurePrimaryClone: %v", err)
+	}
+	defer os.RemoveAll(sandboxDir)
+
+	// Second call with upstream2 — should update the remote.
+	if err := EnsurePrimaryClone(sandboxDir, primary, upstream2); err != nil {
+		t.Fatalf("second EnsurePrimaryClone: %v", err)
+	}
+
+	cmd := exec.Command("git", "-C", sandboxDir, "remote", "get-url", "upstream")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git remote get-url upstream: %v", err)
+	}
+	got := strings.TrimSpace(string(out))
+	if got != upstream2 {
+		t.Errorf("upstream remote URL after update = %q, want %q", got, upstream2)
+	}
+}


### PR DESCRIPTION
Closes droplet ci-0pbgd.

Adds DeliveryMode field to RepoConfig supporting 'direct' (default) and 'fork' (push to fork, PR against upstream). Fixes 5 reviewer findings including: upstream-aware git sync, worktree tracking, invalid DeliveryMode validation, sed URL conversion for repos with dots, and fork owner prefix for cross-repo PRs.